### PR TITLE
Fix claw runtime bootstrap and OpenClaw config generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The Clawdapus Dash fleet dashboard runs on port **8082** — live service health
 
 Message `@quickstart-bot` in your Discord server. The bot responds through the proxy — it has no direct API access. The dashboard updates live.
 
+`claw up` resolves `${...}` placeholders inside `x-claw` metadata from your shell environment and the pod-local `.env` file before it generates runtime config. You do not need to duplicate handle IDs, guild IDs, or channel IDs into service `environment:` just to make driver config generation work.
+
 See [`examples/quickstart/`](./examples/quickstart/) for the full walkthrough, Telegram/Slack alternatives, and migration from existing OpenClaw.
 
 Or scaffold from scratch:

--- a/TESTING.md
+++ b/TESTING.md
@@ -28,14 +28,111 @@ go test -tags e2e -v ./...
 
 ---
 
-## Spike Test (live Discord + Docker required)
+## Spike Tests (live Discord + Docker required)
 
-The spike test (`TestSpikeComposeUp`) is the primary end-to-end validation instrument
-for the trading-desk example. It builds images, runs `claw up`, verifies all
-generated artifacts, starts containers, and confirms live Discord activity.
+Spike tests are the live end-to-end validation layer. They require real credentials,
+Docker, and a real Discord server. They are not CI tests.
 
-**It is not a CI test.** It requires real credentials and a real Discord server.
-Run it when implementing or validating new driver behavior end-to-end.
+There are currently two spike paths:
+
+- `TestSpikeRollCall`: the broad driver-parity validation path. Boots all 6 driver
+  types plus `cllama` passthrough and `clawdash`, sends a Discord roll call, and
+  verifies runtime-specific responses.
+- `TestSpikeComposeUp`: the deeper trading-desk validation path. Focuses on artifact
+  generation, startup wiring, and Discord activity for the richer multi-service example.
+
+Run a spike test when implementing or validating driver/runtime behavior end to end.
+
+### Rollcall Driver Parity Spike
+
+The rollcall spike (`TestSpikeRollCall`) is the best single validation path for
+cross-driver support. It uses [`examples/rollcall/`](./examples/rollcall/) and
+exercises:
+
+- `openclaw`
+- `nullclaw`
+- `microclaw`
+- `nanoclaw`
+- `nanobot`
+- `picoclaw`
+- `cllama` passthrough
+- `clawdash`
+
+### What it validates
+
+- Base images build for all 6 driver families
+- Agent images build from their `Clawfile`s
+- `claw up` succeeds on the rollcall pod
+- All agent containers converge to healthy/running state
+- A Discord trigger message causes each runtime to post an AI-generated
+  self-identification response
+- `cllama` exposes cost data after traffic flows through the proxy
+
+### Prerequisites
+
+- Docker running
+- Go toolchain
+- A Discord server with:
+  - One bot application token with permission to read and post in the target channel
+  - A text channel for the roll call
+  - An incoming webhook URL for posting the non-bot trigger message
+- At least one LLM provider key:
+  - `OPENROUTER_API_KEY` or
+  - `ANTHROPIC_API_KEY`
+
+### Setup
+
+```bash
+cd examples/rollcall
+cp .env.example .env
+# Edit .env with real values
+```
+
+Required `.env` values:
+
+| Variable | What it is |
+|----------|------------|
+| `DISCORD_BOT_TOKEN` | Bot token used by all rollcall services |
+| `DISCORD_BOT_ID` | Discord application/user ID for that bot |
+| `DISCORD_GUILD_ID` | Discord server (guild) ID |
+| `ROLLCALL_CHANNEL_ID` | Channel ID used for the roll call |
+| `DISCORD_WEBHOOK_URL` | Incoming webhook URL used to post the trigger message |
+| `OPENROUTER_API_KEY` | Optional, used by OpenRouter-backed passthrough services |
+| `ANTHROPIC_API_KEY` | Optional, used by Anthropic-backed passthrough services |
+
+### Running
+
+```bash
+go test -tags spike -v -run TestSpikeRollCall ./cmd/claw/...
+```
+
+Expected duration: 3-10 minutes depending on Docker cache warmth, image build time,
+Discord gateway connection, and LLM latency.
+
+### Output
+
+The test logs:
+
+- Image builds and compose startup progress
+- Health convergence for each rollcall container
+- Matching Discord responses for each runtime name
+- Recent container logs on teardown or failure
+- `cllama` health/cost endpoint checks
+
+### Cleanup
+
+Containers are torn down automatically on success, failure, or Ctrl-C.
+
+If a run is killed hard, clean up manually:
+
+```bash
+docker compose -p rollcall down --volumes --remove-orphans
+```
+
+## Trading-Desk Spike
+
+The trading-desk spike (`TestSpikeComposeUp`) remains the deeper artifact and
+workflow validation instrument for the richer `examples/trading-desk/` example.
 
 ### What it validates
 

--- a/cmd/claw/compose_up.go
+++ b/cmd/claw/compose_up.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -23,6 +25,8 @@ import (
 
 var composeUpDetach bool
 
+var envVarPattern = regexp.MustCompile(`\$\{([A-Z_][A-Z0-9_]*)\}`)
+
 var (
 	extractServiceSkillFromImage = runtime.ExtractServiceSkill
 	writeRuntimeFile             = os.WriteFile
@@ -31,6 +35,8 @@ var (
 	generateClawDockerfile       = build.Generate
 	buildGeneratedImage          = build.BuildFromGenerated
 	dockerBuildTaggedImage       = dockerBuildTaggedImageDefault
+	findClawdapusRepoRoot        = findRepoRoot
+	runInfraDockerCommand        = runInfraDockerCommandDefault
 )
 
 var composeUpCmd = &cobra.Command{
@@ -69,9 +75,12 @@ func runComposeUp(podFile string) error {
 	if err != nil {
 		return fmt.Errorf("resolve pod directory: %w", err)
 	}
+	if err := resolveRuntimePlaceholders(podDir, p); err != nil {
+		return fmt.Errorf("resolve x-claw runtime placeholders: %w", err)
+	}
 	runtimeDir := filepath.Join(podDir, ".claw-runtime")
-	if err := os.MkdirAll(runtimeDir, 0700); err != nil {
-		return fmt.Errorf("create runtime dir: %w", err)
+	if err := resetRuntimeDir(runtimeDir); err != nil {
+		return fmt.Errorf("reset runtime dir: %w", err)
 	}
 
 	results := make(map[string]*driver.MaterializeResult)
@@ -523,6 +532,139 @@ func runComposeUp(podFile string) error {
 
 	fmt.Println("[claw] pod is up")
 	return nil
+}
+
+func resetRuntimeDir(path string) error {
+	if err := os.RemoveAll(path); err != nil {
+		return err
+	}
+	return os.MkdirAll(path, 0o700)
+}
+
+func resolveRuntimePlaceholders(podDir string, p *pod.Pod) error {
+	env, err := loadRuntimeEnv(podDir)
+	if err != nil {
+		return err
+	}
+	expand := func(value string) string {
+		return envVarPattern.ReplaceAllStringFunc(value, func(match string) string {
+			key := match[2 : len(match)-1]
+			if v, ok := env[key]; ok {
+				return v
+			}
+			return match
+		})
+	}
+
+	for _, svc := range p.Services {
+		if svc == nil || svc.Claw == nil {
+			continue
+		}
+		svc.Claw.Agent = expand(svc.Claw.Agent)
+		svc.Claw.Persona = expand(svc.Claw.Persona)
+		for i, value := range svc.Claw.Cllama {
+			svc.Claw.Cllama[i] = expand(value)
+		}
+		for key, value := range svc.Claw.CllamaEnv {
+			svc.Claw.CllamaEnv[key] = expand(value)
+		}
+		for i, value := range svc.Claw.Skills {
+			svc.Claw.Skills[i] = expand(value)
+		}
+		for i := range svc.Claw.Invoke {
+			svc.Claw.Invoke[i].Schedule = expand(svc.Claw.Invoke[i].Schedule)
+			svc.Claw.Invoke[i].Message = expand(svc.Claw.Invoke[i].Message)
+			svc.Claw.Invoke[i].Name = expand(svc.Claw.Invoke[i].Name)
+			svc.Claw.Invoke[i].To = expand(svc.Claw.Invoke[i].To)
+		}
+		for _, handle := range svc.Claw.Handles {
+			if handle == nil {
+				continue
+			}
+			handle.ID = expand(handle.ID)
+			handle.Username = expand(handle.Username)
+			for gi := range handle.Guilds {
+				handle.Guilds[gi].ID = expand(handle.Guilds[gi].ID)
+				handle.Guilds[gi].Name = expand(handle.Guilds[gi].Name)
+				for ci := range handle.Guilds[gi].Channels {
+					handle.Guilds[gi].Channels[ci].ID = expand(handle.Guilds[gi].Channels[ci].ID)
+					handle.Guilds[gi].Channels[ci].Name = expand(handle.Guilds[gi].Channels[ci].Name)
+				}
+			}
+		}
+		for i := range svc.Claw.Surfaces {
+			svc.Claw.Surfaces[i].Target = expand(svc.Claw.Surfaces[i].Target)
+			svc.Claw.Surfaces[i].AccessMode = expand(svc.Claw.Surfaces[i].AccessMode)
+			if cc := svc.Claw.Surfaces[i].ChannelConfig; cc != nil {
+				cc.DM.Policy = expand(cc.DM.Policy)
+				for j, value := range cc.DM.AllowFrom {
+					cc.DM.AllowFrom[j] = expand(value)
+				}
+				expandedGuilds := make(map[string]driver.ChannelGuildConfig, len(cc.Guilds))
+				for guildID, guildCfg := range cc.Guilds {
+					guildCfg.Policy = expand(guildCfg.Policy)
+					users := make([]string, len(guildCfg.Users))
+					for j, value := range guildCfg.Users {
+						users[j] = expand(value)
+					}
+					guildCfg.Users = users
+					expandedGuilds[expand(guildID)] = guildCfg
+				}
+				cc.Guilds = expandedGuilds
+			}
+		}
+	}
+	return nil
+}
+
+func loadRuntimeEnv(podDir string) (map[string]string, error) {
+	env := make(map[string]string)
+	dotEnvPath := filepath.Join(podDir, ".env")
+	if fileEnv, err := readDotEnvFile(dotEnvPath); err == nil {
+		for key, value := range fileEnv {
+			env[key] = value
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+	for _, entry := range os.Environ() {
+		eq := strings.IndexByte(entry, '=')
+		if eq < 0 {
+			continue
+		}
+		env[entry[:eq]] = entry[eq+1:]
+	}
+	return env, nil
+}
+
+func readDotEnvFile(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	out := make(map[string]string)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		line = strings.TrimPrefix(line, "export ")
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			continue
+		}
+		key := strings.TrimSpace(line[:eq])
+		value := strings.TrimSpace(line[eq+1:])
+		value = strings.Trim(value, `"'`)
+		out[key] = value
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func mergeResolvedSkills(imageSkills, podSkills []driver.ResolvedSkill) []driver.ResolvedSkill {
@@ -1304,23 +1446,25 @@ func ensureInfraImages(cllamaEnabled bool, proxies []pod.CllamaProxyConfig, dash
 }
 
 // ensureImage builds a Docker image if it doesn't exist locally.
-// It tries: local build from repo source, then git URL build, then errors.
+// It tries: local image, docker pull, local build from repo source, git URL build,
+// then errors with explicit manual-build guidance.
 func ensureImage(imageRef, name, dockerfilePath, contextDir string) error {
-	if build.ImageExistsLocally(imageRef) {
+	if imageExistsLocally(imageRef) {
 		return nil
 	}
 
 	fmt.Printf("[claw] building %s image (first time only)\n", name)
 
-	repoRoot, found := findRepoRoot()
+	if err := runInfraDockerCommand("pull", imageRef); err == nil {
+		return nil
+	}
+
+	repoRoot, found := findClawdapusRepoRoot()
 	if found {
 		df := filepath.Join(repoRoot, dockerfilePath)
 		ctx := filepath.Join(repoRoot, contextDir)
 		if _, err := os.Stat(df); err == nil {
-			cmd := exec.Command("docker", "build", "-t", imageRef, "-f", df, ctx)
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-			if err := cmd.Run(); err != nil {
+			if err := runInfraDockerCommand("build", "-t", imageRef, "-f", df, ctx); err != nil {
 				return fmt.Errorf("build %s image from local source: %w", name, err)
 			}
 			return nil
@@ -1329,13 +1473,17 @@ func ensureImage(imageRef, name, dockerfilePath, contextDir string) error {
 
 	// Fallback: build from git URL.
 	gitURL := fmt.Sprintf("https://github.com/mostlydev/clawdapus.git#master:%s", contextDir)
-	cmd := exec.Command("docker", "build", "-t", imageRef, gitURL)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	if err := runInfraDockerCommand("build", "-t", imageRef, gitURL); err != nil {
 		return fmt.Errorf("could not build %s image; run 'docker build -t %s -f %s %s' from the repo root", name, imageRef, dockerfilePath, contextDir)
 	}
 	return nil
+}
+
+func runInfraDockerCommandDefault(args ...string) error {
+	cmd := exec.Command("docker", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }
 
 // findRepoRoot walks up from cwd looking for go.mod with the clawdapus module.

--- a/cmd/claw/compose_up_test.go
+++ b/cmd/claw/compose_up_test.go
@@ -1,13 +1,16 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/mostlydev/clawdapus/internal/driver"
+	"github.com/mostlydev/clawdapus/internal/driver/openclaw"
 	"github.com/mostlydev/clawdapus/internal/pod"
 )
 
@@ -111,6 +114,112 @@ func TestResolveSkillEmitFallsBackOnExtractionError(t *testing.T) {
 	}
 	if skill != nil {
 		t.Errorf("expected nil skill on extraction failure, got %+v", skill)
+	}
+}
+
+func TestResolveRuntimePlaceholdersUsesDotEnvForHandleTopology(t *testing.T) {
+	tmpDir := t.TempDir()
+	dotEnv := strings.Join([]string{
+		"BOT_ID=123456789",
+		"GUILD_ID=999888777",
+		"CHANNEL_ID=111222333",
+		"BOT_USERNAME=tiverton",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(tmpDir, ".env"), []byte(dotEnv), 0o644); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+
+	p := &pod.Pod{
+		Name: "test-pod",
+		Services: map[string]*pod.Service{
+			"bot": {
+				Claw: &pod.ClawBlock{
+					Handles: map[string]*driver.HandleInfo{
+						"discord": {
+							ID:       "${BOT_ID}",
+							Username: "${BOT_USERNAME}",
+							Guilds: []driver.GuildInfo{{
+								ID: "${GUILD_ID}",
+								Channels: []driver.ChannelInfo{{
+									ID:   "${CHANNEL_ID}",
+									Name: "trading-floor",
+								}},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := resolveRuntimePlaceholders(tmpDir, p); err != nil {
+		t.Fatalf("resolveRuntimePlaceholders: %v", err)
+	}
+
+	handle := p.Services["bot"].Claw.Handles["discord"]
+	if handle.ID != "123456789" {
+		t.Fatalf("expected expanded handle ID, got %q", handle.ID)
+	}
+	if handle.Username != "tiverton" {
+		t.Fatalf("expected expanded username, got %q", handle.Username)
+	}
+	if handle.Guilds[0].ID != "999888777" {
+		t.Fatalf("expected expanded guild ID, got %q", handle.Guilds[0].ID)
+	}
+	if handle.Guilds[0].Channels[0].ID != "111222333" {
+		t.Fatalf("expected expanded channel ID, got %q", handle.Guilds[0].Channels[0].ID)
+	}
+
+	configJSON, err := openclaw.GenerateConfig(&driver.ResolvedClaw{
+		ServiceName: "bot",
+		Handles:     map[string]*driver.HandleInfo{"discord": handle},
+		Models:      map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("GenerateConfig: %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(configJSON, &config); err != nil {
+		t.Fatalf("unmarshal generated config: %v", err)
+	}
+	guilds := config["channels"].(map[string]interface{})["discord"].(map[string]interface{})["guilds"].(map[string]interface{})
+	if _, ok := guilds["999888777"]; !ok {
+		t.Fatalf("expected concrete guild ID key in generated config, got %v", guilds)
+	}
+	if _, ok := guilds["${GUILD_ID}"]; ok {
+		t.Fatalf("did not expect unresolved placeholder key in generated config")
+	}
+}
+
+func TestResetRuntimeDirClearsStaleContents(t *testing.T) {
+	tmpDir := t.TempDir()
+	runtimeDir := filepath.Join(tmpDir, ".claw-runtime")
+	staleDir := filepath.Join(runtimeDir, "nb-roll", "skills", "handle-discord.md")
+	if err := os.MkdirAll(staleDir, 0o755); err != nil {
+		t.Fatalf("create stale dir: %v", err)
+	}
+	staleFile := filepath.Join(runtimeDir, "stale.txt")
+	if err := os.WriteFile(staleFile, []byte("stale"), 0o644); err != nil {
+		t.Fatalf("write stale file: %v", err)
+	}
+
+	if err := resetRuntimeDir(runtimeDir); err != nil {
+		t.Fatalf("reset runtime dir: %v", err)
+	}
+
+	info, err := os.Stat(runtimeDir)
+	if err != nil {
+		t.Fatalf("stat runtime dir: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("expected runtime dir to exist as directory")
+	}
+	if _, err := os.Stat(staleDir); !os.IsNotExist(err) {
+		t.Fatalf("expected stale dir to be removed, got err=%v", err)
+	}
+	if _, err := os.Stat(staleFile); !os.IsNotExist(err) {
+		t.Fatalf("expected stale file to be removed, got err=%v", err)
 	}
 }
 
@@ -303,6 +412,117 @@ func TestResolveManagedServiceImageRequiresImageOrBuild(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "require image: or build:") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnsureImagePullsBeforeTryingLocalBuild(t *testing.T) {
+	prevExists := imageExistsLocally
+	prevFindRepoRoot := findClawdapusRepoRoot
+	prevRunInfra := runInfraDockerCommand
+	defer func() {
+		imageExistsLocally = prevExists
+		findClawdapusRepoRoot = prevFindRepoRoot
+		runInfraDockerCommand = prevRunInfra
+	}()
+
+	imageExistsLocally = func(string) bool { return false }
+	findClawdapusRepoRoot = func() (string, bool) {
+		t.Fatal("unexpected repo-root lookup after successful pull")
+		return "", false
+	}
+
+	var calls [][]string
+	runInfraDockerCommand = func(args ...string) error {
+		calls = append(calls, append([]string(nil), args...))
+		return nil
+	}
+
+	if err := ensureImage("ghcr.io/mostlydev/cllama:latest", "cllama", "cllama/Dockerfile", "cllama"); err != nil {
+		t.Fatalf("ensureImage: %v", err)
+	}
+
+	want := [][]string{{"pull", "ghcr.io/mostlydev/cllama:latest"}}
+	if !slices.EqualFunc(calls, want, func(a, b []string) bool { return slices.Equal(a, b) }) {
+		t.Fatalf("unexpected docker calls: got %v want %v", calls, want)
+	}
+}
+
+func TestEnsureImageFallsBackToLocalBuildAfterPullFailure(t *testing.T) {
+	prevExists := imageExistsLocally
+	prevFindRepoRoot := findClawdapusRepoRoot
+	prevRunInfra := runInfraDockerCommand
+	defer func() {
+		imageExistsLocally = prevExists
+		findClawdapusRepoRoot = prevFindRepoRoot
+		runInfraDockerCommand = prevRunInfra
+	}()
+
+	repoRoot := t.TempDir()
+	dockerfilePath := filepath.Join(repoRoot, "cllama", "Dockerfile")
+	if err := os.MkdirAll(filepath.Dir(dockerfilePath), 0o755); err != nil {
+		t.Fatalf("mkdir dockerfile dir: %v", err)
+	}
+	if err := os.WriteFile(dockerfilePath, []byte("FROM alpine\n"), 0o644); err != nil {
+		t.Fatalf("write dockerfile: %v", err)
+	}
+
+	imageExistsLocally = func(string) bool { return false }
+	findClawdapusRepoRoot = func() (string, bool) { return repoRoot, true }
+
+	var calls [][]string
+	runInfraDockerCommand = func(args ...string) error {
+		calls = append(calls, append([]string(nil), args...))
+		if len(args) > 0 && args[0] == "pull" {
+			return fmt.Errorf("pull failed")
+		}
+		return nil
+	}
+
+	if err := ensureImage("ghcr.io/mostlydev/cllama:latest", "cllama", "cllama/Dockerfile", "cllama"); err != nil {
+		t.Fatalf("ensureImage: %v", err)
+	}
+
+	want := [][]string{
+		{"pull", "ghcr.io/mostlydev/cllama:latest"},
+		{"build", "-t", "ghcr.io/mostlydev/cllama:latest", "-f", dockerfilePath, filepath.Join(repoRoot, "cllama")},
+	}
+	if !slices.EqualFunc(calls, want, func(a, b []string) bool { return slices.Equal(a, b) }) {
+		t.Fatalf("unexpected docker calls: got %v want %v", calls, want)
+	}
+}
+
+func TestEnsureImageFallsBackToRemoteBuildWithoutRepoRoot(t *testing.T) {
+	prevExists := imageExistsLocally
+	prevFindRepoRoot := findClawdapusRepoRoot
+	prevRunInfra := runInfraDockerCommand
+	defer func() {
+		imageExistsLocally = prevExists
+		findClawdapusRepoRoot = prevFindRepoRoot
+		runInfraDockerCommand = prevRunInfra
+	}()
+
+	imageExistsLocally = func(string) bool { return false }
+	findClawdapusRepoRoot = func() (string, bool) { return "", false }
+
+	var calls [][]string
+	runInfraDockerCommand = func(args ...string) error {
+		calls = append(calls, append([]string(nil), args...))
+		if len(args) > 0 && args[0] == "pull" {
+			return fmt.Errorf("pull failed")
+		}
+		return nil
+	}
+
+	if err := ensureImage("ghcr.io/mostlydev/clawdash:latest", "clawdash", "dockerfiles/clawdash/Dockerfile", "."); err != nil {
+		t.Fatalf("ensureImage: %v", err)
+	}
+
+	want := [][]string{
+		{"pull", "ghcr.io/mostlydev/clawdash:latest"},
+		{"build", "-t", "ghcr.io/mostlydev/clawdash:latest", "https://github.com/mostlydev/clawdapus.git#master:."},
+	}
+	if !slices.EqualFunc(calls, want, func(a, b []string) bool { return slices.Equal(a, b) }) {
+		t.Fatalf("unexpected docker calls: got %v want %v", calls, want)
 	}
 }
 

--- a/examples/rollcall/.env.example
+++ b/examples/rollcall/.env.example
@@ -3,5 +3,6 @@ DISCORD_BOT_TOKEN=<your-bot-token>
 DISCORD_BOT_ID=<your-bot-snowflake>
 DISCORD_GUILD_ID=<your-guild-snowflake>
 ROLLCALL_CHANNEL_ID=<channel-id-for-roll-call>
+DISCORD_WEBHOOK_URL=<incoming-webhook-url-for-trigger-message>
 OPENROUTER_API_KEY=<for-cllama-passthrough>
 ANTHROPIC_API_KEY=<for-cllama-passthrough>

--- a/examples/rollcall/README.md
+++ b/examples/rollcall/README.md
@@ -1,0 +1,85 @@
+# Rollcall
+
+End-to-end driver parity fixture for Clawdapus.
+
+This example boots six different runtime families in one pod, wires them through
+`cllama` passthrough, exposes `clawdash`, posts a Discord roll-call prompt, and
+verifies that each runtime replies identifying itself.
+
+## What It Covers
+
+- `openclaw`
+- `nullclaw`
+- `microclaw`
+- `nanoclaw`
+- `nanobot`
+- `picoclaw`
+
+Each service shares the same Discord bot token. The distinction between agents
+comes from their `AGENTS.md` contracts and per-service runtime configuration.
+
+## Files
+
+- `claw-pod.yml`: six agent services plus shared proxy/dashboard wiring
+- `agents/*/Clawfile`: one Clawfile per runtime
+- `agents/*/AGENTS.md`: minimal runtime-specific self-identification contract
+- `Dockerfile.*-base`: local base images used by the spike test
+- `discord-responder.sh`: helper script used by the stub runtimes
+
+## Setup
+
+```bash
+cp .env.example .env
+# Edit .env with real values
+```
+
+Required variables:
+
+- `DISCORD_BOT_TOKEN`
+- `DISCORD_BOT_ID`
+- `DISCORD_GUILD_ID`
+- `ROLLCALL_CHANNEL_ID`
+- `DISCORD_WEBHOOK_URL`
+- `OPENROUTER_API_KEY` or `ANTHROPIC_API_KEY`
+
+`DISCORD_WEBHOOK_URL` is required because the spike posts the trigger message via
+webhook rather than as a bot user. That avoids agents ignoring the message as
+self-authored bot traffic.
+
+## Run
+
+From the repo root:
+
+```bash
+go test -tags spike -v -run TestSpikeRollCall ./cmd/claw/...
+```
+
+Or from this directory:
+
+```bash
+go test -tags spike -v -run TestSpikeRollCall ../../cmd/claw/...
+```
+
+## Expected Result
+
+The test should:
+
+1. Build the base images for each runtime family if needed.
+2. Build the six rollcall agent images.
+3. Run `claw up` on this pod.
+4. Wait for each container to become healthy or running.
+5. Post a Discord roll-call message through the webhook.
+6. Observe six AI-generated replies mentioning:
+   - `openclaw`
+   - `nullclaw`
+   - `microclaw`
+   - `nanoclaw` (or `Claude Agent SDK`)
+   - `nanobot`
+   - `picoclaw`
+7. Confirm `cllama` cost data is reachable.
+
+## Notes
+
+- This is a live spike test, not a CI-safe example.
+- Real Discord and model-provider credentials are required.
+- Cleanup is automatic on normal completion and on Ctrl-C.

--- a/examples/trading-desk/README.md
+++ b/examples/trading-desk/README.md
@@ -51,6 +51,8 @@ OPENROUTER_API_KEY=...
 ANTHROPIC_API_KEY=...
 ```
 
+`claw up` reads this pod-local `.env` file when resolving `${...}` placeholders inside `x-claw` metadata before generating runtime config such as `openclaw.json`. Keep Discord identity and topology values in `x-claw.handles`; only runtime process env like bot tokens need to be duplicated under a service `environment:` block.
+
 ## Running
 
 ```bash

--- a/examples/trading-desk/claw-pod.yml
+++ b/examples/trading-desk/claw-pod.yml
@@ -13,6 +13,8 @@ x-claw:
 #   TIVERTON_DISCORD_ID, WESTIN_DISCORD_ID, ALLEN_DISCORD_ID, LOGAN_DISCORD_ID, MICRO_DISCORD_ID
 #   DISCORD_GUILD_ID, DISCORD_TRADING_FLOOR_CHANNEL
 #   OPENROUTER_API_KEY, ANTHROPIC_API_KEY (proxy-side provider keys for cllama)
+# Note: claw resolves ${...} in x-claw metadata from the pod-local .env before
+# generating runtime config. Bot tokens still belong in service environment.
 # ─────────────────────────────────────────────────────────────────────────────
 
 services:

--- a/internal/driver/openclaw/baseimage.go
+++ b/internal/driver/openclaw/baseimage.go
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN curl -fsSL https://openclaw.ai/install.sh | bash -s -- --no-prompt --no-onboard --method npm
 
-RUN mkdir -p /claw && cat > /claw/entrypoint.sh <<'ENTRYPOINT_EOF'
+RUN mkdir -p /claw /usr/local/bin && cat > /usr/local/bin/openclaw-entrypoint.sh <<'ENTRYPOINT_EOF'
 #!/bin/sh
 set -e
 
@@ -64,9 +64,9 @@ fi
 # Hand off — wait for the gateway process to exit.
 wait "$GATEWAY_PID"
 ENTRYPOINT_EOF
-RUN chmod +x /claw/entrypoint.sh
+RUN chmod +x /usr/local/bin/openclaw-entrypoint.sh
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/claw/entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/openclaw-entrypoint.sh"]
 `
 
 // BaseImage implements driver.BaseImageProvider for the openclaw driver.

--- a/internal/driver/openclaw/baseimage_test.go
+++ b/internal/driver/openclaw/baseimage_test.go
@@ -24,8 +24,11 @@ func TestBaseImageProvider(t *testing.T) {
 	if !strings.Contains(dockerfile, "openclaw.ai/install.sh") {
 		t.Fatal("Dockerfile should install openclaw")
 	}
-	if !strings.Contains(dockerfile, "entrypoint.sh") {
-		t.Fatal("Dockerfile should include entrypoint")
+	if !strings.Contains(dockerfile, "/usr/local/bin/openclaw-entrypoint.sh") {
+		t.Fatal("Dockerfile should install the entrypoint outside /claw")
+	}
+	if strings.Contains(dockerfile, `ENTRYPOINT ["/usr/bin/tini", "--", "/claw/entrypoint.sh"]`) {
+		t.Fatal("Dockerfile should not place the runtime entrypoint under /claw")
 	}
 	if !strings.Contains(dockerfile, "ENTRYPOINT") {
 		t.Fatal("Dockerfile should have ENTRYPOINT directive")


### PR DESCRIPTION
## Summary
- fix claw runtime bootstrap by resetting .claw-runtime and preferring docker pull before local or remote infra builds
- resolve x-claw placeholders from shell env and pod-local .env before runtime config generation
- move the OpenClaw baked entrypoint outside /claw and update docs for the rollcall spike and trading-desk behavior

## Testing
- go test ./cmd/claw/... ./internal/driver/openclaw
- CLLAMA_UI_PORT=18181 go test -tags spike -v -run TestSpikeRollCall -timeout 15m ./cmd/claw/...