### PR TITLE
feat: implement x-claw include composition

### DIFF
--- a/cmd/claw/compose_up.go
+++ b/cmd/claw/compose_up.go
@@ -156,6 +156,14 @@ func runComposeUp(podFile string) error {
 			return fmt.Errorf("service %q: create service runtime dir: %w", name, err)
 		}
 
+		resolvedIncludes, includeSkills, err := materializeContractIncludes(podDir, svcRuntimeDir, agentHostPath, svc.Claw.Include)
+		if err != nil {
+			return fmt.Errorf("service %q: materialize contract includes: %w", name, err)
+		}
+		if len(resolvedIncludes) > 0 {
+			agentHostPath = filepath.Join(svcRuntimeDir, "AGENTS.generated.md")
+		}
+
 		// Merge skills: image-level (from labels) + pod-level (from x-claw)
 		imageSkills, err := runtime.ResolveSkills(podDir, info.Skills)
 		if err != nil {
@@ -181,6 +189,9 @@ func runComposeUp(podFile string) error {
 		}
 		if len(channelSkills) > 0 {
 			generatedSkills = mergeResolvedSkills(generatedSkills, channelSkills)
+		}
+		if len(includeSkills) > 0 {
+			generatedSkills = mergeResolvedSkills(generatedSkills, includeSkills)
 		}
 		handleSkills, err := resolveHandleSkills(svcRuntimeDir, svc.Claw.Handles)
 		if err != nil {
@@ -216,9 +227,11 @@ func runComposeUp(podFile string) error {
 			ClawType:      info.ClawType,
 			Agent:         agentFile,
 			AgentHostPath: agentHostPath,
+			Persona:       firstNonEmpty(svc.Claw.Persona, info.Persona),
 			Models:        info.Models,
 			Handles:       svc.Claw.Handles,
 			PeerHandles:   peerHandles,
+			Includes:      resolvedIncludes,
 			Configures:    info.Configures,
 			Privileges:    info.Privileges,
 			Count:         svc.Claw.Count,
@@ -571,6 +584,12 @@ func resolveRuntimePlaceholders(podDir string, p *pod.Pod) error {
 		for i, value := range svc.Claw.Skills {
 			svc.Claw.Skills[i] = expand(value)
 		}
+		for i := range svc.Claw.Include {
+			svc.Claw.Include[i].ID = expand(svc.Claw.Include[i].ID)
+			svc.Claw.Include[i].File = expand(svc.Claw.Include[i].File)
+			svc.Claw.Include[i].Mode = expand(svc.Claw.Include[i].Mode)
+			svc.Claw.Include[i].Description = expand(svc.Claw.Include[i].Description)
+		}
 		for i := range svc.Claw.Invoke {
 			svc.Claw.Invoke[i].Schedule = expand(svc.Claw.Invoke[i].Schedule)
 			svc.Claw.Invoke[i].Message = expand(svc.Claw.Invoke[i].Message)
@@ -686,6 +705,141 @@ func mergeResolvedSkills(imageSkills, podSkills []driver.ResolvedSkill) []driver
 	}
 
 	return merged
+}
+
+func materializeContractIncludes(baseDir, runtimeDir, agentHostPath string, includes []pod.IncludeEntry) ([]driver.ResolvedInclude, []driver.ResolvedSkill, error) {
+	if len(includes) == 0 {
+		return nil, nil, nil
+	}
+	if agentHostPath == "" {
+		return nil, nil, fmt.Errorf("x-claw.include requires a base agent contract")
+	}
+
+	baseContract, err := os.ReadFile(agentHostPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read base agent contract: %w", err)
+	}
+
+	resolved := make([]driver.ResolvedInclude, 0, len(includes))
+	skills := make([]driver.ResolvedSkill, 0)
+
+	var compiled strings.Builder
+	compiled.WriteString(strings.TrimRight(string(baseContract), "\n"))
+
+	for _, include := range includes {
+		hostPath, err := resolveRuntimeScopedFile(baseDir, include.File)
+		if err != nil {
+			return nil, nil, fmt.Errorf("include %q: %w", include.ID, err)
+		}
+		content, err := os.ReadFile(hostPath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("include %q: read file: %w", include.ID, err)
+		}
+
+		ri := driver.ResolvedInclude{
+			ID:          include.ID,
+			Mode:        include.Mode,
+			Description: include.Description,
+			HostPath:    hostPath,
+		}
+
+		switch include.Mode {
+		case "enforce", "guide":
+			compiled.WriteString("\n\n")
+			compiled.WriteString(fmt.Sprintf("--- BEGIN: %s (%s) ---\n\n", include.ID, include.Mode))
+			compiled.WriteString(strings.TrimRight(string(content), "\n"))
+			compiled.WriteString("\n\n")
+			compiled.WriteString(fmt.Sprintf("--- END: %s (%s) ---", include.ID, include.Mode))
+		case "reference":
+			skillName := includeSkillName(include.ID, hostPath)
+			skillPath := filepath.Join(runtimeDir, "skills", skillName)
+			if err := os.MkdirAll(filepath.Dir(skillPath), 0700); err != nil {
+				return nil, nil, fmt.Errorf("include %q: create skill dir: %w", include.ID, err)
+			}
+			if err := writeRuntimeFile(skillPath, content, 0644); err != nil {
+				return nil, nil, fmt.Errorf("include %q: write reference skill: %w", include.ID, err)
+			}
+			ri.SkillName = skillName
+			skills = append(skills, driver.ResolvedSkill{Name: skillName, HostPath: skillPath})
+		default:
+			return nil, nil, fmt.Errorf("include %q: unsupported mode %q", include.ID, include.Mode)
+		}
+
+		resolved = append(resolved, ri)
+	}
+
+	generatedPath := filepath.Join(runtimeDir, "AGENTS.generated.md")
+	if err := writeRuntimeFile(generatedPath, []byte(compiled.String()+"\n"), 0644); err != nil {
+		return nil, nil, fmt.Errorf("write generated AGENTS.md: %w", err)
+	}
+
+	return resolved, skills, nil
+}
+
+func resolveRuntimeScopedFile(baseDir, relPath string) (string, error) {
+	absBase, err := filepath.Abs(baseDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve base dir %q: %w", baseDir, err)
+	}
+	realBase, err := filepath.EvalSymlinks(absBase)
+	if err != nil {
+		return "", fmt.Errorf("resolve real base dir %q: %w", baseDir, err)
+	}
+
+	hostPath, err := filepath.Abs(filepath.Join(baseDir, relPath))
+	if err != nil {
+		return "", fmt.Errorf("resolve path %q: %w", relPath, err)
+	}
+	if !strings.HasPrefix(hostPath, absBase+string(filepath.Separator)) && hostPath != absBase {
+		return "", fmt.Errorf("path %q escapes base directory %q", relPath, baseDir)
+	}
+
+	info, err := os.Stat(hostPath)
+	if err != nil {
+		return "", fmt.Errorf("file %q not found: %w", hostPath, err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("%q is not a regular file", relPath)
+	}
+
+	realHostPath, err := filepath.EvalSymlinks(hostPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve real path for %q: %w", relPath, err)
+	}
+	if !strings.HasPrefix(realHostPath, realBase+string(filepath.Separator)) && realHostPath != realBase {
+		return "", fmt.Errorf("path %q escapes base directory %q", relPath, baseDir)
+	}
+
+	return realHostPath, nil
+}
+
+func includeSkillName(id, hostPath string) string {
+	safeID := make([]rune, 0, len(id))
+	for _, r := range id {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			safeID = append(safeID, r)
+			continue
+		}
+		safeID = append(safeID, '_')
+	}
+	if len(safeID) == 0 {
+		safeID = []rune("include")
+	}
+
+	ext := filepath.Ext(hostPath)
+	if ext == "" {
+		ext = ".md"
+	}
+	return "include-" + string(safeID) + ext
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func resolveCllama(imageLevel, podLevel []string) []string {

--- a/cmd/claw/compose_up_test.go
+++ b/cmd/claw/compose_up_test.go
@@ -192,6 +192,76 @@ func TestResolveRuntimePlaceholdersUsesDotEnvForHandleTopology(t *testing.T) {
 	}
 }
 
+func TestMaterializeContractIncludesBuildsGeneratedContractAndReferenceSkill(t *testing.T) {
+	baseDir := t.TempDir()
+	runtimeDir := filepath.Join(baseDir, ".claw-runtime", "bot")
+	if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+		t.Fatalf("mkdir runtime dir: %v", err)
+	}
+
+	agentPath := filepath.Join(baseDir, "AGENTS.md")
+	enforcePath := filepath.Join(baseDir, "governance", "risk-limits.md")
+	referencePath := filepath.Join(baseDir, "playbooks", "strategy.md")
+	if err := os.MkdirAll(filepath.Dir(enforcePath), 0o755); err != nil {
+		t.Fatalf("mkdir governance dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(referencePath), 0o755); err != nil {
+		t.Fatalf("mkdir playbooks dir: %v", err)
+	}
+	if err := os.WriteFile(agentPath, []byte("# Base Contract\n"), 0o644); err != nil {
+		t.Fatalf("write base contract: %v", err)
+	}
+	if err := os.WriteFile(enforcePath, []byte("No unauthorized trades.\n"), 0o644); err != nil {
+		t.Fatalf("write enforce include: %v", err)
+	}
+	if err := os.WriteFile(referencePath, []byte("# Strategy Notes\n"), 0o644); err != nil {
+		t.Fatalf("write reference include: %v", err)
+	}
+
+	includes := []pod.IncludeEntry{
+		{ID: "risk_limits", File: "./governance/risk-limits.md", Mode: "enforce", Description: "Hard trading rules"},
+		{ID: "strategy_notes", File: "./playbooks/strategy.md", Mode: "reference", Description: "Desk playbook"},
+	}
+
+	resolved, skills, err := materializeContractIncludes(baseDir, runtimeDir, agentPath, includes)
+	if err != nil {
+		t.Fatalf("materializeContractIncludes: %v", err)
+	}
+	if len(resolved) != 2 {
+		t.Fatalf("expected 2 resolved includes, got %d", len(resolved))
+	}
+	if len(skills) != 1 {
+		t.Fatalf("expected 1 generated reference skill, got %d", len(skills))
+	}
+	if skills[0].Name != "include-strategy_notes.md" {
+		t.Fatalf("unexpected generated skill name: %q", skills[0].Name)
+	}
+
+	generatedPath := filepath.Join(runtimeDir, "AGENTS.generated.md")
+	generated, err := os.ReadFile(generatedPath)
+	if err != nil {
+		t.Fatalf("read generated contract: %v", err)
+	}
+	text := string(generated)
+	if !strings.Contains(text, "# Base Contract") {
+		t.Fatalf("expected base contract in generated output")
+	}
+	if !strings.Contains(text, "--- BEGIN: risk_limits (enforce) ---") {
+		t.Fatalf("expected enforce include marker in generated contract:\n%s", text)
+	}
+	if !strings.Contains(text, "No unauthorized trades.") {
+		t.Fatalf("expected enforce include content in generated contract:\n%s", text)
+	}
+
+	referenceSkill, err := os.ReadFile(skills[0].HostPath)
+	if err != nil {
+		t.Fatalf("read generated reference skill: %v", err)
+	}
+	if string(referenceSkill) != "# Strategy Notes\n" {
+		t.Fatalf("unexpected reference skill content: %q", string(referenceSkill))
+	}
+}
+
 func TestResetRuntimeDirClearsStaleContents(t *testing.T) {
 	tmpDir := t.TempDir()
 	runtimeDir := filepath.Join(tmpDir, ".claw-runtime")

--- a/internal/driver/shared/clawdapus_md.go
+++ b/internal/driver/shared/clawdapus_md.go
@@ -134,7 +134,7 @@ func GenerateClawdapusMD(rc *driver.ResolvedClaw, podName string) string {
 
 	// Operator-provided skills (exclude auto-generated handle-* and surface-* files)
 	for _, sk := range rc.Skills {
-		if strings.HasPrefix(sk.Name, "handle-") || strings.HasPrefix(sk.Name, "surface-") {
+		if strings.HasPrefix(sk.Name, "handle-") || strings.HasPrefix(sk.Name, "surface-") || strings.HasPrefix(sk.Name, "include-") {
 			continue
 		}
 		skillEntries = append(skillEntries, fmt.Sprintf("- `skills/%s` — operator-provided skill", sk.Name))
@@ -145,6 +145,27 @@ func GenerateClawdapusMD(rc *driver.ResolvedClaw, podName string) string {
 	} else {
 		for _, entry := range skillEntries {
 			b.WriteString(entry + "\n")
+		}
+	}
+
+	if len(rc.Includes) > 0 {
+		b.WriteString("\n## Included Context\n\n")
+		for _, include := range rc.Includes {
+			b.WriteString(fmt.Sprintf("### %s (%s)\n", include.ID, include.Mode))
+			if include.Description != "" {
+				b.WriteString(fmt.Sprintf("- **Description:** %s\n", include.Description))
+			}
+			switch include.Mode {
+			case "reference":
+				skillPath := "skills/" + include.SkillName
+				if include.SkillName == "" {
+					skillPath = "skills/"
+				}
+				b.WriteString(fmt.Sprintf("- **Mount:** `%s`\n", skillPath))
+			default:
+				b.WriteString("- **Contract:** inlined into `/claw/AGENTS.md`\n")
+			}
+			b.WriteString(fmt.Sprintf("- **Source:** `%s`\n\n", include.HostPath))
 		}
 	}
 

--- a/internal/driver/shared/clawdapus_md_test.go
+++ b/internal/driver/shared/clawdapus_md_test.go
@@ -108,3 +108,39 @@ func TestGenerateClawdapusMDHandlesSection(t *testing.T) {
 		t.Error("expected handle ID")
 	}
 }
+
+func TestGenerateClawdapusMDIncludesContextComposition(t *testing.T) {
+	rc := &driver.ResolvedClaw{
+		ServiceName: "bot",
+		ClawType:    "openclaw",
+		Includes: []driver.ResolvedInclude{
+			{
+				ID:          "risk_limits",
+				Mode:        "enforce",
+				Description: "Hard constraints",
+				HostPath:    "/workspace/governance/risk-limits.md",
+			},
+			{
+				ID:          "strategy_notes",
+				Mode:        "reference",
+				Description: "Desk playbook",
+				HostPath:    "/workspace/playbooks/strategy.md",
+				SkillName:   "include-strategy_notes.md",
+			},
+		},
+	}
+
+	md := GenerateClawdapusMD(rc, "test-pod")
+	if !strings.Contains(md, "## Included Context") {
+		t.Fatal("expected Included Context section")
+	}
+	if !strings.Contains(md, "risk_limits (enforce)") {
+		t.Fatal("expected enforce include heading")
+	}
+	if !strings.Contains(md, "inlined into `/claw/AGENTS.md`") {
+		t.Fatal("expected enforce include to note inline contract placement")
+	}
+	if !strings.Contains(md, "skills/include-strategy_notes.md") {
+		t.Fatal("expected reference include skill mount")
+	}
+}

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -30,9 +30,11 @@ type ResolvedClaw struct {
 	ClawType      string
 	Agent         string                            // filename from image labels (e.g., "AGENTS.md")
 	AgentHostPath string                            // resolved host path for bind mount
+	Persona       string                            // runtime persona ref from x-claw or image metadata
 	Models        map[string]string                 // slot -> provider/model
 	Handles       map[string]*HandleInfo            // platform -> contact card (from x-claw handles block)
 	PeerHandles   map[string]map[string]*HandleInfo // service name -> platform -> HandleInfo for sibling services
+	Includes      []ResolvedInclude                 // composed contract fragments from x-claw.include
 	Surfaces      []ResolvedSurface
 	Skills        []ResolvedSkill
 	Privileges    map[string]string
@@ -68,6 +70,14 @@ type ChannelInfo struct {
 type ResolvedSkill struct {
 	Name     string // basename (e.g., "custom-workflow.md")
 	HostPath string // resolved absolute host path
+}
+
+type ResolvedInclude struct {
+	ID          string
+	Mode        string
+	Description string
+	HostPath    string
+	SkillName   string // set for reference includes mounted into the skill directory
 }
 
 // ChannelGuildConfig is the routing config for one guild in a channel surface.

--- a/internal/pod/parser.go
+++ b/internal/pod/parser.go
@@ -44,9 +44,17 @@ type rawClawBlock struct {
 	CllamaEnv map[string]string      `yaml:"cllama-env"`
 	Count     int                    `yaml:"count"`
 	Handles   map[string]interface{} `yaml:"handles"`
+	Include   []rawIncludeEntry      `yaml:"include"`
 	Surfaces  []interface{}          `yaml:"surfaces"`
 	Skills    []string               `yaml:"skills"`
 	Invoke    []rawInvokeEntry       `yaml:"invoke"`
+}
+
+type rawIncludeEntry struct {
+	ID          string `yaml:"id"`
+	File        string `yaml:"file"`
+	Mode        string `yaml:"mode"`
+	Description string `yaml:"description"`
 }
 
 // Parse reads a claw-pod.yml from the given reader.
@@ -154,6 +162,10 @@ func Parse(r io.Reader) (*Pod, error) {
 			if err != nil {
 				return nil, fmt.Errorf("service %q: parse handles: %w", name, err)
 			}
+			include, err := parseIncludes(svc.XClaw.Include)
+			if err != nil {
+				return nil, fmt.Errorf("service %q: parse include: %w", name, err)
+			}
 			invoke := make([]InvokeEntry, 0, len(svc.XClaw.Invoke))
 			for _, rawInv := range svc.XClaw.Invoke {
 				if rawInv.Schedule == "" || rawInv.Message == "" {
@@ -173,6 +185,7 @@ func Parse(r io.Reader) (*Pod, error) {
 				CllamaEnv: svc.XClaw.CllamaEnv,
 				Count:     count,
 				Handles:   handles,
+				Include:   include,
 				Surfaces:  parsedSurfaces,
 				Skills:    skills,
 				Invoke:    invoke,
@@ -311,6 +324,45 @@ func parseHandleMap(m map[string]interface{}) (*driver.HandleInfo, error) {
 	}
 
 	return info, nil
+}
+
+func parseIncludes(raw []rawIncludeEntry) ([]IncludeEntry, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+
+	seen := make(map[string]struct{}, len(raw))
+	out := make([]IncludeEntry, 0, len(raw))
+	for i, item := range raw {
+		id := strings.TrimSpace(item.ID)
+		if id == "" {
+			return nil, fmt.Errorf("entry %d: include id must not be empty", i)
+		}
+		if _, exists := seen[id]; exists {
+			return nil, fmt.Errorf("entry %d: duplicate include id %q", i, id)
+		}
+		seen[id] = struct{}{}
+
+		file := strings.TrimSpace(item.File)
+		if file == "" {
+			return nil, fmt.Errorf("entry %d (%s): include file must not be empty", i, id)
+		}
+		mode := strings.ToLower(strings.TrimSpace(item.Mode))
+		switch mode {
+		case "enforce", "guide", "reference":
+		default:
+			return nil, fmt.Errorf("entry %d (%s): unsupported include mode %q", i, id, item.Mode)
+		}
+
+		out = append(out, IncludeEntry{
+			ID:          id,
+			File:        file,
+			Mode:        mode,
+			Description: strings.TrimSpace(item.Description),
+		})
+	}
+
+	return out, nil
 }
 
 func parseGuildEntry(val interface{}) (driver.GuildInfo, error) {

--- a/internal/pod/parser_test.go
+++ b/internal/pod/parser_test.go
@@ -268,6 +268,40 @@ services:
 	}
 }
 
+func TestParseIncludeEntries(t *testing.T) {
+	src := `
+services:
+  bot:
+    image: bot:latest
+    x-claw:
+      agent: ./AGENTS.md
+      include:
+        - id: risk_limits
+          file: ./governance/risk-limits.md
+          mode: enforce
+          description: Hard constraints
+        - id: strategy_notes
+          file: ./playbooks/strategy.md
+          mode: reference
+`
+
+	pod, err := Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	include := pod.Services["bot"].Claw.Include
+	if len(include) != 2 {
+		t.Fatalf("expected 2 include entries, got %d", len(include))
+	}
+	if include[0].ID != "risk_limits" || include[0].Mode != "enforce" {
+		t.Fatalf("unexpected first include: %+v", include[0])
+	}
+	if include[1].Description != "" {
+		t.Fatalf("expected empty description for omitted value, got %q", include[1].Description)
+	}
+}
+
 func TestParseCllamaEnvBlock(t *testing.T) {
 	yaml := `
 x-claw:

--- a/internal/pod/types.go
+++ b/internal/pod/types.go
@@ -37,7 +37,15 @@ type ClawBlock struct {
 	CllamaTokens map[string]string // runtime-only: expanded service name -> token
 	Count        int
 	Handles      map[string]*driver.HandleInfo // platform → contact card
+	Include      []IncludeEntry
 	Surfaces     []driver.ResolvedSurface
 	Skills       []string
 	Invoke       []InvokeEntry
+}
+
+type IncludeEntry struct {
+	ID          string
+	File        string
+	Mode        string
+	Description string
 }


### PR DESCRIPTION
## Summary
- add x-claw.include parsing and validation to the pod model
- compile enforce/guide include fragments into a generated AGENTS contract at runtime
- mount reference includes as generated skills and list them in CLAWDAPUS.md

## Testing
- go test ./...

Closes #45