### PR TITLE
fix(update): match installer asset names to releases

### DIFF
--- a/cmd/claw/install_test.go
+++ b/cmd/claw/install_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type goreleaserConfig struct {
+	Archives []struct {
+		Format       string `yaml:"format"`
+		NameTemplate string `yaml:"name_template"`
+	} `yaml:"archives"`
+}
+
+func TestInstallScriptMatchesArchiveNameTemplate(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "../.."))
+
+	configBytes, err := os.ReadFile(filepath.Join(repoRoot, ".goreleaser.yml"))
+	if err != nil {
+		t.Fatalf("read .goreleaser.yml: %v", err)
+	}
+
+	var cfg goreleaserConfig
+	if err := yaml.Unmarshal(configBytes, &cfg); err != nil {
+		t.Fatalf("parse .goreleaser.yml: %v", err)
+	}
+
+	var archiveTemplate string
+	for _, archive := range cfg.Archives {
+		if archive.Format == "tar.gz" {
+			archiveTemplate = archive.NameTemplate
+			break
+		}
+	}
+	if archiveTemplate == "" {
+		t.Fatal("no tar.gz archive template found in .goreleaser.yml")
+	}
+
+	expectedTarball := strings.NewReplacer(
+		"{{ .Version }}", "${VERSION}",
+		"{{ .Os }}", "${OS}",
+		"{{ .Arch }}", "${ARCH}",
+	).Replace(archiveTemplate) + ".tar.gz"
+
+	installBytes, err := os.ReadFile(filepath.Join(repoRoot, "install.sh"))
+	if err != nil {
+		t.Fatalf("read install.sh: %v", err)
+	}
+
+	wantLine := `TARBALL="` + expectedTarball + `"`
+	if !strings.Contains(string(installBytes), wantLine) {
+		t.Fatalf("install.sh tarball pattern drifted\nwant line: %s", wantLine)
+	}
+}

--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,7 @@ info "Latest release: ${TAG}"
 
 # --- Download tarball and checksums ---
 VERSION="${TAG#v}"
-TARBALL="claw_${VERSION}_${OS}_${ARCH}.tar.gz"
+TARBALL="clawdapus_${VERSION}_${OS}_${ARCH}.tar.gz"
 BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
 
 TMPDIR="$(mktemp -d)"


### PR DESCRIPTION
## Summary
- update `install.sh` to download the same `clawdapus_<version>_<os>_<arch>.tar.gz` artifacts that Goreleaser publishes
- add a regression test that locks the installer tarball pattern to `.goreleaser.yml`
- keep `claw update` trustworthy by fixing the public installer path it shells into

## Validation
- `go test ./cmd/claw -run TestInstallScriptMatchesArchiveNameTemplate`
- `CLAW_INSTALL_DIR=$(mktemp -d) sh ./install.sh` smoke test into a temporary install dir