### PR TITLE
[codex] prevent stale managed image reuse during claw up

### DIFF
--- a/cmd/claw/compose_up.go
+++ b/cmd/claw/compose_up.go
@@ -3028,10 +3028,6 @@ type buildArgValue struct {
 
 func resolveManagedServiceImage(podDir string, p *pod.Pod, serviceName string, svc *pod.Service) (string, error) {
 	imageRef := strings.TrimSpace(svc.Image)
-	if imageRef != "" && imageExistsLocally(imageRef) {
-		return imageRef, nil
-	}
-
 	cfg, err := parseServiceBuildConfig(svc.Compose["build"])
 	if err != nil {
 		return "", fmt.Errorf("service %q: parse build: %w", serviceName, err)
@@ -3040,6 +3036,9 @@ func resolveManagedServiceImage(podDir string, p *pod.Pod, serviceName string, s
 	if cfg == nil {
 		if imageRef == "" {
 			return "", fmt.Errorf("service %q: claw-managed services require image: or build:", serviceName)
+		}
+		if imageExistsLocally(imageRef) {
+			return imageRef, nil
 		}
 		return "", fmt.Errorf("service %q: image %q not found locally and no build config declared", serviceName, imageRef)
 	}
@@ -3051,10 +3050,6 @@ func resolveManagedServiceImage(podDir string, p *pod.Pod, serviceName string, s
 			svc.Compose = make(map[string]interface{})
 		}
 		svc.Compose["image"] = imageRef
-	}
-
-	if imageExistsLocally(imageRef) {
-		return imageRef, nil
 	}
 
 	fmt.Printf("[claw] %s: building image %s for inspection\n", serviceName, imageRef)

--- a/cmd/claw/compose_up_test.go
+++ b/cmd/claw/compose_up_test.go
@@ -926,6 +926,77 @@ func TestResolveManagedServiceImageBuildOnlyClawfile(t *testing.T) {
 	}
 }
 
+func TestResolveManagedServiceImageRebuildsClawfileBuildWhenTagExistsLocally(t *testing.T) {
+	tmpDir := t.TempDir()
+	clawfilePath := filepath.Join(tmpDir, "agents", "shared", "OpenClawfile")
+	if err := os.MkdirAll(filepath.Dir(clawfilePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(clawfilePath, []byte("FROM alpine\nCLAW_TYPE openclaw\nAGENT AGENTS.md\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := &pod.Service{
+		Image: "ghcr.io/example/bot:latest",
+		Compose: map[string]interface{}{
+			"build": map[string]interface{}{
+				"context":    ".",
+				"dockerfile": filepath.ToSlash(filepath.Join("agents", "shared", "OpenClawfile")),
+			},
+		},
+	}
+	p := &pod.Pod{Name: "Research Pod"}
+
+	prevExists := imageExistsLocally
+	prevGenerate := generateClawDockerfile
+	prevBuildGenerated := buildGeneratedImage
+	prevDockerBuild := dockerBuildTaggedImage
+	defer func() {
+		imageExistsLocally = prevExists
+		generateClawDockerfile = prevGenerate
+		buildGeneratedImage = prevBuildGenerated
+		dockerBuildTaggedImage = prevDockerBuild
+	}()
+
+	imageExistsLocally = func(image string) bool { return image == svc.Image }
+	generatedPath := filepath.Join(tmpDir, "Dockerfile.generated")
+	generateClawDockerfile = func(path string) (string, error) {
+		if path != clawfilePath {
+			t.Fatalf("expected Clawfile path %q, got %q", clawfilePath, path)
+		}
+		return generatedPath, nil
+	}
+	var built bool
+	buildGeneratedImage = func(path, tag, contextDir string) error {
+		built = true
+		if path != generatedPath {
+			t.Fatalf("expected generated path %q, got %q", generatedPath, path)
+		}
+		if tag != svc.Image {
+			t.Fatalf("expected built tag %q, got %q", svc.Image, tag)
+		}
+		if contextDir != tmpDir {
+			t.Fatalf("expected build context %q, got %q", tmpDir, contextDir)
+		}
+		return nil
+	}
+	dockerBuildTaggedImage = func(string, string, string, map[string]buildArgValue, string) error {
+		t.Fatal("unexpected plain docker build for Clawfile build")
+		return nil
+	}
+
+	imageRef, err := resolveManagedServiceImage(tmpDir, p, "bot", svc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if imageRef != svc.Image {
+		t.Fatalf("expected image ref %q, got %q", svc.Image, imageRef)
+	}
+	if !built {
+		t.Fatal("expected managed image build to run even when the tagged image already exists locally")
+	}
+}
+
 func TestResolveManagedServiceImageBuildsPlainDockerfile(t *testing.T) {
 	tmpDir := t.TempDir()
 	dockerfilePath := filepath.Join(tmpDir, "Dockerfile")


### PR DESCRIPTION
## Summary

Fix `claw up -d` reusing a stale local managed image for inspection and runtime regeneration.

## What Changed

- stop short-circuiting `resolveManagedServiceImage()` on an existing local image when the service declares `build:`
- keep the existing local-image fast path only for managed services without build configuration
- add a regression test that proves a tagged local image does not suppress the rebuild path for Clawfile/OpenClawfile-managed services

## Root Cause

`resolveManagedServiceImage()` returned early as soon as the configured image tag already existed locally. That meant `claw up` could inspect old labels from an old image and regenerate runtime artifacts from stale metadata even after the underlying build inputs changed.

## Impact

Managed runtime generation now follows the current build source of truth instead of whatever tagged image happened to be present locally. Operators no longer need a separate manual rebuild to make model/provider changes propagate during `claw up -d`.

## Validation

- `go test ./...`

Closes #96.
