### PR TITLE
[codex] fix OpenClaw cron store compatibility

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -141,8 +141,8 @@ workflow validation instrument for the richer `examples/trading-desk/` example.
   guild ID, `groupPolicy`, `dmPolicy`, `allowBots`, `mentionPatterns`, peer `users[]`
 - `jobs.json` generated correctly: `agentTurn` payloads with `delivery.mode=announce`
   and `delivery.to` resolved to the real channel ID
-- `compose.generated.yml` contains correct bind mounts for `/app/config` and
-  `/app/state/cron`
+- `compose.generated.yml` contains the writable `/app/config` bind mount used for
+  both `openclaw.json` and `cron/jobs.json`
 - Both agent containers start and serve mounted files at the expected paths
 - `openclaw health --json` reports healthy inside the tiverton container
 - Both agents post startup greetings to Discord (`tiverton online.`, `westin online.`)

--- a/cmd/claw/spike_test.go
+++ b/cmd/claw/spike_test.go
@@ -330,12 +330,19 @@ func TestSpikeComposeUp(t *testing.T) {
 
 	// ── Verify tiverton's jobs.json ──────────────────────────────────────────
 
-	jobsPath := filepath.Join(runtimeDir, "tiverton", "state", "cron", "jobs.json")
+	jobsPath := filepath.Join(runtimeDir, "tiverton", "config", "cron", "jobs.json")
 	jobsData := spikeReadFile(t, jobsPath)
-	var jobs []map[string]interface{}
-	if err := json.Unmarshal([]byte(jobsData), &jobs); err != nil {
+	var jobsStore struct {
+		Version int                      `json:"version"`
+		Jobs    []map[string]interface{} `json:"jobs"`
+	}
+	if err := json.Unmarshal([]byte(jobsData), &jobsStore); err != nil {
 		t.Fatalf("parse jobs.json: %v", err)
 	}
+	if jobsStore.Version != 1 {
+		t.Fatalf("jobs.json: expected version=1, got %d", jobsStore.Version)
+	}
+	jobs := jobsStore.Jobs
 	if len(jobs) == 0 {
 		t.Fatal("jobs.json: expected at least one job, got empty array")
 	}
@@ -366,10 +373,8 @@ func TestSpikeComposeUp(t *testing.T) {
 	// ── Verify compose.generated.yml ────────────────────────────────────────
 
 	composeSrc := spikeReadFile(t, generatedPath)
-	for _, want := range []string{"/app/state/cron", "/app/config"} {
-		if !strings.Contains(composeSrc, want) {
-			t.Errorf("compose.generated.yml: expected to contain %q", want)
-		}
+	if !strings.Contains(composeSrc, "/app/config") {
+		t.Errorf("compose.generated.yml: expected to contain %q", "/app/config")
 	}
 	if !strings.Contains(composeSrc, "cllama:") {
 		t.Errorf("compose.generated.yml: expected cllama service")
@@ -412,7 +417,7 @@ func TestSpikeComposeUp(t *testing.T) {
 	}
 
 	// jobs.json must be readable and contain the real channel ID
-	out2, err2 := exec.Command("docker", "exec", containerName, "cat", "/app/state/cron/jobs.json").Output()
+	out2, err2 := exec.Command("docker", "exec", containerName, "cat", "/app/config/cron/jobs.json").Output()
 	if err2 != nil {
 		t.Errorf("docker exec cat jobs.json: %v", err2)
 	} else if !strings.Contains(string(out2), channelID) {

--- a/docs/decisions/006-invoke-scheduling.md
+++ b/docs/decisions/006-invoke-scheduling.md
@@ -9,7 +9,7 @@ The initial architecture plan stated that the `INVOKE` directive would be implem
 
 ## Decision
 
-We have updated the enforcement mechanism for the `INVOKE` directive. Instead of relying on system cron, the `INVOKE` directive bakes scheduled tasks into the OCI image as labels (`claw.invoke.N`). At runtime, the driver extracts these labels and translates them into a runner-native scheduling format. For example, the OpenClaw driver generates a `jobs.json` file and mounts it directly into OpenClaw's `/app/state/cron/` directory, allowing OpenClaw's internal scheduler to pick it up automatically.
+We have updated the enforcement mechanism for the `INVOKE` directive. Instead of relying on system cron, the `INVOKE` directive bakes scheduled tasks into the OCI image as labels (`claw.invoke.N`). At runtime, the driver extracts these labels and translates them into a runner-native scheduling format. For example, the OpenClaw driver generates a versioned `jobs.json` store under its writable config directory (`CONFIG_DIR/cron/jobs.json`; `/app/config/cron/jobs.json` in the current Clawdapus layout), allowing OpenClaw's internal scheduler to pick it up automatically.
 
 ## Rationale
 

--- a/examples/openclaw/Clawfile
+++ b/examples/openclaw/Clawfile
@@ -1,7 +1,7 @@
 FROM node:24-bookworm-slim
 
 RUN apt-get update && apt-get install -y bash ca-certificates cron curl git jq tini
-RUN npm install -g openclaw@2026.2.9
+RUN npm install -g openclaw@2026.4.9
 
 CLAW_TYPE openclaw
 AGENT AGENTS.md

--- a/examples/trading-desk/README.md
+++ b/examples/trading-desk/README.md
@@ -106,8 +106,8 @@ the required per-service Discord IDs/topology are missing.
 | `openclaw.json` cllama rewrite | `models.providers.<provider>.baseUrl` points to `cllama`, `apiKey` is per-agent token |
 | `jobs.json` structure | `agentTurn` payload, `delivery.to` = resolved channel ID |
 | cllama context files | `.claw-runtime/context/<agent>/` contains `AGENTS.md`, `CLAWDAPUS.md`, `metadata.json` |
-| Compose mounts | `/app/config` directory, `/app/state/cron` directory |
-| Container readability | `/app/config/openclaw.json`, `/app/state/cron/jobs.json`, `/claw/AGENTS.md` |
+| Compose mounts | `/app/config` directory |
+| Container readability | `/app/config/openclaw.json`, `/app/config/cron/jobs.json`, `/claw/AGENTS.md` |
 | Skills populated | `/claw/skills/` contains extracted skill files |
 | Health check | Docker healthcheck reports healthy |
 | Discord greetings | Messages appear in the channel via REST API polling |

--- a/internal/clawfile/parser_test.go
+++ b/internal/clawfile/parser_test.go
@@ -29,7 +29,7 @@ PRIVILEGE worker root
 PRIVILEGE runtime claw-user
 
 RUN apt-get update && apt-get install -y bash ca-certificates cron curl git jq tini
-RUN npm install -g openclaw@2026.2.9
+RUN npm install -g openclaw@2026.4.9
 WORKDIR /workspace
 `
 

--- a/internal/driver/openclaw/driver.go
+++ b/internal/driver/openclaw/driver.go
@@ -110,19 +110,16 @@ func (d *Driver) Materialize(rc *driver.ResolvedClaw, opts driver.MaterializeOpt
 	}
 
 	// Generate jobs.json if there are scheduled invocations.
-	// Mounted read-write: openclaw updates job state (nextRunAtMs, lastRunAtMs, etc.)
-	// on every timer tick. Read-only would produce EROFS failures in the scheduler.
+	// OpenClaw 2026.3.24 resolves its cron store under CONFIG_DIR/cron/jobs.json,
+	// so keep it under the writable config directory instead of /app/state.
 	if len(rc.Invocations) > 0 {
 		jobsData, err := GenerateJobsJSON(rc)
 		if err != nil {
 			return nil, fmt.Errorf("openclaw driver: generate jobs.json: %w", err)
 		}
-		jobsDir := filepath.Join(opts.RuntimeDir, "state", "cron")
+		jobsDir := filepath.Join(configDir, "cron")
 		if err := os.MkdirAll(jobsDir, 0777); err != nil {
 			return nil, fmt.Errorf("openclaw driver: create jobs dir: %w", err)
-		}
-		if err := os.Chmod(filepath.Join(opts.RuntimeDir, "state"), 0o777); err != nil {
-			return nil, fmt.Errorf("openclaw driver: chmod state dir: %w", err)
 		}
 		if err := os.Chmod(jobsDir, 0o777); err != nil {
 			return nil, fmt.Errorf("openclaw driver: chmod jobs dir: %w", err)
@@ -134,13 +131,6 @@ func (d *Driver) Materialize(rc *driver.ResolvedClaw, opts driver.MaterializeOpt
 		if err := os.Chmod(jobsPath, 0o666); err != nil {
 			return nil, fmt.Errorf("openclaw driver: chmod jobs.json: %w", err)
 		}
-		mounts = append(mounts, driver.Mount{
-			// Bind-mount the directory (not the file) so openclaw can rename temp files
-			// alongside jobs.json during atomic save operations (same pattern as openclaw.json).
-			HostPath:      jobsDir,
-			ContainerPath: "/app/state/cron",
-			ReadOnly:      false,
-		})
 	}
 
 	mounts = append(mounts, driver.Mount{
@@ -180,9 +170,7 @@ func (d *Driver) Materialize(rc *driver.ResolvedClaw, opts driver.MaterializeOpt
 			"/run",
 			// /app/state covers all openclaw state subdirs (identity, logs, memory, agents, etc.).
 			// OpenClaw 2026.3.24 runs as uid/gid 1000, so the tmpfs must be writable by that user
-			// or startup will fail on /app/state/{agents,canvas}. The jobs.json bind mount layers
-			// on top of this tmpfs — Docker applies bind mounts after tmpfs, so
-			// /app/state/cron/jobs.json is accessible read-write as expected.
+			// or startup will fail on /app/state/{agents,canvas}.
 			openclawStateTmpfs,
 		},
 		ReadOnly: true,

--- a/internal/driver/openclaw/driver_test.go
+++ b/internal/driver/openclaw/driver_test.go
@@ -256,7 +256,7 @@ func TestMaterializeInlinesClawdapusContextIntoMountedContract(t *testing.T) {
 	}
 }
 
-func TestMaterializeJobsDirMountedNotFile(t *testing.T) {
+func TestMaterializeWritesJobsUnderConfigDir(t *testing.T) {
 	dir := t.TempDir()
 	agentFile := filepath.Join(dir, "AGENTS.md")
 	os.WriteFile(agentFile, []byte("# Contract"), 0644)
@@ -278,12 +278,13 @@ func TestMaterializeJobsDirMountedNotFile(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// jobs.json must exist in the state/cron/ directory on the host
-	jobsPath := filepath.Join(dir, "state", "cron", "jobs.json")
+	// jobs.json must exist in the config/cron/ directory on the host.
+	// The parent /app/config bind mount covers this path inside the container.
+	jobsPath := filepath.Join(dir, "config", "cron", "jobs.json")
 	if _, err := os.Stat(jobsPath); err != nil {
-		t.Fatalf("jobs.json not written at state/cron/jobs.json: %v", err)
+		t.Fatalf("jobs.json not written at config/cron/jobs.json: %v", err)
 	}
-	jobsDirInfo, err := os.Stat(filepath.Join(dir, "state", "cron"))
+	jobsDirInfo, err := os.Stat(filepath.Join(dir, "config", "cron"))
 	if err != nil {
 		t.Fatalf("stat jobs dir: %v", err)
 	}
@@ -298,20 +299,23 @@ func TestMaterializeJobsDirMountedNotFile(t *testing.T) {
 		t.Fatalf("jobs.json mode = %o, want 666", got)
 	}
 
-	// The mount target must be the cron/ DIRECTORY, not the jobs.json file.
-	// Mounting the file causes EBUSY when openclaw does atomic rename next to it.
-	var jobsMount *driver.Mount
+	var configMount *driver.Mount
 	for i := range result.Mounts {
-		if result.Mounts[i].ContainerPath == "/app/state/cron" {
-			jobsMount = &result.Mounts[i]
+		if result.Mounts[i].ContainerPath == "/app/config" {
+			configMount = &result.Mounts[i]
 			break
 		}
 	}
-	if jobsMount == nil {
-		t.Fatal("expected a mount at /app/state/cron (directory), not /app/state/cron/jobs.json")
+	if configMount == nil {
+		t.Fatal("expected /app/config mount to cover config/cron/jobs.json")
 	}
-	if jobsMount.ReadOnly {
-		t.Error("jobs cron dir must be read-write so openclaw can update job state")
+	if configMount.ReadOnly {
+		t.Error("/app/config must be read-write so openclaw can update cron job state")
+	}
+	for i := range result.Mounts {
+		if result.Mounts[i].ContainerPath == "/app/state/cron" {
+			t.Fatal("unexpected legacy /app/state/cron mount")
+		}
 	}
 }
 

--- a/internal/driver/openclaw/jobs.go
+++ b/internal/driver/openclaw/jobs.go
@@ -25,6 +25,11 @@ type job struct {
 	State         jobState    `json:"state"`
 }
 
+type jobStore struct {
+	Version int   `json:"version"`
+	Jobs    []job `json:"jobs"`
+}
+
 type jobSchedule struct {
 	Expr string `json:"expr"`
 	TZ   string `json:"tz"`
@@ -82,7 +87,10 @@ func GenerateJobsJSON(rc *driver.ResolvedClaw) ([]byte, error) {
 		}
 		jobs = append(jobs, j)
 	}
-	return json.MarshalIndent(jobs, "", "  ")
+	return json.MarshalIndent(jobStore{
+		Version: 1,
+		Jobs:    jobs,
+	}, "", "  ")
 }
 
 func deterministicJobID(parts ...string) string {

--- a/internal/driver/openclaw/jobs_test.go
+++ b/internal/driver/openclaw/jobs_test.go
@@ -7,6 +7,22 @@ import (
 	"github.com/mostlydev/clawdapus/internal/driver"
 )
 
+func parseJobStore(t *testing.T, data []byte) []map[string]interface{} {
+	t.Helper()
+
+	var store struct {
+		Version int                      `json:"version"`
+		Jobs    []map[string]interface{} `json:"jobs"`
+	}
+	if err := json.Unmarshal(data, &store); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if store.Version != 1 {
+		t.Fatalf("expected version=1, got %d", store.Version)
+	}
+	return store.Jobs
+}
+
 func TestGenerateJobsJSONSingleInvocation(t *testing.T) {
 	rc := &driver.ResolvedClaw{
 		ServiceName: "tiverton",
@@ -24,10 +40,7 @@ func TestGenerateJobsJSONSingleInvocation(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var jobs []map[string]interface{}
-	if err := json.Unmarshal(data, &jobs); err != nil {
-		t.Fatalf("invalid JSON: %v", err)
-	}
+	jobs := parseJobStore(t, data)
 	if len(jobs) != 1 {
 		t.Fatalf("expected 1 job, got %d", len(jobs))
 	}
@@ -79,16 +92,22 @@ func TestGenerateJobsJSONNoTo(t *testing.T) {
 	}
 
 	// Use raw map to check key presence
-	var raw []map[string]json.RawMessage
+	var raw struct {
+		Version int                          `json:"version"`
+		Jobs    []map[string]json.RawMessage `json:"jobs"`
+	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		t.Fatalf("invalid JSON: %v", err)
 	}
-	if len(raw) != 1 {
-		t.Fatalf("expected 1 job, got %d", len(raw))
+	if raw.Version != 1 {
+		t.Fatalf("expected version=1, got %d", raw.Version)
+	}
+	if len(raw.Jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(raw.Jobs))
 	}
 
 	var delivery map[string]json.RawMessage
-	if err := json.Unmarshal(raw[0]["delivery"], &delivery); err != nil {
+	if err := json.Unmarshal(raw.Jobs[0]["delivery"], &delivery); err != nil {
 		t.Fatalf("invalid delivery JSON: %v", err)
 	}
 	if _, haTo := delivery["to"]; haTo {
@@ -113,9 +132,8 @@ func TestGenerateJobsJSONDeterministicIDs(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var firstJobs, secondJobs []map[string]interface{}
-	json.Unmarshal(first, &firstJobs)
-	json.Unmarshal(second, &secondJobs)
+	firstJobs := parseJobStore(t, first)
+	secondJobs := parseJobStore(t, second)
 
 	id1 := firstJobs[0]["id"]
 	id2 := secondJobs[0]["id"]
@@ -134,10 +152,7 @@ func TestGenerateJobsJSONEmptyInvocations(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var jobs []map[string]interface{}
-	if err := json.Unmarshal(data, &jobs); err != nil {
-		t.Fatalf("invalid JSON: %v", err)
-	}
+	jobs := parseJobStore(t, data)
 	if len(jobs) != 0 {
 		t.Errorf("expected empty array, got %d jobs", len(jobs))
 	}
@@ -160,10 +175,7 @@ func TestGenerateJobsJSONDisablesPodOriginJobs(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var jobs []map[string]interface{}
-	if err := json.Unmarshal(data, &jobs); err != nil {
-		t.Fatalf("invalid JSON: %v", err)
-	}
+	jobs := parseJobStore(t, data)
 	if jobs[0]["enabled"] != false {
 		t.Fatalf("expected pod-origin job to be disabled, got %v", jobs[0]["enabled"])
 	}


### PR DESCRIPTION
## What changed

This updates the OpenClaw driver to emit pod-origin cron jobs in the store location and JSON shape that OpenClaw `2026.3.24` actually loads:

- write the cron store under the writable config mount at `config/cron/jobs.json`
- emit the versioned envelope form `{ "version": 1, "jobs": [...] }`
- keep deterministic invocation IDs and preserve disabled pod-origin jobs for scheduler-owned wake execution
- update OpenClaw tests, spike assertions, and operator docs away from the legacy `/app/state/cron/jobs.json` contract

## Root cause

`claw-api` already triggers OpenClaw directly via `openclaw cron run <job-id>` for pod-origin schedules. The degradation bug was that Clawdapus compiled those jobs into the old OpenClaw store contract:

- legacy path: `/app/state/cron/jobs.json`
- legacy shape: bare array `[{...}]`

OpenClaw `2026.3.24` loads cron jobs from `CONFIG_DIR/cron/jobs.json` and expects the versioned store envelope. Because the generated store never loaded into OpenClaw's in-memory registry, `openclaw cron run <id>` failed with `unknown cron job id`, and `claw-api` eventually marked the schedules degraded after repeated wake failures.

## Impact

After redeploying pods built from this change, pod-origin scheduled invocations should load into OpenClaw correctly, manual or scheduler-driven `openclaw cron run <id>` calls should resolve, and affected `clawdash` schedule rows should stop drifting into degraded mode from this compatibility bug.

## Validation

- `go test ./internal/driver/openclaw`
- `go test ./cmd/claw`
