### PR TITLE
Handle unknown claw-api principal verbs without crash-looping

### DIFF
--- a/cmd/claw-api/main.go
+++ b/cmd/claw-api/main.go
@@ -77,9 +77,12 @@ func run(args []string, stdout, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
-	store, err := clawapi.LoadStore(cfg.PrincipalsPath)
+	store, warnings, err := clawapi.LoadStoreWithWarnings(cfg.PrincipalsPath)
 	if err != nil {
 		return err
+	}
+	for _, warning := range warnings {
+		fmt.Fprintf(stderr, "claw-api warning: %s\n", warning)
 	}
 	var scheduleState *scheduleStateStore
 	if scheduleManifest != nil {

--- a/internal/clawapi/principal.go
+++ b/internal/clawapi/principal.go
@@ -43,18 +43,24 @@ type Principal struct {
 }
 
 func LoadStore(filePath string) (*Store, error) {
+	store, _, err := LoadStoreWithWarnings(filePath)
+	return store, err
+}
+
+func LoadStoreWithWarnings(filePath string) (*Store, []string, error) {
 	raw, err := os.ReadFile(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("read claw-api principals %q: %w", filePath, err)
+		return nil, nil, fmt.Errorf("read claw-api principals %q: %w", filePath, err)
 	}
 	var store Store
 	if err := json.Unmarshal(raw, &store); err != nil {
-		return nil, fmt.Errorf("parse claw-api principals %q: %w", filePath, err)
+		return nil, nil, fmt.Errorf("parse claw-api principals %q: %w", filePath, err)
 	}
-	if err := validateStore(&store); err != nil {
-		return nil, fmt.Errorf("validate claw-api principals %q: %w", filePath, err)
+	warnings, err := normalizeStore(&store)
+	if err != nil {
+		return nil, nil, fmt.Errorf("validate claw-api principals %q: %w", filePath, err)
 	}
-	return &store, nil
+	return &store, warnings, nil
 }
 
 func (s *Store) ResolveBearer(header string) (*Principal, error) {
@@ -200,6 +206,36 @@ func matchesAny(patterns []string, value string) bool {
 }
 
 func validateStore(store *Store) error {
+	if err := validateStoreStructure(store); err != nil {
+		return err
+	}
+	for _, principal := range store.Principals {
+		if err := validateVerbs(principal.Verbs); err != nil {
+			return fmt.Errorf("principal %q: %w", principal.Name, err)
+		}
+	}
+	return nil
+}
+
+func normalizeStore(store *Store) ([]string, error) {
+	if err := validateStoreStructure(store); err != nil {
+		return nil, err
+	}
+	warnings := make([]string, 0)
+	for i := range store.Principals {
+		filtered, unknown := filterKnownVerbs(store.Principals[i].Verbs)
+		for _, verb := range unknown {
+			warnings = append(warnings, fmt.Sprintf("ignoring unknown verb %q for principal %q", verb, store.Principals[i].Name))
+		}
+		if len(filtered) == 0 && len(store.Principals[i].Verbs) > 0 {
+			warnings = append(warnings, fmt.Sprintf("principal %q has no recognized verbs; token will authorize nothing", store.Principals[i].Name))
+		}
+		store.Principals[i].Verbs = filtered
+	}
+	return warnings, nil
+}
+
+func validateStoreStructure(store *Store) error {
 	if store == nil {
 		return fmt.Errorf("store is nil")
 	}
@@ -222,9 +258,6 @@ func validateStore(store *Store) error {
 		if err := validatePatterns("compose_services", principal.ComposeServices); err != nil {
 			return fmt.Errorf("principal %q: %w", principal.Name, err)
 		}
-		if err := validateVerbs(principal.Verbs); err != nil {
-			return fmt.Errorf("principal %q: %w", principal.Name, err)
-		}
 	}
 	return nil
 }
@@ -232,18 +265,37 @@ func validateStore(store *Store) error {
 func validateVerbs(verbs []string) error {
 	for _, verb := range verbs {
 		verb = strings.TrimSpace(verb)
-		known := false
-		for _, v := range AllVerbs {
-			if v == verb {
-				known = true
-				break
-			}
-		}
-		if !known {
+		if !isKnownVerb(verb) {
 			return fmt.Errorf("unknown verb %q", verb)
 		}
 	}
 	return nil
+}
+
+func filterKnownVerbs(verbs []string) ([]string, []string) {
+	filtered := make([]string, 0, len(verbs))
+	unknown := make([]string, 0)
+	for _, verb := range verbs {
+		verb = strings.TrimSpace(verb)
+		if verb == "" {
+			continue
+		}
+		if isKnownVerb(verb) {
+			filtered = append(filtered, verb)
+			continue
+		}
+		unknown = append(unknown, verb)
+	}
+	return filtered, unknown
+}
+
+func isKnownVerb(verb string) bool {
+	for _, v := range AllVerbs {
+		if v == verb {
+			return true
+		}
+	}
+	return false
 }
 
 func validatePatterns(label string, patterns []string) error {

--- a/internal/clawapi/principal.go
+++ b/internal/clawapi/principal.go
@@ -205,23 +205,11 @@ func matchesAny(patterns []string, value string) bool {
 	return false
 }
 
-func validateStore(store *Store) error {
-	if err := validateStoreStructure(store); err != nil {
-		return err
-	}
-	for _, principal := range store.Principals {
-		if err := validateVerbs(principal.Verbs); err != nil {
-			return fmt.Errorf("principal %q: %w", principal.Name, err)
-		}
-	}
-	return nil
-}
-
 func normalizeStore(store *Store) ([]string, error) {
 	if err := validateStoreStructure(store); err != nil {
 		return nil, err
 	}
-	warnings := make([]string, 0)
+	var warnings []string
 	for i := range store.Principals {
 		filtered, unknown := filterKnownVerbs(store.Principals[i].Verbs)
 		for _, verb := range unknown {
@@ -262,19 +250,9 @@ func validateStoreStructure(store *Store) error {
 	return nil
 }
 
-func validateVerbs(verbs []string) error {
-	for _, verb := range verbs {
-		verb = strings.TrimSpace(verb)
-		if !isKnownVerb(verb) {
-			return fmt.Errorf("unknown verb %q", verb)
-		}
-	}
-	return nil
-}
-
 func filterKnownVerbs(verbs []string) ([]string, []string) {
 	filtered := make([]string, 0, len(verbs))
-	unknown := make([]string, 0)
+	var unknown []string
 	for _, verb := range verbs {
 		verb = strings.TrimSpace(verb)
 		if verb == "" {

--- a/internal/clawapi/principal_test.go
+++ b/internal/clawapi/principal_test.go
@@ -64,14 +64,8 @@ func TestBuildMasterPrincipalHasAllVerbsAndOpaqueToken(t *testing.T) {
 }
 
 func TestLoadStoreRejectsInvalidGlobPattern(t *testing.T) {
-	store := &Store{
-		Principals: []Principal{{
-			Name:     "octopus",
-			Token:    "capi_deadbeef",
-			Services: []string{"[bad"},
-		}},
-	}
-	if err := validateStore(store); err == nil {
+	path := writeStoreFixture(t, `{"principals":[{"name":"octopus","token":"capi_deadbeef","services":["[bad"]}]}`)
+	if _, err := LoadStore(path); err == nil {
 		t.Fatal("expected invalid pattern error")
 	}
 }
@@ -102,33 +96,22 @@ func TestPrincipalComposeServiceScope(t *testing.T) {
 	}
 }
 
-func TestValidateStoreRejectsUnknownVerb(t *testing.T) {
-	store := &Store{
-		Principals: []Principal{{
-			Name:  "bad",
-			Token: "capi_x",
-			Verbs: []string{"fleet.explode"},
-		}},
+func TestLoadStoreFiltersUnknownVerbs(t *testing.T) {
+	path := writeStoreFixture(t, `{"principals":[{"name":"future","token":"capi_x","verbs":["fleet.status","schedule.pause","fleet.logs"]}]}`)
+	store, err := LoadStore(path)
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
 	}
-	if err := validateStore(store); err == nil {
-		t.Fatal("expected unknown verb error")
+	if len(store.Principals) != 1 {
+		t.Fatalf("expected one principal, got %d", len(store.Principals))
 	}
-}
-
-func TestValidateStoreAcceptsAllKnownVerbs(t *testing.T) {
-	store := &Store{
-		Principals: []Principal{{
-			Name:  "full",
-			Token: "capi_x",
-			Verbs: AllVerbs,
-		}},
-	}
-	if err := validateStore(store); err != nil {
-		t.Fatalf("expected all known verbs to be valid: %v", err)
+	wantVerbs := []string{VerbFleetStatus, VerbFleetLogs}
+	if !reflect.DeepEqual(store.Principals[0].Verbs, wantVerbs) {
+		t.Fatalf("verbs=%v want %v", store.Principals[0].Verbs, wantVerbs)
 	}
 }
 
-func TestLoadStoreWithWarningsFiltersUnknownVerbs(t *testing.T) {
+func TestLoadStoreWithWarningsReportsUnknownVerbs(t *testing.T) {
 	path := writeStoreFixture(t, `{"principals":[{"name":"future","token":"capi_x","verbs":["fleet.status","schedule.pause","fleet.logs"]}]}`)
 	store, warnings, err := LoadStoreWithWarnings(path)
 	if err != nil {

--- a/internal/clawapi/principal_test.go
+++ b/internal/clawapi/principal_test.go
@@ -1,6 +1,9 @@
 package clawapi
 
 import (
+	"os"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -125,6 +128,57 @@ func TestValidateStoreAcceptsAllKnownVerbs(t *testing.T) {
 	}
 }
 
+func TestLoadStoreWithWarningsFiltersUnknownVerbs(t *testing.T) {
+	path := writeStoreFixture(t, `{"principals":[{"name":"future","token":"capi_x","verbs":["fleet.status","schedule.pause","fleet.logs"]}]}`)
+	store, warnings, err := LoadStoreWithWarnings(path)
+	if err != nil {
+		t.Fatalf("LoadStoreWithWarnings: %v", err)
+	}
+	if len(store.Principals) != 1 {
+		t.Fatalf("expected one principal, got %d", len(store.Principals))
+	}
+	wantVerbs := []string{VerbFleetStatus, VerbFleetLogs}
+	if !reflect.DeepEqual(store.Principals[0].Verbs, wantVerbs) {
+		t.Fatalf("verbs=%v want %v", store.Principals[0].Verbs, wantVerbs)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], `ignoring unknown verb "schedule.pause"`) {
+		t.Fatalf("expected unknown-verb warning, got %v", warnings)
+	}
+}
+
+func TestLoadStoreWithWarningsKeepsPrincipalWhenAllVerbsAreUnknown(t *testing.T) {
+	path := writeStoreFixture(t, `{"principals":[{"name":"future","token":"capi_x","verbs":["schedule.pause"]}]}`)
+	store, warnings, err := LoadStoreWithWarnings(path)
+	if err != nil {
+		t.Fatalf("LoadStoreWithWarnings: %v", err)
+	}
+	if len(store.Principals) != 1 {
+		t.Fatalf("expected one principal, got %d", len(store.Principals))
+	}
+	if len(store.Principals[0].Verbs) != 0 {
+		t.Fatalf("expected unknown verbs to be dropped, got %v", store.Principals[0].Verbs)
+	}
+	if len(warnings) != 2 {
+		t.Fatalf("expected 2 warnings, got %v", warnings)
+	}
+	if !strings.Contains(warnings[0], `ignoring unknown verb "schedule.pause"`) {
+		t.Fatalf("expected unknown-verb warning, got %v", warnings)
+	}
+	if !strings.Contains(warnings[1], `has no recognized verbs`) {
+		t.Fatalf("expected inert-principal warning, got %v", warnings)
+	}
+	principal, err := store.ResolveBearer("Bearer capi_x")
+	if err != nil {
+		t.Fatalf("ResolveBearer: %v", err)
+	}
+	if principal.Name != "future" {
+		t.Fatalf("unexpected principal: %+v", principal)
+	}
+	if principal.AllowsVerb(VerbFleetStatus) {
+		t.Fatalf("did not expect inert principal to authorize fleet.status")
+	}
+}
+
 func TestPrincipalPodScopeGrantsComposeServiceAccess(t *testing.T) {
 	p := Principal{
 		Name:  "master",
@@ -195,4 +249,13 @@ func TestBuildSchedulerPrincipalIsScheduleScoped(t *testing.T) {
 	if !p.AllowsPod("trading-desk") {
 		t.Fatalf("expected pod scope, got %+v", p)
 	}
+}
+
+func writeStoreFixture(t *testing.T, raw string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "principals.json")
+	if err := os.WriteFile(path, []byte(raw), 0o644); err != nil {
+		t.Fatalf("write store fixture: %v", err)
+	}
+	return path
 }


### PR DESCRIPTION
## Summary
- make `claw-api` tolerate forward-unknown principal verbs at runtime instead of failing startup
- filter unrecognized verbs out of the loaded principal store and emit warnings on service startup
- keep strict compiler-side validation intact and add regression coverage for tolerant runtime loading

## Testing
- `go test ./internal/clawapi ./cmd/claw-api`
- `go test ./...`

## Notes
This addresses the outage-class runtime behavior from #120. It does not yet add a separate `claw up` compatibility warning for skew against an older deployed `claw-api` image.