### PR TITLE
fix: rotate .claw-runtime safely during redeploys

### DIFF
--- a/cmd/claw/compose_up.go
+++ b/cmd/claw/compose_up.go
@@ -87,7 +87,7 @@ var composeUpCmd = &cobra.Command{
 	},
 }
 
-func runComposeUp(podFile string) error {
+func runComposeUp(podFile string) (err error) {
 	p, podDir, err := loadPodDefinition(podFile)
 	if err != nil {
 		return err
@@ -127,9 +127,25 @@ func runComposeUp(podFile string) error {
 	if err := preMigratePortableMemory(runtimeDir, memoryRoot, p); err != nil {
 		return fmt.Errorf("migrate portable memory: %w", err)
 	}
-	if err := resetRuntimeDir(runtimeDir); err != nil {
-		return fmt.Errorf("reset runtime dir: %w", err)
+	runtimeStage, err := prepareRuntimeDir(runtimeDir)
+	if err != nil {
+		return fmt.Errorf("prepare runtime dir: %w", err)
 	}
+	composeApplied := false
+	defer func() {
+		if err == nil || runtimeStage == nil {
+			return
+		}
+		if composeApplied {
+			if runtimeStage.PreviousPath != "" {
+				fmt.Printf("[claw] warning: preserving previous runtime dir at %s after failed apply\n", runtimeStage.PreviousPath)
+			}
+			return
+		}
+		if rollbackErr := runtimeStage.Rollback(); rollbackErr != nil {
+			err = fmt.Errorf("%w (also failed to restore previous runtime dir: %v)", err, rollbackErr)
+		}
+	}()
 	// Governance dir is separate from runtimeDir so it survives claw up resets.
 	governanceDir := filepath.Join(podDir, ".claw-governance")
 	if err := os.MkdirAll(governanceDir, 0o777); err != nil {
@@ -767,6 +783,7 @@ func runComposeUp(podFile string) error {
 		composeArgs = append(composeArgs, "-d")
 	}
 
+	composeApplied = true
 	if err := runComposeDockerCommand(composeArgs...); err != nil {
 		return fmt.Errorf("docker compose up failed: %w", err)
 	}
@@ -794,6 +811,10 @@ func runComposeUp(podFile string) error {
 				fmt.Printf("[claw] %s (%s): post-apply verified\n", generatedService, shortContainerIDForPostApply(containerID))
 			}
 		}
+	}
+
+	if err := runtimeStage.Commit(); err != nil {
+		fmt.Printf("[claw] warning: could not remove previous runtime dir %s: %v\n", runtimeStage.PreviousPath, err)
 	}
 
 	fmt.Println("[claw] pod is up")
@@ -877,11 +898,61 @@ func unsupportedManagedCapabilityList(claw *pod.ClawBlock) []string {
 	return capabilities
 }
 
-func resetRuntimeDir(path string) error {
-	if err := os.RemoveAll(path); err != nil {
+type runtimeDirStage struct {
+	ActivePath   string
+	PreviousPath string
+}
+
+func prepareRuntimeDir(path string) (*runtimeDirStage, error) {
+	stage := &runtimeDirStage{ActivePath: path}
+
+	info, err := os.Stat(path)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		// No prior runtime tree — create a fresh one below.
+	case err != nil:
+		return nil, err
+	default:
+		if !info.IsDir() {
+			return nil, fmt.Errorf("runtime dir %q exists but is not a directory", path)
+		}
+		stage.PreviousPath = fmt.Sprintf("%s.previous-%d", path, time.Now().UnixNano())
+		if err := os.Rename(path, stage.PreviousPath); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		if stage.PreviousPath != "" {
+			_ = os.Rename(stage.PreviousPath, path)
+		}
+		return nil, err
+	}
+	if err := os.Chmod(path, 0o700); err != nil {
+		if stage.PreviousPath != "" {
+			_ = os.RemoveAll(path)
+			_ = os.Rename(stage.PreviousPath, path)
+		}
+		return nil, err
+	}
+	return stage, nil
+}
+
+func (s *runtimeDirStage) Rollback() error {
+	if s == nil || s.PreviousPath == "" {
+		return nil
+	}
+	if err := os.RemoveAll(s.ActivePath); err != nil {
 		return err
 	}
-	return os.MkdirAll(path, 0o700)
+	return os.Rename(s.PreviousPath, s.ActivePath)
+}
+
+func (s *runtimeDirStage) Commit() error {
+	if s == nil || s.PreviousPath == "" {
+		return nil
+	}
+	return os.RemoveAll(s.PreviousPath)
 }
 
 func preMigratePortableMemory(runtimeDir, memoryRoot string, p *pod.Pod) error {

--- a/cmd/claw/compose_up_test.go
+++ b/cmd/claw/compose_up_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -665,7 +666,7 @@ func TestMaterializeContractIncludesBuildsGeneratedContractAndReferenceSkill(t *
 	}
 }
 
-func TestResetRuntimeDirClearsStaleContents(t *testing.T) {
+func TestPrepareRuntimeDirStagesPreviousTreeUntilCommit(t *testing.T) {
 	tmpDir := t.TempDir()
 	runtimeDir := filepath.Join(tmpDir, ".claw-runtime")
 	staleDir := filepath.Join(runtimeDir, "nb-roll", "skills", "handle-discord.md")
@@ -677,8 +678,9 @@ func TestResetRuntimeDirClearsStaleContents(t *testing.T) {
 		t.Fatalf("write stale file: %v", err)
 	}
 
-	if err := resetRuntimeDir(runtimeDir); err != nil {
-		t.Fatalf("reset runtime dir: %v", err)
+	stage, err := prepareRuntimeDir(runtimeDir)
+	if err != nil {
+		t.Fatalf("prepare runtime dir: %v", err)
 	}
 
 	info, err := os.Stat(runtimeDir)
@@ -688,11 +690,63 @@ func TestResetRuntimeDirClearsStaleContents(t *testing.T) {
 	if !info.IsDir() {
 		t.Fatalf("expected runtime dir to exist as directory")
 	}
-	if _, err := os.Stat(staleDir); !os.IsNotExist(err) {
-		t.Fatalf("expected stale dir to be removed, got err=%v", err)
+	if stage.PreviousPath == "" {
+		t.Fatal("expected previous runtime dir to be preserved during staging")
 	}
-	if _, err := os.Stat(staleFile); !os.IsNotExist(err) {
-		t.Fatalf("expected stale file to be removed, got err=%v", err)
+	if _, err := os.Stat(staleDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected stale dir to be absent from fresh runtime dir, got err=%v", err)
+	}
+	if _, err := os.Stat(staleFile); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected stale file to be absent from fresh runtime dir, got err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(stage.PreviousPath, "nb-roll", "skills", "handle-discord.md")); err != nil {
+		t.Fatalf("expected staged previous runtime tree to preserve stale dir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(stage.PreviousPath, "stale.txt")); err != nil {
+		t.Fatalf("expected staged previous runtime tree to preserve stale file: %v", err)
+	}
+
+	if err := stage.Commit(); err != nil {
+		t.Fatalf("commit runtime dir: %v", err)
+	}
+	if _, err := os.Stat(stage.PreviousPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected previous runtime dir to be removed after commit, got err=%v", err)
+	}
+}
+
+func TestPrepareRuntimeDirRollbackRestoresPreviousTree(t *testing.T) {
+	tmpDir := t.TempDir()
+	runtimeDir := filepath.Join(tmpDir, ".claw-runtime")
+	if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+		t.Fatalf("mkdir runtime dir: %v", err)
+	}
+	originalPath := filepath.Join(runtimeDir, "AGENTS.generated.md")
+	if err := os.WriteFile(originalPath, []byte("old"), 0o644); err != nil {
+		t.Fatalf("write original runtime file: %v", err)
+	}
+
+	stage, err := prepareRuntimeDir(runtimeDir)
+	if err != nil {
+		t.Fatalf("prepare runtime dir: %v", err)
+	}
+	replacementPath := filepath.Join(runtimeDir, "AGENTS.generated.md")
+	if err := os.WriteFile(replacementPath, []byte("new"), 0o644); err != nil {
+		t.Fatalf("write replacement runtime file: %v", err)
+	}
+
+	if err := stage.Rollback(); err != nil {
+		t.Fatalf("rollback runtime dir: %v", err)
+	}
+
+	data, err := os.ReadFile(originalPath)
+	if err != nil {
+		t.Fatalf("read restored runtime file: %v", err)
+	}
+	if string(data) != "old" {
+		t.Fatalf("restored runtime file = %q, want %q", string(data), "old")
+	}
+	if _, err := os.Stat(stage.PreviousPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected previous runtime dir to be consumed by rollback, got err=%v", err)
 	}
 }
 

--- a/cmd/claw/spike_runtime_rotation_test.go
+++ b/cmd/claw/spike_runtime_rotation_test.go
@@ -1,0 +1,177 @@
+//go:build spike
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSpikeComposeUpRotatesRuntimeDirSafely covers the live redeploy path that
+// broke Tiverton: calling claw up twice on an already-running pod must not
+// poison bind-mounted runtime artifacts by deleting .claw-runtime in place.
+//
+// The regression shape was:
+//   - first claw up started the pod normally
+//   - second claw up removed .claw-runtime while containers still held mounts
+//   - docker recreated missing bind sources as root-owned directories
+//   - later materialization failed on chmod/write, and /claw/AGENTS.md became a directory
+//
+// This spike proves the fix end-to-end by running the same non-root OpenClaw
+// pod through runComposeUp twice without an intervening down, then asserting:
+//   - the service container was force-recreated onto the new runtime tree
+//   - host runtime artifacts remain regular files after the second deploy
+//   - in-container /claw/AGENTS.md and /claw/CLAWDAPUS.md are regular files
+//   - the non-root user can still create ~/.openclaw/agents after the redeploy
+func TestSpikeComposeUpRotatesRuntimeDirSafely(t *testing.T) {
+	if err := exec.Command("docker", "info").Run(); err != nil {
+		t.Skipf("docker not available: %v", err)
+	}
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+
+	fixtureDir := filepath.Join(repoRoot, "testdata", "openclaw-stub-nonroot")
+	if _, err := os.Stat(filepath.Join(fixtureDir, "Clawfile")); err != nil {
+		t.Fatalf("non-root openclaw stub fixture missing: %v", err)
+	}
+
+	imageTag := fmt.Sprintf("claw-spike-openclaw-runtime-rotation:%d", time.Now().UnixNano())
+	spikeBuildImage(t, fixtureDir, imageTag, "Clawfile")
+	t.Cleanup(func() {
+		_, _ = exec.Command("docker", "image", "rm", "-f", imageTag).CombinedOutput()
+	})
+
+	spikeEnsureRepoInfraImages(t, repoRoot, infraComponentClawdash)
+
+	workDir := t.TempDir()
+	agentsDir := filepath.Join(workDir, "agents")
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatalf("create agents dir: %v", err)
+	}
+	agentPath := filepath.Join(agentsDir, "AGENTS.md")
+	if err := os.WriteFile(agentPath, []byte("# Runtime Rotation Spike Agent\n\nProve repeated claw up leaves runtime mounts intact.\n"), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+
+	podPath := filepath.Join(workDir, "claw-pod.yml")
+	podYAML := fmt.Sprintf(`x-claw:
+  pod: openclaw-runtime-rotation-spike
+
+services:
+  rotating:
+    image: %s
+    x-claw:
+      agent: ./agents/AGENTS.md
+`, imageTag)
+	if err := os.WriteFile(podPath, []byte(podYAML), 0o644); err != nil {
+		t.Fatalf("write pod file: %v", err)
+	}
+
+	generatedPath := filepath.Join(workDir, "compose.generated.yml")
+	runtimeDir := filepath.Join(workDir, ".claw-runtime")
+
+	prevDetach := composeUpDetach
+	composeUpDetach = true
+	defer func() { composeUpDetach = prevDetach }()
+	t.Setenv("CLAWDASH_ADDR", ":"+spikeFreePort(t))
+
+	const composeProject = "openclaw-runtime-rotation-spike"
+	spikeCleanupProject(composeProject, generatedPath)
+	t.Cleanup(func() {
+		spikeCleanupProject(composeProject, generatedPath)
+	})
+
+	if err := runComposeUp(podPath); err != nil {
+		t.Fatalf("first runComposeUp failed: %v", err)
+	}
+
+	firstContainerID := rollcallResolveContainerID(t, generatedPath, "rotating")
+	spikeWaitRunning(t, firstContainerID, 30*time.Second)
+	spikeWaitHealthy(t, firstContainerID, 60*time.Second)
+	assertRuntimeArtifactsAreFiles(t, runtimeDir, "rotating")
+
+	if err := runComposeUp(podPath); err != nil {
+		rotationLogContainer(t, firstContainerID)
+		t.Fatalf("second runComposeUp failed: %v", err)
+	}
+
+	secondContainerID := rollcallResolveContainerID(t, generatedPath, "rotating")
+	if secondContainerID == firstContainerID {
+		t.Fatalf("expected rotating service to be recreated on second claw up; container id stayed %s", firstContainerID)
+	}
+	spikeWaitRunning(t, secondContainerID, 30*time.Second)
+	spikeWaitHealthy(t, secondContainerID, 60*time.Second)
+
+	assertRuntimeArtifactsAreFiles(t, runtimeDir, "rotating")
+	assertContainerArtifactsAreFiles(t, secondContainerID)
+	assertNoPreviousRuntimeDirs(t, workDir)
+}
+
+func assertRuntimeArtifactsAreFiles(t *testing.T, runtimeDir, serviceName string) {
+	t.Helper()
+
+	for _, rel := range []string{
+		filepath.Join(serviceName, "AGENTS.effective.md"),
+		filepath.Join(serviceName, "CLAWDAPUS.md"),
+		filepath.Join(serviceName, "config", "openclaw.json"),
+	} {
+		path := filepath.Join(runtimeDir, rel)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		if !info.Mode().IsRegular() {
+			t.Fatalf("expected %s to be a regular file, got mode %s", path, info.Mode())
+		}
+	}
+}
+
+func assertContainerArtifactsAreFiles(t *testing.T, containerID string) {
+	t.Helper()
+
+	cmd := exec.Command(
+		"docker", "exec", containerID,
+		"sh", "-lc",
+		"test -f /claw/AGENTS.md && test -f /claw/CLAWDAPUS.md && test -f /root/.openclaw/config/openclaw.json && mkdir -p /root/.openclaw/agents/rotation-probe",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		rotationLogContainer(t, containerID)
+		t.Fatalf("container runtime artifacts are not healthy after redeploy: %v\n%s", err, strings.TrimSpace(string(out)))
+	}
+}
+
+func assertNoPreviousRuntimeDirs(t *testing.T, workDir string) {
+	t.Helper()
+
+	matches, err := filepath.Glob(filepath.Join(workDir, ".claw-runtime.previous-*"))
+	if err != nil {
+		t.Fatalf("glob previous runtime dirs: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected previous runtime dirs to be cleaned after successful redeploy, found %v", matches)
+	}
+}
+
+func rotationLogContainer(t *testing.T, containerID string) {
+	t.Helper()
+
+	if strings.TrimSpace(containerID) == "" {
+		return
+	}
+	out, err := exec.Command("docker", "logs", "--tail", "80", containerID).CombinedOutput()
+	if err != nil {
+		t.Logf("docker logs %s failed: %v", containerID, err)
+		return
+	}
+	t.Logf("=== %s logs ===\n%s", containerID, strings.TrimSpace(string(out)))
+}


### PR DESCRIPTION
Closes #153.

## Summary

- rotate the active `.claw-runtime` tree aside instead of deleting it in place before `docker compose up`
- restore the previous runtime tree automatically if materialization fails before compose has applied anything
- keep the previous runtime tree around during compose/apply and remove it only after post-apply verification succeeds
- add unit coverage for staging/commit and rollback behavior

## Why

Repeated `claw up -d` on a live pod could tear out bind-mount sources from under running containers. Docker would then recreate missing file sources like `AGENTS.effective.md` and `CLAWDAPUS.md` as directories, poisoning `.claw-runtime` and causing later deploys to fail with permission and type errors.

This change makes redeploys safe without requiring `claw down` or a manual `.claw-runtime` move first.