### PR TITLE
feat: support MCP sidecar services as managed tools (#177)

### DIFF
--- a/cmd/claw/compose_up.go
+++ b/cmd/claw/compose_up.go
@@ -1333,9 +1333,6 @@ func buildToolManifestEntries(p *pod.Pod, descriptors map[string]*describe.Servi
 
 	entries := make([]cllama.ToolManifestEntry, 0, len(tools))
 	for _, tool := range tools {
-		if tool.HTTP == nil {
-			return nil, fmt.Errorf("tool %q from %q has no HTTP execution metadata", tool.Name, tool.Service)
-		}
 		baseURL, err := resolveServiceBaseURL(p, tool.Service)
 		if err != nil {
 			return nil, fmt.Errorf("tool %q: %w", tool.Name, err)
@@ -1344,12 +1341,10 @@ func buildToolManifestEntries(p *pod.Pod, descriptors map[string]*describe.Servi
 		if err != nil {
 			return nil, fmt.Errorf("tool %q: %w", tool.Name, err)
 		}
-		entries = append(entries, cllama.ToolManifestEntry{
-			Name:        tool.Service + "." + tool.Name,
-			Description: tool.Description,
-			InputSchema: tool.InputSchema,
-			Annotations: tool.Annotations,
-			Execution: cllama.ToolExecution{
+		var execution cllama.ToolExecution
+		switch {
+		case tool.HTTP != nil:
+			execution = cllama.ToolExecution{
 				Transport: "http",
 				Service:   tool.Service,
 				BaseURL:   baseURL,
@@ -1357,7 +1352,25 @@ func buildToolManifestEntries(p *pod.Pod, descriptors map[string]*describe.Servi
 				Path:      tool.HTTP.Path,
 				BodyKey:   tool.HTTP.BodyKey,
 				Auth:      auth,
-			},
+			}
+		case tool.MCP != nil:
+			execution = cllama.ToolExecution{
+				Transport: "mcp",
+				Service:   tool.Service,
+				BaseURL:   baseURL,
+				Path:      tool.MCP.Path,
+				ToolName:  tool.Name,
+				Auth:      auth,
+			}
+		default:
+			return nil, fmt.Errorf("tool %q from %q has no HTTP or MCP execution metadata", tool.Name, tool.Service)
+		}
+		entries = append(entries, cllama.ToolManifestEntry{
+			Name:        tool.Service + "." + tool.Name,
+			Description: tool.Description,
+			InputSchema: tool.InputSchema,
+			Annotations: tool.Annotations,
+			Execution:   execution,
 		})
 	}
 	return entries, nil

--- a/cmd/claw/compose_up_test.go
+++ b/cmd/claw/compose_up_test.go
@@ -3096,6 +3096,67 @@ func TestBuildToolManifestEntriesNamescopesAndProjectsAuth(t *testing.T) {
 	}
 }
 
+func TestBuildToolManifestEntriesProjectsMCPTools(t *testing.T) {
+	p := &pod.Pod{
+		Services: map[string]*pod.Service{
+			"analyst": {
+				Environment: map[string]string{
+					"PERPLEXITY_MCP_TOKEN": "${PERPLEXITY_MCP_TOKEN}",
+				},
+				Claw: &pod.ClawBlock{},
+			},
+			"perplexity-mcp": {
+				Expose: []string{"8080"},
+			},
+		},
+	}
+
+	tools, err := buildToolManifestEntries(
+		p,
+		map[string]*describe.ServiceDescriptor{
+			"perplexity-mcp": {
+				Version: 2,
+				MCP:     &describe.MCPDescriptor{Transport: "streamable_http", Path: "/mcp"},
+				Auth: &describe.AuthDescriptor{
+					Type: "bearer",
+					Env:  "PERPLEXITY_MCP_TOKEN",
+				},
+			},
+		},
+		map[string]string{
+			"PERPLEXITY_MCP_TOKEN": "mcp-token",
+		},
+		"analyst",
+		[]describe.ToolSpec{{
+			Name:        "search",
+			Service:     "perplexity-mcp",
+			Description: "Search the web",
+			InputSchema: map[string]interface{}{"type": "object"},
+			MCP:         &describe.MCPDescriptor{Transport: "streamable_http", Path: "/mcp"},
+		}},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("buildToolManifestEntries: %v", err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool entry, got %+v", tools)
+	}
+	if tools[0].Name != "perplexity-mcp.search" {
+		t.Fatalf("expected namespaced tool name, got %+v", tools[0])
+	}
+	execution := tools[0].Execution
+	if execution.Transport != "mcp" || execution.Service != "perplexity-mcp" || execution.BaseURL != "http://perplexity-mcp:8080" {
+		t.Fatalf("unexpected MCP execution identity: %+v", execution)
+	}
+	if execution.Path != "/mcp" || execution.ToolName != "search" || execution.Method != "" {
+		t.Fatalf("unexpected MCP execution shape: %+v", execution)
+	}
+	if execution.Auth == nil || execution.Auth.Token != "mcp-token" {
+		t.Fatalf("expected projected MCP auth token, got %+v", execution.Auth)
+	}
+}
+
 func TestBuildMemoryManifestEntryUsesProjectedServiceAuth(t *testing.T) {
 	p := &pod.Pod{
 		Services: map[string]*pod.Service{

--- a/docs/decisions/020-cllama-compiled-tool-mediation.md
+++ b/docs/decisions/020-cllama-compiled-tool-mediation.md
@@ -581,9 +581,16 @@ The capability-evolution wave (this ADR + ADR-021) landed together. Current stat
 - Session history `tool_trace`, `status`, and `usage.total_rounds` extensions
 - `claw audit` merges session-history `tool_call` events with proxy log events
 
+**Shipped (Phase 5 — MCP sidecar transport, 2026-04-27, issue #177):**
+- `claw.describe` v2 accepts a top-level `mcp` block (`transport: streamable_http`, `path: /mcp`); when present, `tools[].http` becomes optional
+- `claw up` compiles allowed MCP tools into per-agent `tools.json` with `transport: "mcp"` execution metadata, including the un-namespaced `tool_name` and reusing existing per-agent service-auth resolution
+- cllama gains a Streamable HTTP MCP client (`internal/mcp`) that runs the `initialize` + `notifications/initialized` handshake, caches sessions per target, parses both JSON and `text/event-stream` JSON-RPC responses, and retries once on session-expired (HTTP 400/404)
+- Managed-tool dispatch in cllama switches by transport (`http` → existing path, `mcp` → new MCP client) inside `executeManaged{OpenAI,Anthropic}Tool`; `tool_trace`, namespacing, audit, session-history, policy budgets, and credential-starvation boundaries are unchanged
+- Existing HTTP managed tools and descriptors continue to work without modification; descriptors without `mcp:` still require `tools[].http`
+
 **Not yet shipped:**
 - Phase 2: native projection / runner-side MCP config generation
-- Phase 5: MCP client in cllama, baked `.claw-tools.json` support, `claw discover`
+- Phase 5 follow-up: `claw discover` (live `tools/list` snapshot into the build context) and baked `.claw-tools.json` artifact support
 - Phase 6: `parallel_safe` annotation, dynamic filtering, native mode graduation
 
 See `docs/plans/2026-03-30-memory-plane-and-pluggable-recall.md` for the companion implementation-status document covering both ADR-020 and ADR-021.

--- a/docs/plans/2026-04-27-issue-177-mcp-sidecar-tools.md
+++ b/docs/plans/2026-04-27-issue-177-mcp-sidecar-tools.md
@@ -1,0 +1,304 @@
+# Issue #177 — MCP sidecar services as managed tools
+
+**Date:** 2026-04-27
+**Issue:** https://github.com/mostlydev/clawdapus/issues/177
+**ADR:** ADR-020 (Phase 5)
+**Author:** Claude (draft for Codex review and implementation)
+
+## Background
+
+ADR-020 defines a single capability IR (`tools[]` in `claw.describe`) with two
+delivery modes — `native` (runner-executed) and `mediated` (cllama-executed).
+The mediated path is shipped end-to-end (Phases 1–4), but it can only execute
+tools whose descriptor declares HTTP execution metadata. Each tool needs an
+explicit `http: { method, path }`. There is no path for a standard MCP server
+sidecar to be plugged in as a capability provider — `cllama` validates
+`tool.Execution.Transport == "http"` and rejects everything else with
+`unsupported_transport`.
+
+ADR-020 already names this work as Phase 5: "MCP client in cllama, baked
+`.claw-tools.json`, and `claw discover`". This plan implements the in-pod
+sidecar half of Phase 5. `claw discover` (live tools/list snapshot for the
+operator's build context) is treated as a follow-up (§Out of scope).
+
+## Acceptance criteria (from issue)
+
+1. A service can advertise MCP tools without writing `http` execution
+   metadata for every tool.
+2. `claw up` compiles allowed MCP tools into per-agent context
+   deterministically.
+3. `cllama` executes managed tool calls against the MCP sidecar and preserves
+   existing policy limits (`max_rounds`, `timeout_per_tool_ms`,
+   `total_timeout_ms`, `max_tool_result_bytes`), audit/`tool_trace`,
+   session-history, and credential-starvation boundaries.
+4. Tool names remain namespaced by service (e.g. `perplexity-mcp.search`).
+5. Auth/env stays on the provider sidecar, not in the agent container.
+6. Existing HTTP managed tools continue to work unchanged.
+
+## Design decisions
+
+### D1. Operator surface — descriptor-level `mcp` block
+
+Add an optional top-level `mcp` block to the `claw.describe` v2 descriptor.
+When present, the descriptor is treated as MCP-native: `tools[].http` becomes
+optional and execution routes through the MCP endpoint.
+
+```json
+{
+  "version": 2,
+  "description": "Perplexity MCP server",
+  "mcp": { "transport": "streamable_http", "path": "/mcp" },
+  "tools": [
+    {
+      "name": "search",
+      "description": "Web search with recency control",
+      "inputSchema": { "type": "object", "properties": { "query": { "type": "string" } } }
+    }
+  ],
+  "auth": { "type": "bearer", "env": "PERPLEXITY_BEARER" }
+}
+```
+
+- `mcp.transport` defaults to `"streamable_http"`. Only that transport is
+  accepted in v1 (stdio is local-only and not relevant for sidecars; the
+  legacy HTTP+SSE transport is intentionally not supported).
+- `mcp.path` is the MCP endpoint, defaults to `/mcp`. Must start with `/`.
+- When `mcp` is set, `tools[].http` may be absent. If both are present for a
+  given tool, that is a hard parse error — pick one execution shape per tool.
+- A descriptor without `mcp` must continue to require `http` per tool
+  (existing behavior, no regression).
+
+The pod-side grammar is unchanged — `tools: [{ service: <name>, allow: [...] }]`
+already works because MCP-ness is a property of the providing service, not
+the consumer.
+
+### D2. Compiled manifest — new `transport: "mcp"` execution shape
+
+`tools.json` per agent grows a second execution shape. The LLM-facing fields
+(`name`, `description`, `inputSchema`, `annotations`) are unchanged.
+
+```json
+{
+  "name": "perplexity-mcp.search",
+  "description": "Web search with recency control",
+  "inputSchema": { ... },
+  "execution": {
+    "transport": "mcp",
+    "service": "perplexity-mcp",
+    "base_url": "http://perplexity-mcp:8080",
+    "path": "/mcp",
+    "tool_name": "search",
+    "auth": { "type": "bearer", "token": "<resolved>" }
+  }
+}
+```
+
+Notes:
+- `tool_name` is the un-namespaced MCP tool name. cllama sends this in
+  `tools/call.params.name`. The compiled `name` stays namespaced for
+  collision-free LLM presentation and audit.
+- `method`/`body_key` are not used for MCP tools; omit them.
+- Auth resolution reuses `resolveManifestAuth` exactly — same precedence as
+  HTTP managed tools (per-agent service-auth → descriptor env fallback).
+
+### D3. Discovery — baked tools, no live probe at `claw up`
+
+Per ADR-020 (compile-time hermeticity), `claw up` does NOT connect to MCP
+services to fetch `tools/list`. The operator commits the tool schemas to the
+descriptor (via `tools[]`), exactly as for HTTP services today.
+
+`claw discover` (a future operator command that runs the service container
+once, calls `tools/list`, and writes the result back to the descriptor or to
+a sibling `.claw-tools.json`) is the right operator UX but is **out of scope
+for this issue**. Workaround until it lands: hand-author the tool list in
+`.claw-describe.json`. Most MCP servers publish their tool catalog in their
+README.
+
+### D4. cllama MCP client — minimal Streamable HTTP transport
+
+Add `cllama/internal/mcp/client.go`:
+- `Client.Call(ctx, target, toolName, args) ([]byte, int, error)` —
+  high-level entry point that returns the same `(rawJSON, statusCode, err)`
+  triple as `callManagedHTTPTool`.
+- Per-target session cache keyed by `(base_url + path)`. On cold cache,
+  perform `initialize` + `notifications/initialized`, store any returned
+  `Mcp-Session-Id`, and proceed with `tools/call`. On any
+  `session_required` / `invalid_session` / 4xx-with-no-session error, drop
+  the cached session and retry once.
+- POST `Content-Type: application/json`,
+  `Accept: application/json, text/event-stream`. Handle either response
+  shape: parse a single JSON body, or read SSE events (`data:` lines) until
+  the JSON-RPC response with the matching `id` is received.
+- Bearer auth applied via `Authorization` header when
+  `tool.Execution.Auth.Type == "bearer"`.
+
+Result normalization: MCP `tools/call` responses look like
+
+```json
+{ "result": { "content": [{ "type": "text", "text": "..." }, ...], "isError": false } }
+```
+
+cllama wraps this into the existing managed-tool result envelope:
+
+```json
+{ "ok": true, "data": { "content": [...] } }
+```
+
+`isError: true` becomes `{ "ok": false, "error": { "code": "tool_error", "message": "<flattened text>" } }`.
+JSON-RPC transport errors (parse error, server error, timeout) map onto the
+existing error code vocabulary (`request_failed`, `read_failed`, `http_<n>`,
+`timeout`).
+
+### D5. Dispatch — single switch in `executeManagedOpenAITool` / `executeManagedAnthropicTool`
+
+Both Anthropic and OpenAI execution paths today directly call
+`callManagedHTTPTool`. Replace those two call sites with a thin
+`dispatchManagedTool(ctx, agentID, manifest, args)` that switches on
+`manifest.Execution.Transport`:
+
+```go
+switch strings.ToLower(strings.TrimSpace(tool.Execution.Transport)) {
+case "http":
+    return h.callManagedHTTPTool(ctx, agentID, tool, args)
+case "mcp":
+    return h.callManagedMCPTool(ctx, agentID, tool, args)
+default:
+    return toolErrorPayload("unsupported_transport", ...), 0, nil
+}
+```
+
+Trace fields (`Service`, namespacing, latency, status code) are populated by
+the caller exactly as today — no changes to `tool_trace` shape, audit, or
+session-history.
+
+### D6. Spike coverage
+
+Extend `TestSpikeRollCall` (or add a sibling spike) to exercise an MCP
+provider end-to-end. Use a tiny in-tree fake MCP service (a `dockerfiles/`
+mini-image that speaks Streamable HTTP with one `echo` tool) so the spike is
+hermetic and doesn't depend on a third-party MCP server. This proves cllama
+mediated execution against a real MCP transport, including the
+`initialize` handshake and the `tools/call` round-trip.
+
+## Build sequence
+
+### Phase 5a — descriptor + compile-time wiring
+
+Files to touch:
+- `internal/describe/descriptor.go`: add `MCP *MCPTransport` and
+  `MCPTransport{ Transport, Path string }`. Loosen `validateTools` so that
+  when `d.MCP != nil`, `tool.HTTP` is optional. Reject the both-present case.
+  Reject unknown `mcp.transport` values (only `streamable_http` accepted).
+- `internal/describe/registry.go`: extend `ToolSpec` with `MCP` (carrying
+  the descriptor's MCP block + the un-namespaced tool name) so callers know
+  whether to compile HTTP or MCP execution.
+- `cmd/claw/compose_up.go::buildToolManifestEntries`: switch on
+  `tool.MCP != nil` (or descriptor lookup) to emit a `transport: "mcp"`
+  manifest entry instead of HTTP. Reuse `resolveServiceBaseURL` and
+  `resolveManifestAuth` unchanged.
+- `internal/cllama/context.go`: extend `ToolExecution` with
+  `ToolName string `json:"tool_name,omitempty"``. (Path/BaseURL/Auth fields
+  reused as-is.)
+
+Tests:
+- `internal/describe/descriptor_test.go`: parse a v2 descriptor with `mcp`
+  block, assert tools without `http` validate; assert both-present rejects;
+  assert unknown transport rejects.
+- `internal/describe/registry_test.go`: tool registry carries MCP info
+  through.
+- `internal/cllama/context_test.go`: mediated manifest with
+  `transport: "mcp"` round-trips correctly.
+- `cmd/claw/compose_up_test.go` (or nearest existing test for tool
+  compilation): assert a pod with an MCP provider compiles
+  `transport: "mcp"` entries with the expected `tool_name`, `path`,
+  `base_url`, and `auth`.
+
+### Phase 5b — cllama MCP execution
+
+Files to add/touch:
+- `cllama/internal/mcp/client.go` (new): minimal Streamable HTTP MCP client
+  per D4. JSON-RPC framing, initialize/initialized handshake with cached
+  session, `tools/call` with SSE-or-JSON response parsing, bounded
+  `maxManagedToolResultBytes` reads.
+- `cllama/internal/mcp/client_test.go` (new): table-driven tests against an
+  `httptest.Server` that returns (a) JSON, (b) SSE, (c) JSON-RPC error,
+  (d) session-required-then-OK on retry.
+- `cllama/internal/proxy/toolmediation.go`: introduce
+  `dispatchManagedTool` and replace the two call sites in
+  `executeManagedOpenAITool` / `executeManagedAnthropicTool`. Add
+  `callManagedMCPTool` that wires `agentctx.ToolManifestEntry` → MCP client
+  call and runs the result through the same `toolSuccess` / `toolError`
+  envelope.
+- `cllama/internal/agentctx/agentctx.go`: extend `ToolExecution` with
+  `ToolName` so the proxy sees the un-namespaced tool name.
+- `cllama/internal/proxy/toolmediation_test.go`: extend ownership tests with
+  a transport-MCP manifest entry to cover the dispatch switch.
+
+### Phase 5c — example + spike
+
+- `examples/`: small example pod under `examples/mcp-sidecar/` showing the
+  shape from the issue (one cllama agent, one MCP-shaped service). Real
+  Perplexity is fine if `PERPLEXITY_API_KEY` is documented; otherwise wire
+  it to the in-tree fake echo server.
+- `dockerfiles/mcp-echo/` (new, contributor-only): tiny Streamable HTTP
+  server with a single `echo` tool. Used for the spike fixture and the
+  example. Published manually by maintainers (no separate publication
+  workflow needed for v1; treat it like the other `dockerfiles/` images).
+- `cmd/claw/spike_*_test.go` (new or extension): bring up the
+  mcp-sidecar example, cllama mediates a tool call, assert audit shows the
+  `tool_call` event with `service = mcp-echo`.
+
+### Phase 5d — docs
+
+- `docs/decisions/020-cllama-compiled-tool-mediation.md`: append an
+  Implementation Status note flipping Phase 5 partial-shipped (sidecar
+  transport done, `claw discover` deferred).
+- `README.md` and/or `docs/plans/2026-04-05-issue-115-managed-tools-injection.md`:
+  short note on the new `mcp` descriptor block.
+- `site/changelog.md`: entry under the next version once released.
+
+## Test plan
+
+- `go vet ./... && go test ./...` — unit + describe + compose_up coverage.
+- `go test ./cllama/...` — MCP client tests + proxy dispatch.
+- `go test -tags integration ./...` — should remain green (no
+  intentional regression).
+- `go test -tags spike -run TestSpikeMCPSidecar ./cmd/claw/...` — new
+  hermetic spike against the mcp-echo image.
+- Manual: `cd examples/mcp-sidecar && claw up -d && claw audit` shows
+  managed tool calls with the MCP transport and namespaced names.
+
+## Out of scope
+
+- `claw discover` (live `tools/list` snapshot). File a follow-up issue.
+- MCP `resources` and `prompts` primitives — feeds and skills cover those
+  intent-wise (ADR-020 §9). Not needed for sidecar tool support.
+- HTTP+SSE legacy MCP transport. Streamable HTTP only in v1.
+- stdio-transport MCP servers — out of scope by definition (sidecars are
+  network services).
+- Native-mode pod-shared tool delivery (ADR-020 Phase 2 / Phase 6) — this
+  plan is mediated-only.
+- Per-tool MCP `annotations` extensions (parallel-safe, etc.) — mirror
+  whatever MCP returns into `tool_trace`, but no policy behavior change.
+
+## Open questions for review
+
+1. **Auth shape.** Should descriptor `auth.type == "bearer"` translate to
+   `Authorization: Bearer ...` for MCP, or do MCP servers commonly expect a
+   custom header (e.g. `X-API-Key`)? Proposed answer: bearer in v1; add
+   `auth.type == "header"` projection later if needed (the descriptor
+   already accepts `header` as a type — just need to define how the
+   compiled manifest represents it).
+2. **Session caching scope.** Per cllama process, or per request? Per
+   process is more efficient but introduces a tiny piece of cross-request
+   state inside the proxy — does that violate any boundary we care about?
+   Session IDs are not user-scoped, so the answer is probably "no", but
+   worth confirming.
+3. **Result truncation semantics.** When `tools/call` returns an SSE stream
+   that exceeds `maxManagedToolResultBytes`, do we want to truncate the
+   final flattened JSON, or drop the response entirely? Today the HTTP path
+   truncates the body — proposing the same here for symmetry.
+4. **Spike fixture.** Build a tiny Go-based `mcp-echo` server in-tree, or
+   pull a public reference (e.g. the `mcp-server-everything` reference
+   image)? In-tree is more reproducible and avoids network dependence in
+   spike runs.

--- a/internal/cllama/context.go
+++ b/internal/cllama/context.go
@@ -51,8 +51,9 @@ type ToolExecution struct {
 	Transport string     `json:"transport"`
 	Service   string     `json:"service"`
 	BaseURL   string     `json:"base_url"`
-	Method    string     `json:"method"`
+	Method    string     `json:"method,omitempty"`
 	Path      string     `json:"path"`
+	ToolName  string     `json:"tool_name,omitempty"`
 	BodyKey   string     `json:"body_key,omitempty"`
 	Auth      *AuthEntry `json:"auth,omitempty"`
 }

--- a/internal/cllama/context_test.go
+++ b/internal/cllama/context_test.go
@@ -188,3 +188,47 @@ func TestGenerateContextDirWritesOptionalFeedsAndServiceAuth(t *testing.T) {
 		t.Fatalf("unexpected service-auth payload: %v", auth)
 	}
 }
+
+func TestGenerateContextDirWritesMCPToolExecution(t *testing.T) {
+	dir := t.TempDir()
+	agents := []AgentContextInput{{
+		AgentID:     "octopus",
+		AgentsMD:    "# Contract",
+		ClawdapusMD: "# Infra",
+		Metadata:    map[string]interface{}{"service": "octopus"},
+		Tools: []ToolManifestEntry{{
+			Name:        "perplexity-mcp.search",
+			Description: "Search the web",
+			InputSchema: map[string]interface{}{"type": "object"},
+			Execution: ToolExecution{
+				Transport: "mcp",
+				Service:   "perplexity-mcp",
+				BaseURL:   "http://perplexity-mcp:8080",
+				Path:      "/mcp",
+				ToolName:  "search",
+				Auth:      &AuthEntry{Type: "bearer", Token: "service-token"},
+			},
+		}},
+	}}
+
+	if err := GenerateContextDir(dir, agents); err != nil {
+		t.Fatal(err)
+	}
+
+	toolsRaw, err := os.ReadFile(filepath.Join(dir, "context", "octopus", "tools.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var toolsManifest map[string]interface{}
+	if err := json.Unmarshal(toolsRaw, &toolsManifest); err != nil {
+		t.Fatal(err)
+	}
+	tools := toolsManifest["tools"].([]interface{})
+	execution := tools[0].(map[string]interface{})["execution"].(map[string]interface{})
+	if execution["transport"] != "mcp" || execution["path"] != "/mcp" || execution["tool_name"] != "search" {
+		t.Fatalf("unexpected MCP tool execution payload: %v", execution)
+	}
+	if _, exists := execution["method"]; exists {
+		t.Fatalf("MCP execution should not emit HTTP method: %v", execution)
+	}
+}

--- a/internal/describe/descriptor.go
+++ b/internal/describe/descriptor.go
@@ -12,6 +12,7 @@ type ServiceDescriptor struct {
 	Version     int                  `json:"version"`
 	Description string               `json:"description,omitempty"`
 	Feeds       []FeedDescriptor     `json:"feeds,omitempty"`
+	MCP         *MCPDescriptor       `json:"mcp,omitempty"`
 	Tools       []ToolDescriptor     `json:"tools,omitempty"`
 	Memory      *MemoryDescriptor    `json:"memory,omitempty"`
 	Endpoints   []EndpointDescriptor `json:"endpoints,omitempty"`
@@ -43,6 +44,11 @@ type ToolDescriptor struct {
 	InputSchema map[string]interface{} `json:"inputSchema"`
 	HTTP        *ToolHTTP              `json:"http,omitempty"`
 	Annotations map[string]interface{} `json:"annotations,omitempty"`
+}
+
+type MCPDescriptor struct {
+	Transport string `json:"transport,omitempty"`
+	Path      string `json:"path,omitempty"`
 }
 
 type ToolHTTP struct {
@@ -127,13 +133,19 @@ func (d *ServiceDescriptor) Validate() error {
 		if len(d.Tools) > 0 {
 			return fmt.Errorf("descriptor version 1 does not support tools")
 		}
+		if d.MCP != nil {
+			return fmt.Errorf("descriptor version 1 does not support mcp")
+		}
 		if d.Memory != nil {
 			return fmt.Errorf("descriptor version 1 does not support memory")
 		}
 	}
 
 	if d.Version >= 2 {
-		if err := validateTools(d.Tools); err != nil {
+		if err := validateMCP(d.MCP); err != nil {
+			return err
+		}
+		if err := validateTools(d.Tools, d.MCP); err != nil {
 			return err
 		}
 		if err := validateMemory(d.Memory); err != nil {
@@ -156,7 +168,28 @@ func (d *ServiceDescriptor) Validate() error {
 	return nil
 }
 
-func validateTools(tools []ToolDescriptor) error {
+func validateMCP(mcp *MCPDescriptor) error {
+	if mcp == nil {
+		return nil
+	}
+	transport := strings.ToLower(strings.TrimSpace(mcp.Transport))
+	switch transport {
+	case "", "http", "streamable_http", "streamable-http":
+		mcp.Transport = "streamable_http"
+	default:
+		return fmt.Errorf("mcp.transport %q is unsupported", mcp.Transport)
+	}
+	mcp.Path = strings.TrimSpace(mcp.Path)
+	if mcp.Path == "" {
+		mcp.Path = "/mcp"
+	}
+	if !strings.HasPrefix(mcp.Path, "/") {
+		return fmt.Errorf("mcp.path %q must start with '/'", mcp.Path)
+	}
+	return nil
+}
+
+func validateTools(tools []ToolDescriptor, mcp *MCPDescriptor) error {
 	seenTools := make(map[string]struct{}, len(tools))
 	for i := range tools {
 		tool := &tools[i]
@@ -182,7 +215,13 @@ func validateTools(tools []ToolDescriptor) error {
 		if strings.ToLower(strings.TrimSpace(schemaType)) != "object" {
 			return fmt.Errorf("tools[%d]: inputSchema.type must be \"object\"", i)
 		}
+		if mcp != nil && tool.HTTP != nil {
+			return fmt.Errorf("tools[%d]: http must not be set when descriptor mcp is set", i)
+		}
 		if tool.HTTP == nil {
+			if mcp != nil {
+				continue
+			}
 			return fmt.Errorf("tools[%d]: http is required", i)
 		}
 		tool.HTTP.Method = strings.ToUpper(strings.TrimSpace(tool.HTTP.Method))

--- a/internal/describe/descriptor_test.go
+++ b/internal/describe/descriptor_test.go
@@ -87,6 +87,39 @@ func TestParseDescriptorV2SupportsToolsAndMemory(t *testing.T) {
 	}
 }
 
+func TestParseDescriptorV2SupportsMCPToolsWithoutHTTP(t *testing.T) {
+	data := []byte(`{
+	  "version": 2,
+	  "description": "Perplexity MCP",
+	  "mcp": {"transport": "http", "path": " /mcp "},
+	  "tools": [{
+	    "name": " search ",
+	    "description": " Search the web ",
+	    "inputSchema": {"type": "object", "properties": {"query": {"type": "string"}}}
+	  }]
+	}`)
+
+	descriptor, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if descriptor.MCP == nil {
+		t.Fatal("expected mcp descriptor")
+	}
+	if descriptor.MCP.Transport != "streamable_http" {
+		t.Fatalf("expected normalized transport, got %q", descriptor.MCP.Transport)
+	}
+	if descriptor.MCP.Path != "/mcp" {
+		t.Fatalf("expected normalized path, got %q", descriptor.MCP.Path)
+	}
+	if descriptor.Tools[0].HTTP != nil {
+		t.Fatalf("expected MCP tool to omit http metadata, got %+v", descriptor.Tools[0].HTTP)
+	}
+	if descriptor.Tools[0].Name != "search" {
+		t.Fatalf("expected trimmed tool name, got %q", descriptor.Tools[0].Name)
+	}
+}
+
 func TestParseDescriptorRejectsVersionOneToolsAndMemory(t *testing.T) {
 	tests := []struct {
 		name string
@@ -99,6 +132,10 @@ func TestParseDescriptorRejectsVersionOneToolsAndMemory(t *testing.T) {
 		{
 			name: "memory",
 			data: `{"version":1,"memory":{"recall":{"path":"/recall"}}}`,
+		},
+		{
+			name: "mcp",
+			data: `{"version":1,"mcp":{"path":"/mcp"}}`,
 		},
 	}
 
@@ -131,6 +168,18 @@ func TestParseDescriptorRejectsInvalidV2CapabilityShape(t *testing.T) {
 		{
 			name: "missing tool http",
 			data: `{"version":2,"tools":[{"name":"lookup","description":"Lookup","inputSchema":{"type":"object"}}]}`,
+		},
+		{
+			name: "mcp and http both present",
+			data: `{"version":2,"mcp":{"path":"/mcp"},"tools":[{"name":"lookup","description":"Lookup","inputSchema":{"type":"object"},"http":{"method":"post","path":"/lookup"}}]}`,
+		},
+		{
+			name: "unsupported mcp transport",
+			data: `{"version":2,"mcp":{"transport":"stdio","path":"/mcp"},"tools":[{"name":"lookup","description":"Lookup","inputSchema":{"type":"object"}}]}`,
+		},
+		{
+			name: "invalid mcp path",
+			data: `{"version":2,"mcp":{"path":"mcp"},"tools":[{"name":"lookup","description":"Lookup","inputSchema":{"type":"object"}}]}`,
 		},
 		{
 			name: "body key on get",

--- a/internal/describe/registry.go
+++ b/internal/describe/registry.go
@@ -17,6 +17,7 @@ type ToolSpec struct {
 	Description string
 	InputSchema map[string]interface{}
 	HTTP        *ToolHTTP
+	MCP         *MCPDescriptor
 	Annotations map[string]interface{}
 }
 
@@ -62,12 +63,18 @@ func BuildToolRegistry(descriptors map[string]*ServiceDescriptor) (ToolRegistry,
 				return nil, fmt.Errorf("tool name %q is declared multiple times by %q", tool.Name, serviceName)
 			}
 			seen[tool.Name] = struct{}{}
+			var mcp *MCPDescriptor
+			if descriptor.MCP != nil && tool.HTTP == nil {
+				copied := *descriptor.MCP
+				mcp = &copied
+			}
 			spec := ToolSpec{
 				Name:        tool.Name,
 				Service:     serviceName,
 				Description: tool.Description,
 				InputSchema: tool.InputSchema,
 				HTTP:        tool.HTTP,
+				MCP:         mcp,
 				Annotations: tool.Annotations,
 			}
 			specs = append(specs, spec)

--- a/internal/describe/registry_test.go
+++ b/internal/describe/registry_test.go
@@ -32,6 +32,31 @@ func TestBuildToolRegistryGroupsToolsByService(t *testing.T) {
 	}
 }
 
+func TestBuildToolRegistryCarriesMCPDescriptor(t *testing.T) {
+	registry, err := BuildToolRegistry(map[string]*ServiceDescriptor{
+		"perplexity-mcp": {
+			Version: 2,
+			MCP:     &MCPDescriptor{Transport: "streamable_http", Path: "/mcp"},
+			Tools: []ToolDescriptor{
+				{Name: "search", Description: "Search", InputSchema: map[string]interface{}{"type": "object"}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildToolRegistry: %v", err)
+	}
+	specs := registry["perplexity-mcp"]
+	if len(specs) != 1 {
+		t.Fatalf("expected 1 MCP tool, got %+v", specs)
+	}
+	if specs[0].HTTP != nil {
+		t.Fatalf("expected no HTTP metadata, got %+v", specs[0].HTTP)
+	}
+	if specs[0].MCP == nil || specs[0].MCP.Path != "/mcp" {
+		t.Fatalf("expected MCP metadata, got %+v", specs[0].MCP)
+	}
+}
+
 func TestBuildToolRegistryRejectsDuplicateNamesWithinService(t *testing.T) {
 	_, err := BuildToolRegistry(map[string]*ServiceDescriptor{
 		"trading-api": {


### PR DESCRIPTION
## Summary

- `claw.describe` v2 accepts a top-level `mcp` block (`transport: streamable_http`, `path: /mcp`); when present, individual `tools[]` entries omit `http` and execution routes through the MCP endpoint.
- `claw up` compiles allowed MCP tools into per-agent `tools.json` with `transport: "mcp"` execution metadata, including the un-namespaced `tool_name` for `tools/call` routing.
- Bumps the cllama submodule pointer to mostlydev/cllama#10, which adds the Streamable HTTP MCP client and dispatch switch in the proxy.
- Auth resolution, namespacing (`<service>.<tool>`), audit, session-history, and policy budgets are unchanged. Existing HTTP managed-tool descriptors continue to work without modification.
- ADR-020 implementation status updated; `claw discover` and baked `.claw-tools.json` artifact support remain follow-up work.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go test -tags integration ./...`
- [x] cllama: `go vet ./...` + `go test ./...`
- [ ] Manual: spike against an MCP sidecar fixture (deferred; existing rollcall spike continues to exercise the unchanged HTTP managed-tool path)

Closes #177