### PR TITLE
fix: Hermes handle validation accepts Compose env token references

### DIFF
--- a/internal/driver/hermes/driver.go
+++ b/internal/driver/hermes/driver.go
@@ -38,18 +38,18 @@ func (d *Driver) Validate(rc *driver.ResolvedClaw) error {
 		switch platform := strings.ToLower(strings.TrimSpace(rawPlatform)); platform {
 		case "discord":
 			supported++
-			if shared.ResolveEnvTokenFromMap(rc.Environment, "DISCORD_BOT_TOKEN") == "" {
+			if !hasServiceEnvValue(rc.Environment, "DISCORD_BOT_TOKEN") {
 				return fmt.Errorf("hermes driver: HANDLE discord requires DISCORD_BOT_TOKEN in service environment")
 			}
 		case "telegram":
 			supported++
-			if shared.ResolveEnvTokenFromMap(rc.Environment, "TELEGRAM_BOT_TOKEN") == "" {
+			if !hasServiceEnvValue(rc.Environment, "TELEGRAM_BOT_TOKEN") {
 				return fmt.Errorf("hermes driver: HANDLE telegram requires TELEGRAM_BOT_TOKEN in service environment")
 			}
 		case "slack":
 			supported++
-			if shared.ResolveEnvTokenFromMap(rc.Environment, "SLACK_BOT_TOKEN") == "" ||
-				shared.ResolveEnvTokenFromMap(rc.Environment, "SLACK_APP_TOKEN") == "" {
+			if !hasServiceEnvValue(rc.Environment, "SLACK_BOT_TOKEN") ||
+				!hasServiceEnvValue(rc.Environment, "SLACK_APP_TOKEN") {
 				return fmt.Errorf("hermes driver: HANDLE slack requires SLACK_BOT_TOKEN and SLACK_APP_TOKEN in service environment")
 			}
 		default:
@@ -80,6 +80,14 @@ func (d *Driver) Validate(rc *driver.ResolvedClaw) error {
 		return fmt.Errorf("hermes driver: invalid MODEL primary %q (expected provider/model)", modelRef)
 	}
 	return nil
+}
+
+func hasServiceEnvValue(env map[string]string, key string) bool {
+	raw, ok := env[key]
+	if !ok {
+		return false
+	}
+	return strings.TrimSpace(raw) != ""
 }
 
 func (d *Driver) Materialize(rc *driver.ResolvedClaw, opts driver.MaterializeOpts) (*driver.MaterializeResult, error) {

--- a/internal/driver/hermes/driver_test.go
+++ b/internal/driver/hermes/driver_test.go
@@ -70,6 +70,30 @@ func TestValidateRequiresSupportedHandle(t *testing.T) {
 	}
 }
 
+func TestValidateAcceptsComposeEnvTokenReference(t *testing.T) {
+	t.Setenv("ALLEN_BOT_TOKEN", "")
+
+	rc, _ := newTestRC(t)
+	rc.Environment["DISCORD_BOT_TOKEN"] = "${ALLEN_BOT_TOKEN}"
+
+	if err := (&Driver{}).Validate(rc); err != nil {
+		t.Fatalf("Validate should accept Compose env token references: %v", err)
+	}
+}
+
+func TestValidateRejectsBlankHandleToken(t *testing.T) {
+	rc, _ := newTestRC(t)
+	rc.Environment["DISCORD_BOT_TOKEN"] = "  "
+
+	err := (&Driver{}).Validate(rc)
+	if err == nil {
+		t.Fatal("expected blank DISCORD_BOT_TOKEN validation error")
+	}
+	if !strings.Contains(err.Error(), "DISCORD_BOT_TOKEN") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestValidateSlackRequiresAppToken(t *testing.T) {
 	rc, _ := newTestRC(t)
 	rc.Handles = map[string]*driver.HandleInfo{"slack": {}}


### PR DESCRIPTION
## Summary

Hermes preflight previously rejected pods that declared `DISCORD_BOT_TOKEN` / `TELEGRAM_BOT_TOKEN` / `SLACK_BOT_TOKEN` as `${VAR}` with the actual value supplied by Docker Compose `.env` substitution. `shared.ResolveEnvTokenFromMap` resolved against the `claw` process env and treated unresolved Compose references as missing, breaking valid Compose pods unless operators sourced `.env` before running `claw up`.

`Validate` now checks that the required service-environment keys are declared with non-blank values via a local `hasServiceEnvValue` helper, leaving secret resolution to Compose. Missing keys and blank values are still rejected.

## Test plan

- [x] `go test ./internal/driver/hermes/...`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] New tests: `${VAR}` reference accepted with var unset; blank value still rejected; existing missing-key coverage preserved

## Notes

Same anti-pattern (`ResolveEnvTokenFromMap == ""` for handle preflight) exists in `nanobot/driver.go`, `nullclaw/driver.go`, and `microclaw/driver.go`. Out of scope for #194 — worth a follow-up issue.

Closes #194