### PR TITLE
[codex] resolve driver env refs from pod dotenv

### DIFF
--- a/cmd/claw/compose_up.go
+++ b/cmd/claw/compose_up.go
@@ -124,6 +124,10 @@ func runComposeUp(podFile string) (err error) {
 	if err := resolveRuntimePlaceholders(podDir, p); err != nil {
 		return fmt.Errorf("resolve x-claw runtime placeholders: %w", err)
 	}
+	runtimeEnv, err := loadRuntimeEnv(podDir)
+	if err != nil {
+		return err
+	}
 	if composeUpDiscoverTools && podHasMCPStdioServices(p) {
 		if _, err := discoverMCPStdioServices(context.Background(), podDir, p, nil, discoverSelectionMissingOrStale); err != nil {
 			return fmt.Errorf("discover stdio MCP tools: %w", err)
@@ -335,6 +339,7 @@ func runComposeUp(podFile string) (err error) {
 			Privileges:    info.Privileges,
 			Count:         svc.Claw.Count,
 			Environment:   svc.Environment,
+			RuntimeEnv:    runtimeEnv,
 			Surfaces:      surfaces,
 			Skills:        skills,
 			Cllama:        resolveCllama(info.Cllama, svc.Claw.Cllama),
@@ -430,10 +435,6 @@ func runComposeUp(podFile string) (err error) {
 	}
 
 	clawAPIAuth, err := prepareClawAPIRuntime(runtimeDir, p, resolvedClaws)
-	if err != nil {
-		return err
-	}
-	runtimeEnv, err := loadRuntimeEnv(podDir)
 	if err != nil {
 		return err
 	}

--- a/internal/driver/hermes/config.go
+++ b/internal/driver/hermes/config.go
@@ -77,7 +77,11 @@ func GenerateEnvFile(rc *driver.ResolvedClaw, modelCfg *modelConfig) ([]byte, er
 	}
 
 	for _, key := range allowedEnvPassthroughKeys() {
-		if value := resolvedEnvValue(rc.Environment, key); value != "" {
+		value, err := resolvedEnvValue(rc, key)
+		if err != nil {
+			return nil, err
+		}
+		if value != "" {
 			env[key] = value
 		}
 	}
@@ -223,12 +227,19 @@ func resolveModelConfig(rc *driver.ResolvedClaw) (*modelConfig, error) {
 		}, nil
 	}
 
-	if baseURL := resolvedEnvValue(rc.Environment, "OPENAI_BASE_URL"); baseURL != "" {
+	baseURL, err := resolvedEnvValue(rc, "OPENAI_BASE_URL")
+	if err != nil {
+		return nil, err
+	}
+	if baseURL != "" {
 		defaultModel := modelRef
 		if provider == "openai" {
 			defaultModel = modelID
 		}
-		apiKey := resolvedEnvValue(rc.Environment, "OPENAI_API_KEY")
+		apiKey, err := resolvedEnvValue(rc, "OPENAI_API_KEY")
+		if err != nil {
+			return nil, err
+		}
 		return &modelConfig{
 			DefaultModel: defaultModel,
 			Provider:     "custom",
@@ -307,23 +318,12 @@ func hasDiscordHandle(rc *driver.ResolvedClaw) bool {
 	return false
 }
 
-func resolvedEnvValue(env map[string]string, key string) string {
-	raw := strings.TrimSpace(env[key])
-	if raw == "" {
-		return ""
+func resolvedEnvValue(rc *driver.ResolvedClaw, key string) (string, error) {
+	value, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, key, rc.RuntimeEnv)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", key, err)
 	}
-	// For single ${VAR} tokens, delegate to the shared resolver.
-	if resolved := shared.ResolveEnvToken(raw); resolved != "" && resolved != raw {
-		return resolved
-	}
-	// Expand all ${VAR} references in compound strings (e.g. "${A},${B}").
-	if strings.Contains(raw, "${") {
-		expanded := os.Expand(raw, os.Getenv)
-		if expanded != raw {
-			return expanded
-		}
-	}
-	return raw
+	return value, nil
 }
 
 func dotenvValue(value string) string {

--- a/internal/driver/hermes/config_test.go
+++ b/internal/driver/hermes/config_test.go
@@ -79,25 +79,78 @@ func TestGenerateConfigAnthropicModelUsesBareModelName(t *testing.T) {
 }
 
 func TestResolvedEnvValueExpandsCompoundVars(t *testing.T) {
-	// Set env vars for the test
+	rc := &driver.ResolvedClaw{
+		Environment: map[string]string{
+			"SINGLE":   "${TEST_ID_A}",
+			"COMPOUND": "${TEST_ID_A},${TEST_ID_B},${TEST_ID_C}",
+			"LITERAL":  "plain-value",
+		},
+		RuntimeEnv: map[string]string{
+			"TEST_ID_A": "111",
+			"TEST_ID_B": "222",
+			"TEST_ID_C": "333",
+		},
+	}
+
+	if got, err := resolvedEnvValue(rc, "SINGLE"); err != nil || got != "111" {
+		t.Fatalf("single var: expected 111, got %q (err=%v)", got, err)
+	}
+	if got, err := resolvedEnvValue(rc, "COMPOUND"); err != nil || got != "111,222,333" {
+		t.Fatalf("compound var: expected 111,222,333, got %q (err=%v)", got, err)
+	}
+	if got, err := resolvedEnvValue(rc, "LITERAL"); err != nil || got != "plain-value" {
+		t.Fatalf("literal: expected plain-value, got %q (err=%v)", got, err)
+	}
+}
+
+func TestGenerateEnvFileUsesRuntimeEnvForComposeReferences(t *testing.T) {
+	rc := &driver.ResolvedClaw{
+		Environment: map[string]string{
+			"DISCORD_ALLOWED_USERS": "${OPERATOR_DISCORD_ID},${WESTON_DISCORD_ID}",
+		},
+		RuntimeEnv: map[string]string{
+			"OPERATOR_DISCORD_ID": "167037070349434880",
+			"WESTON_DISCORD_ID":   "1464508146579148851",
+		},
+	}
+
+	data, err := GenerateEnvFile(rc, &modelConfig{Env: map[string]string{}})
+	if err != nil {
+		t.Fatalf("GenerateEnvFile returned error: %v", err)
+	}
+	env := string(data)
+	if !strings.Contains(env, "DISCORD_ALLOWED_USERS=167037070349434880,1464508146579148851\n") {
+		t.Fatalf("expected resolved Discord allowlist in .env, got:\n%s", env)
+	}
+}
+
+func TestGenerateEnvFileRejectsUnresolvedComposeReferences(t *testing.T) {
+	rc := &driver.ResolvedClaw{
+		Environment: map[string]string{
+			"DISCORD_ALLOWED_USERS": "${OPERATOR_DISCORD_ID},${MISSING_DISCORD_ID}",
+		},
+		RuntimeEnv: map[string]string{
+			"OPERATOR_DISCORD_ID": "167037070349434880",
+		},
+	}
+
+	_, err := GenerateEnvFile(rc, &modelConfig{Env: map[string]string{}})
+	if err == nil {
+		t.Fatal("expected unresolved Compose reference error")
+	}
+	if !strings.Contains(err.Error(), "MISSING_DISCORD_ID") {
+		t.Fatalf("expected missing variable in error, got: %v", err)
+	}
+}
+
+func TestResolvedEnvValueFallsBackToProcessEnv(t *testing.T) {
 	t.Setenv("TEST_ID_A", "111")
-	t.Setenv("TEST_ID_B", "222")
-	t.Setenv("TEST_ID_C", "333")
-
-	env := map[string]string{
-		"SINGLE":   "${TEST_ID_A}",
-		"COMPOUND": "${TEST_ID_A},${TEST_ID_B},${TEST_ID_C}",
-		"LITERAL":  "plain-value",
+	rc := &driver.ResolvedClaw{
+		Environment: map[string]string{"SINGLE": "${TEST_ID_A}"},
 	}
 
-	if got := resolvedEnvValue(env, "SINGLE"); got != "111" {
+	if got, err := resolvedEnvValue(rc, "SINGLE"); err != nil || got != "111" {
 		t.Fatalf("single var: expected 111, got %q", got)
-	}
-	if got := resolvedEnvValue(env, "COMPOUND"); got != "111,222,333" {
-		t.Fatalf("compound var: expected 111,222,333, got %q", got)
-	}
-	if got := resolvedEnvValue(env, "LITERAL"); got != "plain-value" {
-		t.Fatalf("literal: expected plain-value, got %q", got)
 	}
 }
 

--- a/internal/driver/hermes/driver.go
+++ b/internal/driver/hermes/driver.go
@@ -185,7 +185,11 @@ func (d *Driver) Materialize(rc *driver.ResolvedClaw, opts driver.MaterializeOpt
 	if hasDiscordHandle(rc) {
 		env["HERMES_TOOL_ONLY_MODE"] = "1"
 		env[hermesToolProgressModeEnv] = "off"
-		if value := resolvedEnvValue(rc.Environment, hermesToolProgressModeEnv); value != "" {
+		value, err := resolvedEnvValue(rc, hermesToolProgressModeEnv)
+		if err != nil {
+			return nil, fmt.Errorf("hermes driver: %w", err)
+		}
+		if value != "" {
 			env[hermesToolProgressModeEnv] = value
 		}
 	}

--- a/internal/driver/microclaw/driver.go
+++ b/internal/driver/microclaw/driver.go
@@ -50,15 +50,31 @@ func (d *Driver) Validate(rc *driver.ResolvedClaw) error {
 	for platform := range rc.Handles {
 		switch platform {
 		case "discord":
-			if shared.ResolveEnvTokenFromMap(rc.Environment, "DISCORD_BOT_TOKEN") == "" {
+			token, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "DISCORD_BOT_TOKEN", rc.RuntimeEnv)
+			if err != nil {
+				return fmt.Errorf("microclaw driver: DISCORD_BOT_TOKEN: %w", err)
+			}
+			if token == "" {
 				return fmt.Errorf("microclaw driver: HANDLE discord requires DISCORD_BOT_TOKEN in service environment")
 			}
 		case "telegram":
-			if shared.ResolveEnvTokenFromMap(rc.Environment, "TELEGRAM_BOT_TOKEN") == "" {
+			token, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "TELEGRAM_BOT_TOKEN", rc.RuntimeEnv)
+			if err != nil {
+				return fmt.Errorf("microclaw driver: TELEGRAM_BOT_TOKEN: %w", err)
+			}
+			if token == "" {
 				return fmt.Errorf("microclaw driver: HANDLE telegram requires TELEGRAM_BOT_TOKEN in service environment")
 			}
 		case "slack":
-			if shared.ResolveEnvTokenFromMap(rc.Environment, "SLACK_BOT_TOKEN") == "" || shared.ResolveEnvTokenFromMap(rc.Environment, "SLACK_APP_TOKEN") == "" {
+			botToken, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "SLACK_BOT_TOKEN", rc.RuntimeEnv)
+			if err != nil {
+				return fmt.Errorf("microclaw driver: SLACK_BOT_TOKEN: %w", err)
+			}
+			appToken, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "SLACK_APP_TOKEN", rc.RuntimeEnv)
+			if err != nil {
+				return fmt.Errorf("microclaw driver: SLACK_APP_TOKEN: %w", err)
+			}
+			if botToken == "" || appToken == "" {
 				return fmt.Errorf("microclaw driver: HANDLE slack requires SLACK_BOT_TOKEN and SLACK_APP_TOKEN in service environment")
 			}
 		default:
@@ -69,7 +85,11 @@ func (d *Driver) Validate(rc *driver.ResolvedClaw) error {
 	if len(rc.Cllama) == 0 {
 		llmProvider := shared.NormalizeProvider(provider)
 		if !shared.ProviderAllowsEmptyAPIKey(llmProvider) {
-			if key := shared.ResolveProviderAPIKey(llmProvider, rc.Environment); key == "" {
+			key, err := shared.ResolveProviderAPIKeyWithRuntimeEnv(llmProvider, rc.Environment, rc.RuntimeEnv)
+			if err != nil {
+				return fmt.Errorf("microclaw driver: provider %q API key: %w", llmProvider, err)
+			}
+			if key == "" {
 				expected := strings.Join(shared.ExpectedProviderKeys(llmProvider), ", ")
 				return fmt.Errorf("microclaw driver: no API key found for provider %q (checked: %s)", llmProvider, expected)
 			}
@@ -292,7 +312,10 @@ func generateConfig(rc *driver.ResolvedClaw) (map[string]interface{}, error) {
 		llmProvider := shared.NormalizeProvider(provider)
 		cfg["llm_provider"] = llmProvider
 		cfg["model"] = modelID
-		apiKey := shared.ResolveProviderAPIKey(llmProvider, rc.Environment)
+		apiKey, err := shared.ResolveProviderAPIKeyWithRuntimeEnv(llmProvider, rc.Environment, rc.RuntimeEnv)
+		if err != nil {
+			return nil, fmt.Errorf("config generation: provider %q api_key: %w", llmProvider, err)
+		}
 		if apiKey != "" {
 			cfg["api_key"] = apiKey
 		} else {
@@ -311,7 +334,11 @@ func generateConfig(rc *driver.ResolvedClaw) (map[string]interface{}, error) {
 		switch platform {
 		case "discord":
 			discord := map[string]interface{}{"enabled": true, "mention_only": true}
-			if token := shared.ResolveEnvTokenFromMap(rc.Environment, "DISCORD_BOT_TOKEN"); token != "" {
+			token, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "DISCORD_BOT_TOKEN", rc.RuntimeEnv)
+			if err != nil {
+				return nil, fmt.Errorf("config generation: HANDLE discord: DISCORD_BOT_TOKEN: %w", err)
+			}
+			if token != "" {
 				discord["bot_token"] = token
 			}
 			if h != nil && strings.TrimSpace(h.Username) != "" {
@@ -323,7 +350,11 @@ func generateConfig(rc *driver.ResolvedClaw) (map[string]interface{}, error) {
 			channels["discord"] = discord
 		case "telegram":
 			telegram := map[string]interface{}{"enabled": true}
-			if token := shared.ResolveEnvTokenFromMap(rc.Environment, "TELEGRAM_BOT_TOKEN"); token != "" {
+			token, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "TELEGRAM_BOT_TOKEN", rc.RuntimeEnv)
+			if err != nil {
+				return nil, fmt.Errorf("config generation: HANDLE telegram: TELEGRAM_BOT_TOKEN: %w", err)
+			}
+			if token != "" {
 				telegram["bot_token"] = token
 			}
 			if h != nil && strings.TrimSpace(h.Username) != "" {
@@ -335,10 +366,18 @@ func generateConfig(rc *driver.ResolvedClaw) (map[string]interface{}, error) {
 			channels["telegram"] = telegram
 		case "slack":
 			slack := map[string]interface{}{"enabled": true}
-			if bot := shared.ResolveEnvTokenFromMap(rc.Environment, "SLACK_BOT_TOKEN"); bot != "" {
+			bot, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "SLACK_BOT_TOKEN", rc.RuntimeEnv)
+			if err != nil {
+				return nil, fmt.Errorf("config generation: HANDLE slack: SLACK_BOT_TOKEN: %w", err)
+			}
+			if bot != "" {
 				slack["bot_token"] = bot
 			}
-			if app := shared.ResolveEnvTokenFromMap(rc.Environment, "SLACK_APP_TOKEN"); app != "" {
+			app, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "SLACK_APP_TOKEN", rc.RuntimeEnv)
+			if err != nil {
+				return nil, fmt.Errorf("config generation: HANDLE slack: SLACK_APP_TOKEN: %w", err)
+			}
+			if app != "" {
 				slack["app_token"] = app
 			}
 			if allowed := slackAllowedChannels(h); len(allowed) > 0 {

--- a/internal/driver/nanobot/config.go
+++ b/internal/driver/nanobot/config.go
@@ -42,7 +42,11 @@ func GenerateConfig(rc *driver.ResolvedClaw) ([]byte, error) {
 		}
 	} else {
 		for _, provider := range shared.CollectProviders(rc.Models) {
-			if token := shared.ResolveProviderAPIKey(provider, rc.Environment); token != "" {
+			token, err := shared.ResolveProviderAPIKeyWithRuntimeEnv(provider, rc.Environment, rc.RuntimeEnv)
+			if err != nil {
+				return nil, fmt.Errorf("config generation: provider %q api_key: %w", provider, err)
+			}
+			if token != "" {
 				if err := shared.SetPath(config, "providers."+provider+".api_key", token); err != nil {
 					return nil, fmt.Errorf("config generation: provider %q api_key: %w", provider, err)
 				}
@@ -59,7 +63,11 @@ func GenerateConfig(rc *driver.ResolvedClaw) ([]byte, error) {
 			if err := shared.SetPath(config, "channels.discord.mention_only", true); err != nil {
 				return nil, fmt.Errorf("config generation: HANDLE discord: %w", err)
 			}
-			if token := shared.ResolveEnvTokenFromMap(rc.Environment, "DISCORD_BOT_TOKEN"); token != "" {
+			token, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "DISCORD_BOT_TOKEN", rc.RuntimeEnv)
+			if err != nil {
+				return nil, fmt.Errorf("config generation: HANDLE discord: DISCORD_BOT_TOKEN: %w", err)
+			}
+			if token != "" {
 				if err := shared.SetPath(config, "channels.discord.token", token); err != nil {
 					return nil, fmt.Errorf("config generation: HANDLE discord: %w", err)
 				}
@@ -80,7 +88,11 @@ func GenerateConfig(rc *driver.ResolvedClaw) ([]byte, error) {
 			if err := shared.SetPath(config, "channels.telegram.enabled", true); err != nil {
 				return nil, fmt.Errorf("config generation: HANDLE telegram: %w", err)
 			}
-			if token := shared.ResolveEnvTokenFromMap(rc.Environment, "TELEGRAM_BOT_TOKEN"); token != "" {
+			token, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "TELEGRAM_BOT_TOKEN", rc.RuntimeEnv)
+			if err != nil {
+				return nil, fmt.Errorf("config generation: HANDLE telegram: TELEGRAM_BOT_TOKEN: %w", err)
+			}
+			if token != "" {
 				if err := shared.SetPath(config, "channels.telegram.bot_token", token); err != nil {
 					return nil, fmt.Errorf("config generation: HANDLE telegram: %w", err)
 				}
@@ -89,17 +101,29 @@ func GenerateConfig(rc *driver.ResolvedClaw) ([]byte, error) {
 			if err := shared.SetPath(config, "channels.slack.enabled", true); err != nil {
 				return nil, fmt.Errorf("config generation: HANDLE slack: %w", err)
 			}
-			if token := shared.ResolveEnvTokenFromMap(rc.Environment, "SLACK_BOT_TOKEN"); token != "" {
+			token, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "SLACK_BOT_TOKEN", rc.RuntimeEnv)
+			if err != nil {
+				return nil, fmt.Errorf("config generation: HANDLE slack: SLACK_BOT_TOKEN: %w", err)
+			}
+			if token != "" {
 				if err := shared.SetPath(config, "channels.slack.bot_token", token); err != nil {
 					return nil, fmt.Errorf("config generation: HANDLE slack: %w", err)
 				}
 			}
-			if appToken := shared.ResolveEnvTokenFromMap(rc.Environment, "SLACK_APP_TOKEN"); appToken != "" {
+			appToken, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "SLACK_APP_TOKEN", rc.RuntimeEnv)
+			if err != nil {
+				return nil, fmt.Errorf("config generation: HANDLE slack: SLACK_APP_TOKEN: %w", err)
+			}
+			if appToken != "" {
 				if err := shared.SetPath(config, "channels.slack.app_token", appToken); err != nil {
 					return nil, fmt.Errorf("config generation: HANDLE slack: %w", err)
 				}
 			}
-			if signingSecret := shared.ResolveEnvTokenFromMap(rc.Environment, "SLACK_SIGNING_SECRET"); signingSecret != "" {
+			signingSecret, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "SLACK_SIGNING_SECRET", rc.RuntimeEnv)
+			if err != nil {
+				return nil, fmt.Errorf("config generation: HANDLE slack: SLACK_SIGNING_SECRET: %w", err)
+			}
+			if signingSecret != "" {
 				if err := shared.SetPath(config, "channels.slack.signing_secret", signingSecret); err != nil {
 					return nil, fmt.Errorf("config generation: HANDLE slack: %w", err)
 				}

--- a/internal/driver/nanobot/config_test.go
+++ b/internal/driver/nanobot/config_test.go
@@ -122,6 +122,34 @@ func TestGenerateConfigHandleMappings(t *testing.T) {
 	}
 }
 
+func TestGenerateConfigUsesRuntimeEnvForComposeReferences(t *testing.T) {
+	rc := &driver.ResolvedClaw{
+		Models: map[string]string{"primary": "openrouter/anthropic/claude-sonnet-4"},
+		Handles: map[string]*driver.HandleInfo{
+			"discord": {Guilds: []driver.GuildInfo{{ID: "123"}}},
+		},
+		Environment: map[string]string{
+			"OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}",
+			"DISCORD_BOT_TOKEN":  "${DISCORD_BOT_TOKEN}",
+		},
+		RuntimeEnv: map[string]string{
+			"OPENROUTER_API_KEY": "runtime-or-key",
+			"DISCORD_BOT_TOKEN":  "runtime-discord-token",
+		},
+	}
+
+	data, err := GenerateConfig(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v, _ := getPath(data, "providers.openrouter.api_key"); v != "runtime-or-key" {
+		t.Fatalf("unexpected providers.openrouter.api_key: %v", v)
+	}
+	if v, _ := getPath(data, "channels.discord.token"); v != "runtime-discord-token" {
+		t.Fatalf("unexpected channels.discord.token: %v", v)
+	}
+}
+
 func TestGenerateConfigConfigureOverride(t *testing.T) {
 	rc := &driver.ResolvedClaw{
 		Models: map[string]string{"primary": "anthropic/claude-sonnet-4"},

--- a/internal/driver/nanobot/driver.go
+++ b/internal/driver/nanobot/driver.go
@@ -46,15 +46,27 @@ func (d *Driver) Validate(rc *driver.ResolvedClaw) error {
 	for platform := range rc.Handles {
 		switch strings.ToLower(platform) {
 		case "discord":
-			if shared.ResolveEnvTokenFromMap(rc.Environment, "DISCORD_BOT_TOKEN") == "" {
+			token, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "DISCORD_BOT_TOKEN", rc.RuntimeEnv)
+			if err != nil {
+				return fmt.Errorf("nanobot driver: DISCORD_BOT_TOKEN: %w", err)
+			}
+			if token == "" {
 				return fmt.Errorf("nanobot driver: HANDLE discord requires DISCORD_BOT_TOKEN in service environment")
 			}
 		case "telegram":
-			if shared.ResolveEnvTokenFromMap(rc.Environment, "TELEGRAM_BOT_TOKEN") == "" {
+			token, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "TELEGRAM_BOT_TOKEN", rc.RuntimeEnv)
+			if err != nil {
+				return fmt.Errorf("nanobot driver: TELEGRAM_BOT_TOKEN: %w", err)
+			}
+			if token == "" {
 				return fmt.Errorf("nanobot driver: HANDLE telegram requires TELEGRAM_BOT_TOKEN in service environment")
 			}
 		case "slack":
-			if shared.ResolveEnvTokenFromMap(rc.Environment, "SLACK_BOT_TOKEN") == "" {
+			token, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "SLACK_BOT_TOKEN", rc.RuntimeEnv)
+			if err != nil {
+				return fmt.Errorf("nanobot driver: SLACK_BOT_TOKEN: %w", err)
+			}
+			if token == "" {
 				return fmt.Errorf("nanobot driver: HANDLE slack requires SLACK_BOT_TOKEN in service environment")
 			}
 		default:
@@ -65,7 +77,11 @@ func (d *Driver) Validate(rc *driver.ResolvedClaw) error {
 	if len(rc.Cllama) == 0 {
 		llmProvider := shared.NormalizeProvider(provider)
 		if !shared.ProviderAllowsEmptyAPIKey(llmProvider) {
-			if key := shared.ResolveProviderAPIKey(llmProvider, rc.Environment); key == "" {
+			key, err := shared.ResolveProviderAPIKeyWithRuntimeEnv(llmProvider, rc.Environment, rc.RuntimeEnv)
+			if err != nil {
+				return fmt.Errorf("nanobot driver: provider %q API key: %w", llmProvider, err)
+			}
+			if key == "" {
 				expected := strings.Join(shared.ExpectedProviderKeys(llmProvider), ", ")
 				return fmt.Errorf("nanobot driver: no API key found for provider %q (checked: %s)", llmProvider, expected)
 			}

--- a/internal/driver/nanobot/driver_test.go
+++ b/internal/driver/nanobot/driver_test.go
@@ -64,6 +64,24 @@ func TestValidateDiscordHandleRequiresToken(t *testing.T) {
 	}
 }
 
+func TestValidateAcceptsRuntimeEnvComposeReferences(t *testing.T) {
+	rc, _ := newTestRC(t)
+	rc.Models = map[string]string{"primary": "openrouter/anthropic/claude-sonnet-4"}
+	rc.Handles = map[string]*driver.HandleInfo{"discord": {ID: "123"}}
+	rc.Environment = map[string]string{
+		"OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}",
+		"DISCORD_BOT_TOKEN":  "${DISCORD_BOT_TOKEN}",
+	}
+	rc.RuntimeEnv = map[string]string{
+		"OPENROUTER_API_KEY": "runtime-or-key",
+		"DISCORD_BOT_TOKEN":  "runtime-discord-token",
+	}
+
+	if err := (&Driver{}).Validate(rc); err != nil {
+		t.Fatalf("Validate should accept Compose references resolved from RuntimeEnv: %v", err)
+	}
+}
+
 func TestValidateRejectsInvalidConfigureCommand(t *testing.T) {
 	rc, _ := newTestRC(t)
 	rc.Environment["ANTHROPIC_API_KEY"] = "anthropic-key"

--- a/internal/driver/nullclaw/config.go
+++ b/internal/driver/nullclaw/config.go
@@ -76,7 +76,11 @@ func GenerateConfig(rc *driver.ResolvedClaw) ([]byte, error) {
 			if err := shared.SetPath(config, "channels.discord.accounts.main.mention_only", true); err != nil {
 				return nil, fmt.Errorf("config generation: HANDLE discord: %w", err)
 			}
-			if token := shared.ResolveEnvTokenFromMap(rc.Environment, "DISCORD_BOT_TOKEN"); token != "" {
+			token, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "DISCORD_BOT_TOKEN", rc.RuntimeEnv)
+			if err != nil {
+				return nil, fmt.Errorf("config generation: HANDLE discord: DISCORD_BOT_TOKEN: %w", err)
+			}
+			if token != "" {
 				if err := shared.SetPath(config, "channels.discord.accounts.main.token", token); err != nil {
 					return nil, fmt.Errorf("config generation: HANDLE discord: %w", err)
 				}
@@ -94,18 +98,29 @@ func GenerateConfig(rc *driver.ResolvedClaw) ([]byte, error) {
 				}
 			}
 		case "telegram":
-			if token := shared.ResolveEnvTokenFromMap(rc.Environment, "TELEGRAM_BOT_TOKEN"); token != "" {
+			token, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "TELEGRAM_BOT_TOKEN", rc.RuntimeEnv)
+			if err != nil {
+				return nil, fmt.Errorf("config generation: HANDLE telegram: TELEGRAM_BOT_TOKEN: %w", err)
+			}
+			if token != "" {
 				if err := shared.SetPath(config, "channels.telegram.accounts.main.bot_token", token); err != nil {
 					return nil, fmt.Errorf("config generation: HANDLE telegram: %w", err)
 				}
 			}
 		case "slack":
-			if token := shared.ResolveEnvTokenFromMap(rc.Environment, "SLACK_BOT_TOKEN"); token != "" {
+			token, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "SLACK_BOT_TOKEN", rc.RuntimeEnv)
+			if err != nil {
+				return nil, fmt.Errorf("config generation: HANDLE slack: SLACK_BOT_TOKEN: %w", err)
+			}
+			if token != "" {
 				if err := shared.SetPath(config, "channels.slack.accounts.main.bot_token", token); err != nil {
 					return nil, fmt.Errorf("config generation: HANDLE slack: %w", err)
 				}
 			}
-			appToken := shared.ResolveEnvTokenFromMap(rc.Environment, "SLACK_APP_TOKEN")
+			appToken, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "SLACK_APP_TOKEN", rc.RuntimeEnv)
+			if err != nil {
+				return nil, fmt.Errorf("config generation: HANDLE slack: SLACK_APP_TOKEN: %w", err)
+			}
 			if appToken != "" {
 				if err := shared.SetPath(config, "channels.slack.accounts.main.app_token", appToken); err != nil {
 					return nil, fmt.Errorf("config generation: HANDLE slack: %w", err)
@@ -114,7 +129,10 @@ func GenerateConfig(rc *driver.ResolvedClaw) ([]byte, error) {
 					return nil, fmt.Errorf("config generation: HANDLE slack: %w", err)
 				}
 			}
-			signingSecret := shared.ResolveEnvTokenFromMap(rc.Environment, "SLACK_SIGNING_SECRET")
+			signingSecret, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "SLACK_SIGNING_SECRET", rc.RuntimeEnv)
+			if err != nil {
+				return nil, fmt.Errorf("config generation: HANDLE slack: SLACK_SIGNING_SECRET: %w", err)
+			}
 			if signingSecret != "" {
 				if err := shared.SetPath(config, "channels.slack.accounts.main.signing_secret", signingSecret); err != nil {
 					return nil, fmt.Errorf("config generation: HANDLE slack: %w", err)

--- a/internal/driver/nullclaw/driver.go
+++ b/internal/driver/nullclaw/driver.go
@@ -36,15 +36,27 @@ func (d *Driver) Validate(rc *driver.ResolvedClaw) error {
 	for platform := range rc.Handles {
 		switch strings.ToLower(platform) {
 		case "discord":
-			if shared.ResolveEnvTokenFromMap(rc.Environment, "DISCORD_BOT_TOKEN") == "" {
+			token, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "DISCORD_BOT_TOKEN", rc.RuntimeEnv)
+			if err != nil {
+				return fmt.Errorf("nullclaw driver: DISCORD_BOT_TOKEN: %w", err)
+			}
+			if token == "" {
 				return fmt.Errorf("nullclaw driver: HANDLE discord requires DISCORD_BOT_TOKEN in service environment")
 			}
 		case "telegram":
-			if shared.ResolveEnvTokenFromMap(rc.Environment, "TELEGRAM_BOT_TOKEN") == "" {
+			token, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "TELEGRAM_BOT_TOKEN", rc.RuntimeEnv)
+			if err != nil {
+				return fmt.Errorf("nullclaw driver: TELEGRAM_BOT_TOKEN: %w", err)
+			}
+			if token == "" {
 				return fmt.Errorf("nullclaw driver: HANDLE telegram requires TELEGRAM_BOT_TOKEN in service environment")
 			}
 		case "slack":
-			if shared.ResolveEnvTokenFromMap(rc.Environment, "SLACK_BOT_TOKEN") == "" {
+			token, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "SLACK_BOT_TOKEN", rc.RuntimeEnv)
+			if err != nil {
+				return fmt.Errorf("nullclaw driver: SLACK_BOT_TOKEN: %w", err)
+			}
+			if token == "" {
 				return fmt.Errorf("nullclaw driver: HANDLE slack requires SLACK_BOT_TOKEN in service environment")
 			}
 		default:

--- a/internal/driver/picoclaw/config.go
+++ b/internal/driver/picoclaw/config.go
@@ -101,7 +101,11 @@ func GenerateConfig(rc *driver.ResolvedClaw) ([]byte, error) {
 
 		tokenVar := shared.PlatformTokenVar(platform)
 		if tokenVar != "" {
-			if token := shared.ResolveEnvTokenFromMap(rc.Environment, tokenVar); token != "" {
+			token, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, tokenVar, rc.RuntimeEnv)
+			if err != nil {
+				return nil, fmt.Errorf("config generation: HANDLE %s: %s: %w", platform, tokenVar, err)
+			}
+			if token != "" {
 				channel["token"] = token
 				channel["bot_token"] = token
 			}
@@ -121,10 +125,18 @@ func GenerateConfig(rc *driver.ResolvedClaw) ([]byte, error) {
 				}
 			}
 		case "slack":
-			if appToken := shared.ResolveEnvTokenFromMap(rc.Environment, "SLACK_APP_TOKEN"); appToken != "" {
+			appToken, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "SLACK_APP_TOKEN", rc.RuntimeEnv)
+			if err != nil {
+				return nil, fmt.Errorf("config generation: HANDLE slack: SLACK_APP_TOKEN: %w", err)
+			}
+			if appToken != "" {
 				channel["app_token"] = appToken
 			}
-			if signingSecret := shared.ResolveEnvTokenFromMap(rc.Environment, "SLACK_SIGNING_SECRET"); signingSecret != "" {
+			signingSecret, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, "SLACK_SIGNING_SECRET", rc.RuntimeEnv)
+			if err != nil {
+				return nil, fmt.Errorf("config generation: HANDLE slack: SLACK_SIGNING_SECRET: %w", err)
+			}
+			if signingSecret != "" {
 				channel["signing_secret"] = signingSecret
 			}
 		}
@@ -183,7 +195,11 @@ func buildModelList(rc *driver.ResolvedClaw) ([]map[string]interface{}, error) {
 			entry["api_key"] = rc.CllamaToken
 		} else {
 			llmProvider := shared.NormalizeProvider(provider)
-			if apiKey := shared.ResolveProviderAPIKey(llmProvider, rc.Environment); apiKey != "" {
+			apiKey, err := shared.ResolveProviderAPIKeyWithRuntimeEnv(llmProvider, rc.Environment, rc.RuntimeEnv)
+			if err != nil {
+				return nil, fmt.Errorf("MODEL %s provider %q api_key: %w", slot, llmProvider, err)
+			}
+			if apiKey != "" {
 				entry["api_key"] = apiKey
 			}
 		}

--- a/internal/driver/picoclaw/driver.go
+++ b/internal/driver/picoclaw/driver.go
@@ -61,7 +61,11 @@ func (d *Driver) Validate(rc *driver.ResolvedClaw) error {
 		if tokenVar == "" {
 			return fmt.Errorf("picoclaw driver: unsupported token mapping for HANDLE %q", rawPlatform)
 		}
-		if shared.ResolveEnvTokenFromMap(rc.Environment, tokenVar) == "" {
+		token, err := shared.ResolveEnvTokenFromMapWithRuntimeEnv(rc.Environment, tokenVar, rc.RuntimeEnv)
+		if err != nil {
+			return fmt.Errorf("picoclaw driver: %s: %w", tokenVar, err)
+		}
+		if token == "" {
 			return fmt.Errorf("picoclaw driver: HANDLE %s requires %s in service environment", platform, tokenVar)
 		}
 	}
@@ -73,7 +77,11 @@ func (d *Driver) Validate(rc *driver.ResolvedClaw) error {
 	if len(rc.Cllama) == 0 {
 		llmProvider := shared.NormalizeProvider(provider)
 		if !shared.ProviderAllowsEmptyAPIKey(llmProvider) {
-			if key := shared.ResolveProviderAPIKey(llmProvider, rc.Environment); key == "" {
+			key, err := shared.ResolveProviderAPIKeyWithRuntimeEnv(llmProvider, rc.Environment, rc.RuntimeEnv)
+			if err != nil {
+				return fmt.Errorf("picoclaw driver: provider %q API key: %w", llmProvider, err)
+			}
+			if key == "" {
 				expected := strings.Join(shared.ExpectedProviderKeys(llmProvider), ", ")
 				return fmt.Errorf("picoclaw driver: no API key found for provider %q (checked: %s)", llmProvider, expected)
 			}

--- a/internal/driver/shared/env.go
+++ b/internal/driver/shared/env.go
@@ -1,0 +1,174 @@
+package shared
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+var envPlaceholderPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
+
+// ResolveEnvTokenFromMapWithRuntimeEnv resolves a service environment value
+// using the same interpolation context claw up passes to Compose: pod .env
+// values plus process environment overrides.
+func ResolveEnvTokenFromMapWithRuntimeEnv(env map[string]string, key string, runtimeEnv map[string]string) (string, error) {
+	if env == nil {
+		return "", nil
+	}
+	return ResolveEnvTokenWithRuntimeEnv(env[key], runtimeEnv)
+}
+
+func ResolveProviderAPIKeyWithRuntimeEnv(provider string, env map[string]string, runtimeEnv map[string]string) (string, error) {
+	for _, key := range ExpectedProviderKeys(provider) {
+		token, err := ResolveEnvTokenFromMapWithRuntimeEnv(env, key, runtimeEnv)
+		if err != nil {
+			return "", fmt.Errorf("%s: %w", key, err)
+		}
+		if token != "" {
+			return token, nil
+		}
+	}
+	return "", nil
+}
+
+func ResolveEnvTokenWithRuntimeEnv(raw string, runtimeEnv map[string]string) (string, error) {
+	v := strings.TrimSpace(raw)
+	if v == "" {
+		return "", nil
+	}
+
+	if strings.HasPrefix(v, "${") && strings.HasSuffix(v, "}") {
+		return expandEnvRefs(v, runtimeEnv)
+	}
+	if strings.HasPrefix(v, "$") {
+		name := strings.TrimSpace(strings.TrimPrefix(v, "$"))
+		if isEnvVarName(name) {
+			value, ok := lookupRuntimeEnv(name, runtimeEnv)
+			if !ok {
+				return "", fmt.Errorf("unresolved environment variable %q", name)
+			}
+			return strings.TrimSpace(value), nil
+		}
+	}
+	if strings.Contains(v, "${") {
+		return expandEnvRefs(v, runtimeEnv)
+	}
+	return v, nil
+}
+
+func expandEnvRefs(value string, runtimeEnv map[string]string) (string, error) {
+	var expandErr error
+	expanded := envPlaceholderPattern.ReplaceAllStringFunc(value, func(match string) string {
+		if expandErr != nil {
+			return match
+		}
+		resolved, err := resolveEnvPlaceholder(match, runtimeEnv)
+		if err != nil {
+			expandErr = err
+			return match
+		}
+		return resolved
+	})
+	if expandErr != nil {
+		return "", expandErr
+	}
+	if unresolved := envPlaceholderPattern.FindString(expanded); unresolved != "" {
+		return "", fmt.Errorf("unresolved environment placeholder %q", unresolved)
+	}
+	return strings.TrimSpace(expanded), nil
+}
+
+func resolveEnvPlaceholder(match string, runtimeEnv map[string]string) (string, error) {
+	expr := strings.TrimSpace(match[2 : len(match)-1])
+	name, op, operand, err := parseEnvPlaceholderExpr(expr)
+	if err != nil {
+		return "", err
+	}
+
+	value, isSet := lookupRuntimeEnv(name, runtimeEnv)
+	nonEmpty := strings.TrimSpace(value) != ""
+
+	resolveOperand := func() (string, error) {
+		return expandEnvRefs(operand, runtimeEnv)
+	}
+
+	switch op {
+	case "":
+		if !isSet {
+			return "", fmt.Errorf("unresolved environment variable %q", name)
+		}
+		return value, nil
+	case ":-":
+		if !isSet || !nonEmpty {
+			return resolveOperand()
+		}
+		return value, nil
+	case "-":
+		if !isSet {
+			return resolveOperand()
+		}
+		return value, nil
+	case ":?":
+		if !isSet || !nonEmpty {
+			msg := strings.TrimSpace(operand)
+			if msg == "" {
+				msg = fmt.Sprintf("%s is required", name)
+			}
+			return "", fmt.Errorf("%s", msg)
+		}
+		return value, nil
+	case "?":
+		if !isSet {
+			msg := strings.TrimSpace(operand)
+			if msg == "" {
+				msg = fmt.Sprintf("%s is required", name)
+			}
+			return "", fmt.Errorf("%s", msg)
+		}
+		return value, nil
+	case ":+":
+		if isSet && nonEmpty {
+			return resolveOperand()
+		}
+		return "", nil
+	case "+":
+		if isSet {
+			return resolveOperand()
+		}
+		return "", nil
+	default:
+		return "", fmt.Errorf("unsupported environment placeholder operator %q", op)
+	}
+}
+
+func parseEnvPlaceholderExpr(expr string) (name, op, operand string, err error) {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return "", "", "", fmt.Errorf("empty environment placeholder")
+	}
+
+	for _, candidate := range []string{":-", ":?", ":+", "-", "?", "+"} {
+		if idx := strings.Index(expr, candidate); idx > 0 {
+			name = strings.TrimSpace(expr[:idx])
+			op = candidate
+			operand = expr[idx+len(candidate):]
+			break
+		}
+	}
+	if name == "" {
+		name = expr
+	}
+	if !isEnvVarName(name) {
+		return "", "", "", fmt.Errorf("invalid environment placeholder %q", expr)
+	}
+	return name, op, operand, nil
+}
+
+func lookupRuntimeEnv(name string, runtimeEnv map[string]string) (string, bool) {
+	if runtimeEnv != nil {
+		value, ok := runtimeEnv[name]
+		return value, ok
+	}
+	return os.LookupEnv(name)
+}

--- a/internal/driver/shared/model_test.go
+++ b/internal/driver/shared/model_test.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -84,5 +85,66 @@ func TestResolveEnvToken(t *testing.T) {
 		if got := ResolveEnvToken(tt.raw); got != tt.want {
 			t.Fatalf("ResolveEnvToken(%q) = %q, want %q", tt.raw, got, tt.want)
 		}
+	}
+}
+
+func TestResolveEnvTokenWithRuntimeEnv(t *testing.T) {
+	runtimeEnv := map[string]string{
+		"TOKEN_A": "runtime-a",
+		"TOKEN_B": "runtime-b",
+		"EMPTY":   "",
+	}
+
+	tests := []struct {
+		raw  string
+		want string
+	}{
+		{raw: "literal", want: "literal"},
+		{raw: "$TOKEN_A", want: "runtime-a"},
+		{raw: "${TOKEN_B}", want: "runtime-b"},
+		{raw: "${TOKEN_A},${TOKEN_B}", want: "runtime-a,runtime-b"},
+		{raw: "${MISSING:-fallback}", want: "fallback"},
+		{raw: "${EMPTY:-fallback}", want: "fallback"},
+		{raw: "${EMPTY-fallback}", want: ""},
+		{raw: "${TOKEN_A:+alt}", want: "alt"},
+	}
+
+	for _, tt := range tests {
+		got, err := ResolveEnvTokenWithRuntimeEnv(tt.raw, runtimeEnv)
+		if err != nil {
+			t.Fatalf("ResolveEnvTokenWithRuntimeEnv(%q) returned error: %v", tt.raw, err)
+		}
+		if got != tt.want {
+			t.Fatalf("ResolveEnvTokenWithRuntimeEnv(%q) = %q, want %q", tt.raw, got, tt.want)
+		}
+	}
+}
+
+func TestResolveEnvTokenWithRuntimeEnvRejectsMissingVars(t *testing.T) {
+	_, err := ResolveEnvTokenWithRuntimeEnv("${TOKEN_A},${MISSING}", map[string]string{"TOKEN_A": "runtime-a"})
+	if err == nil {
+		t.Fatal("expected unresolved variable error")
+	}
+	if !strings.Contains(err.Error(), "MISSING") {
+		t.Fatalf("expected missing variable in error, got: %v", err)
+	}
+}
+
+func TestResolveProviderAPIKeyWithRuntimeEnv(t *testing.T) {
+	env := map[string]string{
+		"OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}",
+		"OPENAI_API_KEY":     "${OPENAI_API_KEY}",
+	}
+	runtimeEnv := map[string]string{
+		"OPENROUTER_API_KEY": "runtime-openrouter-key",
+		"OPENAI_API_KEY":     "runtime-openai-key",
+	}
+
+	got, err := ResolveProviderAPIKeyWithRuntimeEnv("openrouter", env, runtimeEnv)
+	if err != nil {
+		t.Fatalf("ResolveProviderAPIKeyWithRuntimeEnv returned error: %v", err)
+	}
+	if got != "runtime-openrouter-key" {
+		t.Fatalf("ResolveProviderAPIKeyWithRuntimeEnv(openrouter) = %q", got)
 	}
 }

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -85,6 +85,7 @@ type ResolvedClaw struct {
 	Invocations     []Invocation      // scheduled agent tasks from image labels + pod x-claw.invoke
 	Count           int               // from pod x-claw (default 1)
 	Environment     map[string]string // from pod environment block
+	RuntimeEnv      map[string]string // compose interpolation context: pod .env plus process env
 	Timezone        string            // resolved service timezone from TZ env (falls back to UTC)
 	Cllama          []string          // ordered cllama proxy types (e.g., ["passthrough"])
 	CllamaToken     string            // per-agent bearer token injected when cllama is active


### PR DESCRIPTION
## Summary

- add a shared Compose-aware env resolver for driver materialization and validation
- pass the `claw up` runtime env context (`.env` plus process env overrides) into `ResolvedClaw`
- update Hermes, Nanobot, NullClaw, MicroClaw, and PicoClaw driver paths that bake service env references into runner config
- fail fast with the missing variable name when a materialized driver env reference cannot be resolved

## Root Cause

The prior Hermes validation fix allowed Compose-style token references to pass preflight, but materialization still resolved runner-native config with `os.Getenv` only. When the operator relied on the pod `.env` file instead of sourcing it into the shell, compound values like `${OPERATOR_DISCORD_ID},${WESTON_DISCORD_ID}` collapsed to blank comma lists before Hermes wrote `/root/.hermes/.env`.

The same process-env-only resolver was also used by several other drivers for handle tokens and direct-provider API keys, so this PR fixes the shared class of bug rather than adding a Hermes-only guard.

## Validation

- `go test ./internal/driver/shared ./internal/driver/hermes ./internal/driver/nanobot ./internal/driver/nullclaw ./internal/driver/microclaw ./internal/driver/picoclaw`
- `go test ./cmd/claw`
- `go test ./...`
- `go vet ./...`

Closes #197