### PR TITLE
fix: claw-wall channel-context defaults to non-consuming tail (#201)

### DIFF
--- a/cmd/claw-wall/discord.go
+++ b/cmd/claw-wall/discord.go
@@ -12,6 +12,8 @@ import (
 	"time"
 )
 
+const maxDiscordFetchLimit = 100
+
 type tokenPair struct {
 	ChannelID string
 	Token     string
@@ -101,6 +103,9 @@ func newDiscordPoller(client *http.Client, store *conversationStore, targets []t
 	}
 	if fetchLimit < 1 {
 		fetchLimit = 50
+	}
+	if fetchLimit > maxDiscordFetchLimit {
+		fetchLimit = maxDiscordFetchLimit
 	}
 	return &discordPoller{
 		client:       client,

--- a/cmd/claw-wall/main.go
+++ b/cmd/claw-wall/main.go
@@ -89,7 +89,7 @@ func run(args []string) error {
 }
 
 func loadConfig() (config, error) {
-	bufferLimit, err := envInt("CLAW_WALL_LIMIT", 50)
+	bufferLimit, err := envInt("CLAW_WALL_LIMIT", 500)
 	if err != nil {
 		return config{}, err
 	}

--- a/cmd/claw-wall/main_test.go
+++ b/cmd/claw-wall/main_test.go
@@ -28,7 +28,7 @@ func TestParseTokenPairsDeduplicates(t *testing.T) {
 	}
 }
 
-func TestConversationStoreConsumeAdvancesCursorWithoutSkipping(t *testing.T) {
+func TestConversationStoreConsumeDeltaAdvancesCursorWithoutSkipping(t *testing.T) {
 	store := newConversationStore(50)
 	store.merge("chan-1", []wallMessage{
 		{ID: "100", Author: "alice", Content: "first", Timestamp: time.Unix(100, 0)},
@@ -54,7 +54,86 @@ func TestConversationStoreConsumeAdvancesCursorWithoutSkipping(t *testing.T) {
 	}
 }
 
-func TestChannelContextHandlerReturnsBackgroundContextOnQuietTurn(t *testing.T) {
+func TestConversationStoreTailReturnsLatestIdempotent(t *testing.T) {
+	store := newConversationStore(50)
+	store.merge("chan-1", []wallMessage{
+		{ID: "100", Author: "alice", Content: "first", Timestamp: time.Unix(100, 0)},
+		{ID: "101", Author: "bob", Content: "second", Timestamp: time.Unix(101, 0)},
+		{ID: "102", Author: "carol", Content: "third", Timestamp: time.Unix(102, 0)},
+	})
+
+	req := tailRequest{ChannelIDs: []string{"chan-1"}, Limit: 2, Now: time.Unix(200, 0)}
+	first := store.tail(req)
+	second := store.tail(req)
+	for label, got := range map[string]tailResult{"first": first, "second": second} {
+		if len(got.Messages) != 2 || got.Messages[0].ID != "101" || got.Messages[1].ID != "102" {
+			t.Fatalf("%s tail = %+v", label, got.Messages)
+		}
+		if got.Available != 3 || got.Omitted != 1 || got.CapReason != "limit" {
+			t.Fatalf("%s metadata = %+v", label, got)
+		}
+	}
+}
+
+func TestConversationStoreTailFiltersBySinceWindow(t *testing.T) {
+	store := newConversationStore(50)
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	store.merge("chan-1", []wallMessage{
+		{ID: "100", Author: "alice", Content: "old", Timestamp: now.Add(-48 * time.Hour)},
+		{ID: "101", Author: "bob", Content: "recent", Timestamp: now.Add(-2 * time.Hour)},
+	})
+
+	got := store.tail(tailRequest{ChannelIDs: []string{"chan-1"}, Since: 24 * time.Hour, Limit: 10, Now: now})
+	if len(got.Messages) != 1 || got.Messages[0].ID != "101" {
+		t.Fatalf("expected only recent message, got %+v", got.Messages)
+	}
+	if got.Available != 1 || !got.WindowStart.Equal(now.Add(-24*time.Hour)) {
+		t.Fatalf("unexpected tail metadata: %+v", got)
+	}
+}
+
+func TestConversationStoreTailRespectsMaxCharsWithoutDroppingNewest(t *testing.T) {
+	store := newConversationStore(50)
+	store.merge("chan-1", []wallMessage{
+		{ID: "100", Author: "alice", Content: "older", Timestamp: time.Unix(100, 0)},
+		{ID: "101", Author: "bob", Content: strings.Repeat("x", 200), Timestamp: time.Unix(101, 0)},
+		{ID: "102", Author: "carol", Content: "newest", Timestamp: time.Unix(102, 0)},
+	})
+
+	got := store.tail(tailRequest{ChannelIDs: []string{"chan-1"}, Limit: 10, MaxChars: 80, Now: time.Unix(200, 0)})
+	if len(got.Messages) != 1 || got.Messages[0].ID != "102" {
+		t.Fatalf("expected newest message to survive max_chars cap, got %+v", got.Messages)
+	}
+	if got.Omitted != 2 || got.CapReason != "max_chars" {
+		t.Fatalf("unexpected max_chars metadata: %+v", got)
+	}
+
+	giantNewest := newConversationStore(50)
+	giantNewest.merge("chan-1", []wallMessage{
+		{ID: "200", Author: "alice", Content: "older", Timestamp: time.Unix(200, 0)},
+		{ID: "201", Author: "bob", Content: strings.Repeat("y", 200), Timestamp: time.Unix(201, 0)},
+	})
+	got = giantNewest.tail(tailRequest{ChannelIDs: []string{"chan-1"}, Limit: 10, MaxChars: 80, Now: time.Unix(300, 0)})
+	if len(got.Messages) != 1 || got.Messages[0].ID != "201" {
+		t.Fatalf("expected giant newest message to be included, got %+v", got.Messages)
+	}
+}
+
+func TestConversationStoreTailDoesNotMutateDeltaCursor(t *testing.T) {
+	store := newConversationStore(50)
+	store.merge("chan-1", []wallMessage{
+		{ID: "100", Author: "alice", Content: "first", Timestamp: time.Unix(100, 0)},
+		{ID: "101", Author: "bob", Content: "second", Timestamp: time.Unix(101, 0)},
+	})
+
+	_ = store.tail(tailRequest{ChannelIDs: []string{"chan-1"}, Limit: 1, Now: time.Unix(200, 0)})
+	firstDelta := store.consume("trader-0", []string{"chan-1"}, 1)
+	if len(firstDelta) != 1 || firstDelta[0].ID != "100" {
+		t.Fatalf("tail moved delta cursor; first delta = %+v", firstDelta)
+	}
+}
+
+func TestChannelContextHandlerTailModeIsDefault(t *testing.T) {
 	store := newConversationStore(50)
 	store.merge("chan-1", []wallMessage{
 		{
@@ -81,6 +160,9 @@ func TestChannelContextHandlerReturnsBackgroundContextOnQuietTurn(t *testing.T) 
 	if firstResp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", firstResp.StatusCode)
 	}
+	if !strings.Contains(string(firstBody), "[channel-context] mode=tail") {
+		t.Fatalf("expected tail coverage header, got %q", string(firstBody))
+	}
 	if !strings.Contains(string(firstBody), "latest signals") {
 		t.Fatalf("expected channel context body, got %q", string(firstBody))
 	}
@@ -97,9 +179,49 @@ func TestChannelContextHandlerReturnsBackgroundContextOnQuietTurn(t *testing.T) 
 	if secondResp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", secondResp.StatusCode)
 	}
-	// Quiet turn: no new delta, but background context returns the last message again.
-	if !strings.Contains(string(secondBody), "latest signals") {
-		t.Fatalf("expected background context on quiet turn, got %q", string(secondBody))
+	if string(firstBody) != string(secondBody) {
+		t.Fatalf("expected stable tail response across repeated fetches\nfirst: %q\nsecond: %q", string(firstBody), string(secondBody))
+	}
+}
+
+func TestChannelContextHandlerDeltaModePreservesCursorPaging(t *testing.T) {
+	store := newConversationStore(50)
+	store.merge("chan-1", []wallMessage{
+		{ID: "100", Author: "alice", Content: "first", Timestamp: time.Unix(100, 0)},
+		{ID: "101", Author: "bob", Content: "second", Timestamp: time.Unix(101, 0)},
+		{ID: "102", Author: "carol", Content: "third", Timestamp: time.Unix(102, 0)},
+	})
+
+	server := httptest.NewServer(newHandler(store))
+	defer server.Close()
+
+	firstResp, err := http.Get(server.URL + "/channel-context?mode=delta&consumer=trader-0&channels=chan-1&limit=2")
+	if err != nil {
+		t.Fatalf("first GET: %v", err)
+	}
+	defer firstResp.Body.Close()
+	firstBody, err := io.ReadAll(firstResp.Body)
+	if err != nil {
+		t.Fatalf("read first response: %v", err)
+	}
+	if strings.Contains(string(firstBody), "[channel-context]") {
+		t.Fatalf("delta response should not include tail header: %q", string(firstBody))
+	}
+	if !strings.Contains(string(firstBody), "first") || !strings.Contains(string(firstBody), "second") || strings.Contains(string(firstBody), "third") {
+		t.Fatalf("unexpected first delta body: %q", string(firstBody))
+	}
+
+	secondResp, err := http.Get(server.URL + "/channel-context?mode=delta&consumer=trader-0&channels=chan-1&limit=2")
+	if err != nil {
+		t.Fatalf("second GET: %v", err)
+	}
+	defer secondResp.Body.Close()
+	secondBody, err := io.ReadAll(secondResp.Body)
+	if err != nil {
+		t.Fatalf("read second response: %v", err)
+	}
+	if !strings.Contains(string(secondBody), "third") || strings.Contains(string(secondBody), "first") {
+		t.Fatalf("unexpected second delta body: %q", string(secondBody))
 	}
 }
 
@@ -116,6 +238,9 @@ func TestLoadConfigDefaultsPollIntervalToThirtySeconds(t *testing.T) {
 	if cfg.PollInterval != 30*time.Second {
 		t.Fatalf("expected 30s poll interval, got %s", cfg.PollInterval)
 	}
+	if cfg.BufferLimit != 500 {
+		t.Fatalf("expected default buffer limit 500, got %d", cfg.BufferLimit)
+	}
 }
 
 func TestLoadConfigUsesPollIntervalOverride(t *testing.T) {
@@ -130,6 +255,13 @@ func TestLoadConfigUsesPollIntervalOverride(t *testing.T) {
 	}
 	if cfg.PollInterval != 42*time.Second {
 		t.Fatalf("expected 42s poll interval, got %s", cfg.PollInterval)
+	}
+}
+
+func TestDiscordPollerClampsFetchLimitToDiscordMaximum(t *testing.T) {
+	poller := newDiscordPoller(nil, newConversationStore(500), []tokenPair{{ChannelID: "chan-1", Token: "token-a"}}, 500)
+	if poller.fetchLimit != maxDiscordFetchLimit {
+		t.Fatalf("expected fetch limit %d, got %d", maxDiscordFetchLimit, poller.fetchLimit)
 	}
 }
 

--- a/cmd/claw-wall/store.go
+++ b/cmd/claw-wall/store.go
@@ -13,6 +13,8 @@ import (
 const (
 	defaultResponseLimit  = 20
 	backgroundContextSize = 10
+	defaultTailLimit      = 40
+	defaultTailMaxChars   = 8 * 1024
 )
 
 type wallMessage struct {
@@ -33,6 +35,25 @@ type conversationStore struct {
 	mu       sync.Mutex
 	channels map[string]*channelBuffer
 	cursors  map[string]map[string]string
+}
+
+type tailRequest struct {
+	ChannelIDs []string
+	Since      time.Duration
+	Limit      int
+	MaxChars   int
+	Now        time.Time
+}
+
+type tailResult struct {
+	ChannelIDs   []string
+	Messages     []wallMessage
+	Available    int
+	Omitted      int
+	CapReason    string
+	WindowStart  time.Time
+	BufferOldest time.Time
+	BufferNewest time.Time
 }
 
 func newConversationStore(limit int) *conversationStore {
@@ -160,6 +181,105 @@ func (s *conversationStore) consume(consumer string, channelIDs []string, limit 
 	return out
 }
 
+func (s *conversationStore) tail(req tailRequest) tailResult {
+	limit := req.Limit
+	if limit <= 0 {
+		limit = defaultTailLimit
+	}
+	if limit > s.limit {
+		limit = s.limit
+	}
+	maxChars := req.MaxChars
+	if maxChars < 0 {
+		maxChars = 0
+	}
+	now := req.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	var windowStart time.Time
+	if req.Since > 0 {
+		windowStart = now.Add(-req.Since)
+	}
+
+	channelIDs := normalizeChannelIDs(req.ChannelIDs)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	candidates := make([]wallMessage, 0)
+	for _, channelID := range channelIDs {
+		state := s.channels[channelID]
+		if state == nil {
+			continue
+		}
+		for _, msg := range state.messages {
+			if req.Since > 0 && !msg.Timestamp.IsZero() && msg.Timestamp.Before(windowStart) {
+				continue
+			}
+			candidates = append(candidates, msg)
+		}
+	}
+
+	sortWallMessages(candidates)
+	selectedReversed := make([]wallMessage, 0, min(limit, len(candidates)))
+	usedChars := 0
+	capReason := ""
+	for i := len(candidates) - 1; i >= 0; i-- {
+		if len(selectedReversed) >= limit {
+			capReason = "limit"
+			break
+		}
+		lineLen := len(formatWallMessage(candidates[i]))
+		if len(selectedReversed) > 0 {
+			lineLen++
+		}
+		if maxChars > 0 && usedChars+lineLen > maxChars && len(selectedReversed) > 0 {
+			capReason = "max_chars"
+			break
+		}
+		selectedReversed = append(selectedReversed, candidates[i])
+		usedChars += lineLen
+	}
+
+	messages := make([]wallMessage, 0, len(selectedReversed))
+	for i := len(selectedReversed) - 1; i >= 0; i-- {
+		messages = append(messages, selectedReversed[i])
+	}
+
+	if len(messages) < len(candidates) && capReason == "" {
+		capReason = "limit"
+	}
+
+	result := tailResult{
+		ChannelIDs:  channelIDs,
+		Messages:    messages,
+		Available:   len(candidates),
+		Omitted:     len(candidates) - len(messages),
+		CapReason:   capReason,
+		WindowStart: windowStart,
+	}
+	for _, channelID := range channelIDs {
+		state := s.channels[channelID]
+		if state == nil {
+			continue
+		}
+		for _, msg := range state.messages {
+			if msg.Timestamp.IsZero() {
+				continue
+			}
+			if result.BufferOldest.IsZero() || msg.Timestamp.Before(result.BufferOldest) {
+				result.BufferOldest = msg.Timestamp
+			}
+			if result.BufferNewest.IsZero() || msg.Timestamp.After(result.BufferNewest) {
+				result.BufferNewest = msg.Timestamp
+			}
+		}
+	}
+
+	return result
+}
+
 func newHandler(store *conversationStore) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
@@ -167,9 +287,12 @@ func newHandler(store *conversationStore) http.Handler {
 		_, _ = w.Write([]byte(`{"ok":true}`))
 	})
 	mux.HandleFunc("/channel-context", func(w http.ResponseWriter, r *http.Request) {
-		consumer := strings.TrimSpace(r.URL.Query().Get("consumer"))
-		if consumer == "" {
-			http.Error(w, "consumer is required", http.StatusBadRequest)
+		mode := strings.TrimSpace(r.URL.Query().Get("mode"))
+		if mode == "" {
+			mode = "tail"
+		}
+		if mode != "tail" && mode != "delta" {
+			http.Error(w, "mode must be tail or delta", http.StatusBadRequest)
 			return
 		}
 
@@ -180,7 +303,11 @@ func newHandler(store *conversationStore) http.Handler {
 		}
 		channelIDs := strings.Split(rawChannels, ",")
 
-		limit := defaultResponseLimit
+		defaultLimit := defaultTailLimit
+		if mode == "delta" {
+			defaultLimit = defaultResponseLimit
+		}
+		limit := defaultLimit
 		if rawLimit := strings.TrimSpace(r.URL.Query().Get("limit")); rawLimit != "" {
 			parsed, err := strconv.Atoi(rawLimit)
 			if err != nil || parsed < 1 {
@@ -190,13 +317,45 @@ func newHandler(store *conversationStore) http.Handler {
 			limit = parsed
 		}
 
-		messages := store.consume(consumer, channelIDs, limit)
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-		if len(messages) == 0 {
-			w.WriteHeader(http.StatusOK)
+		if mode == "delta" {
+			consumer := strings.TrimSpace(r.URL.Query().Get("consumer"))
+			if consumer == "" {
+				http.Error(w, "consumer is required", http.StatusBadRequest)
+				return
+			}
+			messages := store.consume(consumer, channelIDs, limit)
+			if len(messages) == 0 {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			_, _ = w.Write([]byte(formatWallMessages(messages)))
 			return
 		}
-		_, _ = w.Write([]byte(formatWallMessages(messages)))
+
+		since, err := parseDurationQuery(r.URL.Query().Get("since"), r.URL.Query().Get("window"))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		maxChars := defaultTailMaxChars
+		if rawMaxChars := strings.TrimSpace(r.URL.Query().Get("max_chars")); rawMaxChars != "" {
+			parsed, err := strconv.Atoi(rawMaxChars)
+			if err != nil || parsed < 1 {
+				http.Error(w, "max_chars must be a positive integer", http.StatusBadRequest)
+				return
+			}
+			maxChars = parsed
+		}
+
+		result := store.tail(tailRequest{
+			ChannelIDs: channelIDs,
+			Since:      since,
+			Limit:      limit,
+			MaxChars:   maxChars,
+			Now:        time.Now(),
+		})
+		_, _ = w.Write([]byte(formatTailContext(result, since)))
 	})
 	return mux
 }
@@ -207,9 +366,87 @@ func formatWallMessages(messages []wallMessage) string {
 		if i > 0 {
 			b.WriteByte('\n')
 		}
-		fmt.Fprintf(&b, "[%s] %s: %s", formatWallTimestamp(msg.Timestamp), msg.Author, msg.Content)
+		b.WriteString(formatWallMessage(msg))
 	}
 	return b.String()
+}
+
+func formatWallMessage(msg wallMessage) string {
+	return fmt.Sprintf("[%s] %s: %s", formatWallTimestamp(msg.Timestamp), msg.Author, msg.Content)
+}
+
+func formatTailContext(result tailResult, since time.Duration) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "[channel-context] mode=tail since=%s channels=%s messages=%d available=%d omitted=%d",
+		formatDurationForHeader(since), strings.Join(result.ChannelIDs, ","), len(result.Messages), result.Available, result.Omitted)
+	if result.CapReason != "" {
+		fmt.Fprintf(&b, " cap=%s", result.CapReason)
+	}
+	fmt.Fprintf(&b, " range=%s buffer_range=%s",
+		formatTimeRange(messageRange(result.Messages)),
+		formatTimeRange(result.BufferOldest, result.BufferNewest))
+	b.WriteString("\n")
+	if result.Omitted > 0 {
+		fmt.Fprintf(&b, "[omitted %d older retained messages due to %s; newest retained messages follow]\n",
+			result.Omitted, result.CapReason)
+	}
+	if len(result.Messages) > 0 {
+		b.WriteByte('\n')
+		b.WriteString(formatWallMessages(result.Messages))
+	}
+	return b.String()
+}
+
+func parseDurationQuery(rawSince, rawWindow string) (time.Duration, error) {
+	raw := strings.TrimSpace(rawSince)
+	if raw == "" {
+		raw = strings.TrimSpace(rawWindow)
+	}
+	if raw == "" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d < 0 {
+		return 0, fmt.Errorf("since must be a non-negative duration")
+	}
+	return d, nil
+}
+
+func formatDurationForHeader(d time.Duration) string {
+	if d <= 0 {
+		return "all"
+	}
+	return d.String()
+}
+
+func messageRange(messages []wallMessage) (time.Time, time.Time) {
+	var oldest, newest time.Time
+	for _, msg := range messages {
+		if msg.Timestamp.IsZero() {
+			continue
+		}
+		if oldest.IsZero() || msg.Timestamp.Before(oldest) {
+			oldest = msg.Timestamp
+		}
+		if newest.IsZero() || msg.Timestamp.After(newest) {
+			newest = msg.Timestamp
+		}
+	}
+	return oldest, newest
+}
+
+func formatTimeRange(start, end time.Time) string {
+	if start.IsZero() || end.IsZero() {
+		return "empty"
+	}
+	return formatHeaderTimestamp(start) + ".." + formatHeaderTimestamp(end)
+}
+
+func formatHeaderTimestamp(ts time.Time) string {
+	if ts.IsZero() {
+		return "unknown-time"
+	}
+	return ts.UTC().Format("2006-01-02T15:04Z")
 }
 
 func formatWallTimestamp(ts time.Time) string {

--- a/cmd/claw/compose_up.go
+++ b/cmd/claw/compose_up.go
@@ -43,7 +43,10 @@ const (
 	conversationWallServiceName  = "claw-wall"
 	conversationWallFeedName     = "channel-context"
 	conversationWallFeedTTL      = 30
-	conversationWallFeedLimit    = 20
+	conversationWallFeedSince    = "24h"
+	conversationWallFeedLimit    = 40
+	conversationWallFeedMaxChars = 8 * 1024
+	conversationWallBufferLimit  = 500
 	conversationWallPollInterval = "30"
 	conversationWallInternalPort = "8080"
 	conversationWallDockerfile   = "dockerfiles/claw-wall/Dockerfile"
@@ -1670,13 +1673,15 @@ func injectConversationWall(p *pod.Pod, resolvedClaws map[string]*driver.Resolve
 		if svc == nil || svc.Claw == nil {
 			continue
 		}
-		svc.Claw.Feeds = appendConversationWallFeed(svc.Claw.Feeds, channelIDs)
+		settings := conversationWallChannelContext(p, svc)
+		svc.Claw.Feeds = appendConversationWallFeed(svc.Claw.Feeds, channelIDs, settings)
 	}
 
 	p.Services[conversationWallServiceName] = &pod.Service{
 		Image: resolveConversationWallImageRef(),
 		Environment: map[string]string{
 			"CLAW_WALL_TOKENS":        formatConversationWallTokenPairs(tokenPairs),
+			"CLAW_WALL_LIMIT":         strconv.Itoa(conversationWallBufferForPod(p, triggerServices)),
 			"CLAW_WALL_POLL_INTERVAL": envOrDefault("CLAW_WALL_POLL_INTERVAL", conversationWallPollInterval),
 		},
 		Expose: []string{conversationWallInternalPort},
@@ -1729,8 +1734,70 @@ func sortedConversationWallServiceNames(services map[string]*pod.Service) []stri
 	return names
 }
 
-func appendConversationWallFeed(feeds []pod.FeedEntry, channelIDs []string) []pod.FeedEntry {
-	path := fmt.Sprintf("/channel-context?consumer={claw_id}&channels=%s&limit=%d", strings.Join(channelIDs, ","), conversationWallFeedLimit)
+type conversationWallContextSettings struct {
+	Since    string
+	Limit    int
+	MaxChars int
+	Buffer   int
+}
+
+func conversationWallChannelContext(p *pod.Pod, svc *pod.Service) conversationWallContextSettings {
+	settings := conversationWallContextSettings{
+		Since:    conversationWallFeedSince,
+		Limit:    conversationWallFeedLimit,
+		MaxChars: conversationWallFeedMaxChars,
+		Buffer:   conversationWallBufferLimit,
+	}
+	if p != nil && p.Context != nil {
+		settings = applyConversationWallChannelContext(settings, p.Context.Channel)
+	}
+	if svc != nil && svc.Claw != nil && svc.Claw.Context != nil {
+		settings = applyConversationWallChannelContext(settings, svc.Claw.Context.Channel)
+	}
+	return settings
+}
+
+func applyConversationWallChannelContext(settings conversationWallContextSettings, cfg *pod.ChannelContextConfig) conversationWallContextSettings {
+	if cfg == nil {
+		return settings
+	}
+	if strings.TrimSpace(cfg.Since) != "" {
+		settings.Since = strings.TrimSpace(cfg.Since)
+	}
+	if cfg.Limit > 0 {
+		settings.Limit = cfg.Limit
+	}
+	if cfg.MaxChars > 0 {
+		settings.MaxChars = cfg.MaxChars
+	}
+	if cfg.Buffer > 0 {
+		settings.Buffer = cfg.Buffer
+	}
+	return settings
+}
+
+func conversationWallBufferForPod(p *pod.Pod, triggerServices map[string][]string) int {
+	buffer := conversationWallBufferLimit
+	for name := range triggerServices {
+		svc := p.Services[name]
+		if svc == nil {
+			continue
+		}
+		if candidate := conversationWallChannelContext(p, svc).Buffer; candidate > buffer {
+			buffer = candidate
+		}
+	}
+	return buffer
+}
+
+func appendConversationWallFeed(feeds []pod.FeedEntry, channelIDs []string, settings conversationWallContextSettings) []pod.FeedEntry {
+	path := fmt.Sprintf(
+		"/channel-context?consumer={claw_id}&channels=%s&mode=tail&since=%s&limit=%d&max_chars=%d",
+		strings.Join(channelIDs, ","),
+		settings.Since,
+		settings.Limit,
+		settings.MaxChars,
+	)
 	for _, feed := range feeds {
 		if feed.Name == conversationWallFeedName && feed.Source == conversationWallServiceName && feed.Path == path {
 			return feeds

--- a/cmd/claw/compose_up_test.go
+++ b/cmd/claw/compose_up_test.go
@@ -3020,7 +3020,7 @@ func TestBuildFeedManifestUsesOrdinalClawID(t *testing.T) {
 						{
 							Name:   conversationWallFeedName,
 							Source: conversationWallServiceName,
-							Path:   "/channel-context?consumer={claw_id}&channels=chan-a,chan-b&limit=20",
+							Path:   "/channel-context?consumer={claw_id}&channels=chan-a,chan-b&mode=tail&since=24h&limit=40&max_chars=8192",
 							TTL:    conversationWallFeedTTL,
 						},
 					},
@@ -3036,10 +3036,10 @@ func TestBuildFeedManifestUsesOrdinalClawID(t *testing.T) {
 	if len(feeds) != 1 {
 		t.Fatalf("expected one feed, got %d", len(feeds))
 	}
-	if feeds[0].Path != "/channel-context?consumer=trader-1&channels=chan-a,chan-b&limit=20" {
+	if feeds[0].Path != "/channel-context?consumer=trader-1&channels=chan-a,chan-b&mode=tail&since=24h&limit=40&max_chars=8192" {
 		t.Fatalf("expected ordinal claw_id substitution, got %q", feeds[0].Path)
 	}
-	if feeds[0].URL != "http://claw-wall:8080/channel-context?consumer=trader-1&channels=chan-a,chan-b&limit=20" {
+	if feeds[0].URL != "http://claw-wall:8080/channel-context?consumer=trader-1&channels=chan-a,chan-b&mode=tail&since=24h&limit=40&max_chars=8192" {
 		t.Fatalf("expected ordinal wall URL, got %q", feeds[0].URL)
 	}
 }
@@ -3537,6 +3537,9 @@ func TestInjectConversationWallAddsServiceAndFeed(t *testing.T) {
 	if wall.Environment["CLAW_WALL_POLL_INTERVAL"] != conversationWallPollInterval {
 		t.Fatalf("unexpected CLAW_WALL_POLL_INTERVAL: %q", wall.Environment["CLAW_WALL_POLL_INTERVAL"])
 	}
+	if wall.Environment["CLAW_WALL_LIMIT"] != "500" {
+		t.Fatalf("unexpected CLAW_WALL_LIMIT: %q", wall.Environment["CLAW_WALL_LIMIT"])
+	}
 
 	traderFeeds := p.Services["trader"].Claw.Feeds
 	if len(traderFeeds) != 1 {
@@ -3545,11 +3548,67 @@ func TestInjectConversationWallAddsServiceAndFeed(t *testing.T) {
 	if traderFeeds[0].Source != conversationWallServiceName {
 		t.Fatalf("expected claw-wall feed source, got %+v", traderFeeds[0])
 	}
-	if traderFeeds[0].Path != "/channel-context?consumer={claw_id}&channels=chan-1,chan-2&limit=20" {
+	if traderFeeds[0].Path != "/channel-context?consumer={claw_id}&channels=chan-1,chan-2&mode=tail&since=24h&limit=40&max_chars=8192" {
 		t.Fatalf("unexpected wall feed path: %q", traderFeeds[0].Path)
 	}
 	if len(p.Services["observer"].Claw.Feeds) != 0 {
 		t.Fatalf("expected no wall feed for non-cllama service, got %+v", p.Services["observer"].Claw.Feeds)
+	}
+}
+
+func TestInjectConversationWallHonorsChannelContextConfig(t *testing.T) {
+	p := &pod.Pod{
+		Name: "desk",
+		Context: &pod.ContextConfig{
+			Channel: &pod.ChannelContextConfig{
+				Since:    "6h",
+				Limit:    25,
+				MaxChars: 4096,
+				Buffer:   300,
+			},
+		},
+		Services: map[string]*pod.Service{
+			"trader": testConversationWallService("${TRADER_DISCORD_BOT_TOKEN}", "chan-1"),
+			"scout":  testConversationWallService("${SCOUT_DISCORD_BOT_TOKEN}", "chan-1"),
+		},
+	}
+	p.Services["scout"].Claw.Context = &pod.ContextConfig{
+		Channel: &pod.ChannelContextConfig{
+			Since:    "30m",
+			Limit:    8,
+			MaxChars: 1024,
+			Buffer:   700,
+		},
+	}
+
+	resolvedClaws := map[string]*driver.ResolvedClaw{
+		"trader": {ServiceName: "trader", Cllama: []string{"passthrough"}},
+		"scout":  {ServiceName: "scout", Cllama: []string{"passthrough"}},
+	}
+
+	if err := injectConversationWall(p, resolvedClaws); err != nil {
+		t.Fatalf("injectConversationWall: %v", err)
+	}
+
+	traderFeeds := p.Services["trader"].Claw.Feeds
+	if len(traderFeeds) != 1 {
+		t.Fatalf("expected trader feed, got %+v", traderFeeds)
+	}
+	if traderFeeds[0].Path != "/channel-context?consumer={claw_id}&channels=chan-1&mode=tail&since=6h&limit=25&max_chars=4096" {
+		t.Fatalf("unexpected trader feed path: %q", traderFeeds[0].Path)
+	}
+
+	scoutFeeds := p.Services["scout"].Claw.Feeds
+	if len(scoutFeeds) != 1 {
+		t.Fatalf("expected scout feed, got %+v", scoutFeeds)
+	}
+	if scoutFeeds[0].Path != "/channel-context?consumer={claw_id}&channels=chan-1&mode=tail&since=30m&limit=8&max_chars=1024" {
+		t.Fatalf("unexpected scout feed path: %q", scoutFeeds[0].Path)
+	}
+
+	wall := p.Services[conversationWallServiceName]
+	if wall.Environment["CLAW_WALL_LIMIT"] != "700" {
+		t.Fatalf("expected wall buffer to use max service buffer, got %q", wall.Environment["CLAW_WALL_LIMIT"])
 	}
 }
 

--- a/cmd/claw/skill_data/SKILL.md
+++ b/cmd/claw/skill_data/SKILL.md
@@ -387,7 +387,7 @@ The proxy sits between agents and LLM providers. Agents get bearer tokens, proxy
 
 ### claw-wall sidecar
 
-Auto-injected by `claw up` when any cllama-enabled service has Discord channel IDs. Polls Discord channels and serves incremental message history to agents. Per-consumer cursors ensure agents only see new messages since their last turn. The service name `claw-wall` is reserved — declaring it in `claw-pod.yml` is a hard error.
+Auto-injected by `claw up` when any cllama-enabled service has Discord channel IDs. Polls Discord channels and serves the recent channel transcript to agents through `channel-context` tail feeds; legacy unread-mailbox cursor paging remains available as `mode=delta`. Configure the generated tail window with pod or service `x-claw.context.channel` (`since`, `limit`, `max-chars`, `buffer`). The service name `claw-wall` is reserved — declaring it in `claw-pod.yml` is a hard error.
 
 ## Generated Artifacts
 

--- a/docs/plans/2026-04-29-issue-201-channel-context-tail-mode.md
+++ b/docs/plans/2026-04-29-issue-201-channel-context-tail-mode.md
@@ -1,0 +1,229 @@
+# Plan — Issue #201: claw-wall channel-context returns oldest unread page instead of latest tail
+
+**Issue:** https://github.com/mostlydev/clawdapus/issues/201
+**Branch:** `issue-201-channel-context-tail` (already created by codex)
+**Workflow:** Claude drafts → codex reviews / implements → Claude tests + releases. Same cadence as #177/#179/#182.
+
+## 1. Problem
+
+`claw-wall`'s generated `channel-context` feed currently behaves like an unread mailbox: each fetch returns the **oldest** `limit` messages newer than the consumer's cursor, then advances the cursor. For Discord-mention/invocation context, this is the wrong semantic. Live evidence from Tiverton: an agent received a `channel-context` feed in its prompt that contained backlog from 17:02–20:37, while the actual mention happened at 23:53. The conversation that prompted the invocation was not visible to the agent, even though ingestion had captured it.
+
+The bug is at `cmd/claw-wall/store.go:116-118`: when `collected` (messages newer than cursor) exceeds `limit`, we keep `collected[:limit]` (oldest first) and bump the cursor to that page's last ID. After a long quiet period, the agent drains the buffer oldest-first across many invocations before ever seeing the latest message.
+
+A second-order consequence: cache instability. Even in a quiet channel, every fetch advances the cursor, so the rendered feed body changes each turn even when the room is silent. That breaks the cllama feed cache (and downstream prompt caches) for no benefit.
+
+The "background context" branch (`store.go:120-146`) is already the right shape — newest tail, no cursor write — but it only fires when there are **no** unread messages. As soon as backlog exists, we drop back to mailbox mode.
+
+## 2. Design constraints
+
+- **Agent perspective:** when the bot is mentioned in a channel it's part of, it must see the recent room conversation, just like a human walking back into the room would.
+- **Cache stability:** identical store contents should produce identical feed body. This is a hard requirement for prompt-cache-friendliness.
+- **No silent gaps:** if the buffer or the requested window can't cover the full request, the agent must be able to see that.
+- **No layering violations:** claw-wall stays a dumb tail buffer. Summarization, salience, episodic compression — those belong to the salience-memory adapter (in-flight per `docs/plans/2026-04-29-salience-memory-adapter.md`). Don't bake LLM-derived condensation into claw-wall.
+- **Wider continuity already exists:** Tiverton confirms `agent-scaffold` (daily, ~2.8KB), `desk-chronicle` (daily, ~3.5KB), and `agent-memory` (10min, small/private) already cover non-recent context. `channel-context` is strictly *recent room transcript*.
+- **Backwards-compatibility:** the existing cursor/delta API path stays callable for any consumer that genuinely wants mailbox semantics, but it stops being the default.
+
+## 3. Answers to codex's open questions
+
+### Q1 — Default API behavior: keep delta default, or flip to tail?
+
+**Flip to tail by default.** Both the public API and the auto-generated feed move to `mode=tail`. `mode=delta` remains supported but explicit.
+
+Reasoning: there is exactly one in-tree consumer of `/channel-context` — the compose-generated feed — and that consumer is the bug victim. Keeping `delta` as the implicit default leaves a footgun for any future caller. There are no documented external consumers to preserve. The existing `TestConversationStoreConsumeAdvancesCursorWithoutSkipping` regression remains green by becoming explicit about `mode=delta`.
+
+### Q2 — Default cap: limit (count), max_chars (bytes), or both?
+
+**Both, dual cap with whichever-fires-first semantics. Defaults: `limit=40` and `max_chars=8KB`.**
+
+Reasoning:
+- Pure count cap explodes the prompt budget when a single Discord message has a 4KB embed.
+- Pure byte cap silently drops sane numbers of messages when content is dense.
+- `8KB` aligns with cllama's existing `MaxFeedResponseBytes` truncation threshold, so a well-formed tail fits without hitting cllama's "truncated" path.
+- `40` is ≈2× a reasonable "enough recent context for a mention" baseline (the current 20 was tight; it's the value the issue notes as not-enough-on-its-own).
+
+The dual cap renders newest-first walk: walk messages from newest backward, accept while both `count < limit` and `bytes < max_chars`, stop on either limit. Then sort ASC for output.
+
+### Q3 — Startup Discord backfill?
+
+**No, not in v1.** Honest retained-coverage metadata is sufficient.
+
+Reasoning:
+- Backfill against Discord history brings its own concerns: rate-limit budgets, auth scoping, "how far back is far enough", out-of-order vs. paginated fetches, dedupe against the live poller.
+- The wider-continuity feeds (agent-scaffold, desk-chronicle, agent-memory) already cover the cold-start window for Tiverton-class deployments.
+- The coverage header (see §4.3) makes the "I just came online, my buffer only has 5 minutes" case visible to the agent so it can reason about its own context.
+- Operators who need a true 24h window today can raise `CLAW_WALL_LIMIT` (and pod-level `buffer`) so the in-process buffer is the durable record over restarts that fit inside `CLAW_WALL_BUFFER_RETENTION_HOURS` worth of Discord traffic. (claw-wall already runs as a sidecar across normal restart cycles; cold-start happens on `claw down && claw up`, not on every poll.)
+- A separate follow-up issue can scope backfill once we have real signal that retained-coverage isn't enough.
+
+## 4. Design
+
+### 4.1 Wire contract
+
+```
+GET /channel-context?consumer=<id>&channels=<csv>&mode=tail&since=24h&limit=40&max_chars=8192
+```
+
+Query params:
+- `consumer` — required in `mode=delta`, optional and ignored in `mode=tail`.
+- `channels` — required CSV of channel IDs. Same channel-authorization model as today (caller already restricted upstream to surface-derived channels).
+- `mode` — `tail` (default) | `delta` (legacy cursor paging).
+- `since` — Go-duration-parsable window (`24h`, `30m`, `2h15m`). Optional. If absent, no time filter; only count/byte caps apply. Tail mode only.
+- `limit` — positive integer message count cap. Defaults: `mode=tail` → 40, `mode=delta` → 20 (existing).
+- `max_chars` — positive integer byte cap on rendered body (excluding header). Tail mode only. Default 8192.
+
+`mode=delta` keeps its current behavior verbatim (cursor paging, oldest-page truncation, cursor advance). No new params apply to it.
+
+### 4.2 Store API
+
+New method on `*conversationStore`:
+
+```go
+type tailRequest struct {
+    channels []string
+    since    time.Duration  // 0 = no time filter
+    limit    int
+    maxChars int            // 0 = no byte cap
+    now      time.Time
+}
+
+type tailResult struct {
+    messages       []wallMessage
+    bufferOldest   time.Time   // earliest message in any requested channel buffer
+    bufferNewest   time.Time   // latest message
+    truncatedByLimit    bool
+    truncatedByMaxChars bool
+    truncatedByWindow   bool   // since-window contains > limit/max_chars; older-in-window omitted
+}
+
+func (s *conversationStore) consumeTail(req tailRequest) tailResult
+```
+
+Implementation:
+1. Lock store, walk per-channel buffers, collect all messages where `since == 0 || msg.Timestamp >= now-since`.
+2. Sort DESC by snowflake.
+3. Walk newest-first, accumulate while `count < limit` and `bytes < maxChars`. Track which cap fired.
+4. Reverse to ASC for output.
+5. Compute `bufferOldest`/`bufferNewest` across all requested buffers (for coverage telemetry, regardless of `since`).
+6. Set `truncatedByWindow` if there exist messages within `since` that we didn't return.
+7. Do **not** touch cursors. The function is pure-read.
+
+### 4.3 Coverage header
+
+Tail-mode response is one header line (terminated by `\n\n`), then existing `[ts] author: content` lines:
+
+```
+[channel-context] mode=tail since=24h messages=23 range=2026-04-29T03:14Z..2026-04-29T05:42Z channels=1464509330731696213,1464796137893662843 retained=23/since-24h
+[2026-04-29 03:14] alice: Has anyone reviewed the latest signals?
+[2026-04-29 03:18] bob: I'll take it.
+...
+```
+
+`retained=N/M` in the header reads as "we returned N messages; M is the largest set we could have returned given store contents, the since window, and surface-authorized channels." When `truncatedByLimit` or `truncatedByMaxChars` fires, `M > N`. When `truncatedByWindow` fires, `retained=N/since-Xh` instead of a number, signaling "this is the entire since-bounded set, capped." When the buffer itself is the limit (cold start, restart): `retained=N/buffer` with `range` showing the actual oldest_ts.
+
+`mode=delta` responses do **not** include the header (preserves existing format and existing tests).
+
+Header cost: ~140 bytes. Trivial relative to message body. Worth it because:
+- Agents can reason about coverage explicitly ("I'm only seeing the last 12 minutes — must have just rebooted").
+- Operators debugging issue-201-class problems get coverage info inline without extra plumbing.
+- Coverage info is stable across quiet-period fetches, so it doesn't bust the cache.
+
+### 4.4 Generated feed (compose_up)
+
+`appendConversationWallFeed` (`cmd/claw/compose_up.go:1732`) emits:
+
+```
+/channel-context?consumer={claw_id}&channels=<sorted-ids>&mode=tail&since=<dur>&limit=<n>&max_chars=<n>
+```
+
+Defaults if pod doesn't override: `since=24h`, `limit=40`, `max_chars=8192`.
+
+`{claw_id}` template stays so the URL keeps a deterministic per-ordinal shape (consistent with `delta` mode generation), even though `consumer` is unused in tail mode. This avoids a second feed-template branch.
+
+### 4.5 Pod YAML configuration
+
+Pod-level config under `x-claw.context.channel` (new key, no migration needed since claw-wall auto-injection has no current config knobs):
+
+```yaml
+x-claw:
+  pod: tiverton-house
+  master: sentinel
+  context:
+    channel:
+      since: 24h         # default 24h
+      limit: 40          # default 40
+      max_chars: 8192    # default 8192
+      buffer: 500        # default unset (claw-wall env CLAW_WALL_LIMIT default 50)
+```
+
+`since`/`limit`/`max_chars` flow into the generated feed path. `buffer` flows into the auto-injected `claw-wall` service env as `CLAW_WALL_LIMIT=<buffer>` so chatty channels can hold a real 24h window.
+
+Service-level overrides via `x-claw.context.channel` on individual services follow the same pod-defaults pattern as `surfaces`/`feeds`/`tools`.
+
+### 4.6 Cache stability claim
+
+For a quiet channel (no new poll deltas), tail mode returns the identical body — same messages, same coverage header — across every fetch within the buffer-retention window. The cllama 30s feed cache stays warm; downstream prompt caches stay warm. The current bug forces every fetch to mutate the cursor and produce a new body even in a silent room. Fixing this is the headline win.
+
+For an active channel, the body changes on each new message, as it should. The bug fix doesn't hurt this case; it just stops creating fake churn in the silent case. Stable-prefix + fresh-tail two-block rendering is interesting but **out of scope** — defer to salience-memory adapter integration when that lands (#164 / `docs/plans/2026-04-29-salience-memory-adapter.md`).
+
+## 5. Non-goals (v1)
+
+- LLM-driven summarization of older content. Salience-memory adapter handles that.
+- Discord history backfill beyond the in-process buffer.
+- Two-block stable-prefix + fresh-tail rendering for max prompt-cache stability.
+- Per-channel (vs. per-pod/service) override of since/limit/max_chars.
+- Header-line localization, channel-name resolution (we only have IDs), or richer telemetry (e.g. message-id high-watermark in the header).
+
+## 6. Build sequence
+
+1. **Store + handler** — `consumeTail` + dual cap + coverage header. New tests; existing tests stay green.
+2. **Compose generation** — `appendConversationWallFeed` writes `mode=tail&since=...&limit=...&max_chars=...`. Pod parser picks up `x-claw.context.channel`. Buffer flows into `CLAW_WALL_LIMIT`.
+3. **Skill + docs** — `skills/clawdapus/SKILL.md` (and embedded mirror), guide pages mentioning channel-context, ADR/changelog. Roadmap reference.
+4. **Spike check** — verify generated feed in `examples/quickstart`/local pod produces correct paths; manual fetch round-trip against a fresh pod.
+5. **Tiverton rollout** — separate from this PR. After release, update `tiverton-house/claw-pod.yml` on the live host with `x-claw.context.channel.since: 24h, limit: 40, buffer: 500`, run `claw up -d`, verify.
+
+## 7. Tests
+
+### claw-wall (`cmd/claw-wall/`)
+- `TestConsumeTailReturnsLatestIdempotent` — store has 100/101/102, repeated `consumeTail{limit:2}` returns 101,102 every time.
+- `TestConsumeTailFiltersBySinceWindow` — messages spanning 0–48h, `since=24h` returns only the recent half.
+- `TestConsumeTailRespectsMaxChars` — single 9KB message + smaller messages; `max_chars=8KB` excludes the giant one and truncates by bytes, not just count.
+- `TestConsumeTailDoesNotMutateCursor` — interleave delta and tail consumers; tail fetches don't move the delta consumer's cursor.
+- `TestConsumeDeltaPreservesExistingPagination` — keeps current `100,101 → 102` behavior verbatim (rename of existing test).
+- `TestChannelContextHandlerTailModeIsDefault` — hit `/channel-context` with no `mode` → tail mode header, no cursor advance.
+- `TestChannelContextHandlerDeltaMode` — `mode=delta` returns existing format with no coverage header (regression).
+- `TestChannelContextHandlerCoverageHeaderShape` — header line parses, contains expected fields, `range` reflects actual oldest/newest in the result.
+- `TestChannelContextHandlerCoverageHeaderTruncation` — when limit fires, header reads `retained=N/M` with M > N; when window-bounded full set returned, `retained=N/since-24h`; when buffer is the limit, `retained=N/buffer`.
+
+### compose_up (`cmd/claw/`)
+- `TestAppendConversationWallFeedTailMode` — generated feed path includes `mode=tail&since=24h&limit=40&max_chars=8192` by default.
+- `TestAppendConversationWallFeedHonorsPodConfig` — pod-level `x-claw.context.channel` overrides flow into the path.
+- `TestConversationWallServiceUsesPodBuffer` — pod-level `buffer` flows into wall service `CLAW_WALL_LIMIT` env.
+
+### pod parser (`internal/pod/`)
+- `TestParseClawContextChannel` — accepts `since`/`limit`/`max_chars`/`buffer`, rejects negatives, rejects unparseable durations.
+- `TestPodDefaultsContextChannel` — service-level `x-claw.context.channel` overrides pod defaults using the standard pattern.
+
+## 8. Open questions for design challenge
+
+1. **Coverage header format** — single line vs. multi-line vs. JSON sidecar response? I picked single-line for cache-friendliness and minimal token cost; flag if you'd rather have it as a separate JSON metadata line so consumers can parse.
+2. **Buffer-as-pod-config name** — `x-claw.context.channel.buffer` is a bit indirect (it's really claw-wall ring-buffer size). Alternative: keep it as a claw-wall sidecar env override the operator sets directly, and don't surface it through pod-yml. I lean toward surfacing it (operators shouldn't need to know about claw-wall as an env-var contract), but flag if you'd rather defer.
+3. **`since` lower bound** — should we reject `since < 1m` to prevent agents from accidentally requesting 5-second windows? Or trust the value? I lean trust + clamp at zero.
+4. **`max_chars` interaction with cllama's `MaxFeedResponseBytes`** — are we double-truncating? Verify `MaxFeedResponseBytes` value and confirm 8KB is at or below it. If cllama caps lower, drop our default to match.
+5. **Tail rendering sort order** — ASC (oldest at top, newest at bottom = like reading a chat log) vs. DESC (newest at top, "latest first" framing). I picked ASC because it matches the current format and how humans read Discord. Flag if reverse-chrono is better for prompt locality.
+
+## 9. Acceptance criteria mapping (from issue body)
+
+| Issue criterion | This plan |
+|---|---|
+| Mention sees latest channel messages immediately preceding the mention | `mode=tail` returns newest-first walk, sorted ASC, no cursor effect |
+| Repeated quiet-period fetches show recent context, not draining backlog | `consumeTail` is pure-read, no cursor mutation; identical body across quiet fetches |
+| Backlog does not hide current conversation | Newest-first walk with dual cap; latest always present |
+| Agents only receive their configured surface-derived channels | Unchanged from today; channel filtering happens upstream of claw-wall |
+| If the last 24h exceeds context cap, summary + latest full | **Partially deferred:** v1 caps and signals truncation in the header; LLM summarization is the salience-memory adapter's job, not claw-wall's |
+| Tests cover both modes | Yes (see §7) |
+
+## 10. Out of this PR
+
+- Tiverton pod-yml update (separate change on the host after release).
+- Salience-memory adapter integration that could replace the older end of the channel transcript with a stable summary block.
+- Backfill from Discord history.
+- Renaming `claw-wall` (the name is reserved and stable).

--- a/internal/pod/parser.go
+++ b/internal/pod/parser.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -26,6 +27,7 @@ type rawPodClaw struct {
 	Master                string                 `yaml:"master"`
 	SequentialConformance bool                   `yaml:"sequential-conformance"`
 	HandlesDefaults       map[string]interface{} `yaml:"handles-defaults"`
+	Context               *rawContextConfig      `yaml:"context"`
 	Principals            []rawPrincipalEntry    `yaml:"principals"`
 	AlertWebhooks         []string               `yaml:"alert-webhooks"`
 	AlertMentions         []string               `yaml:"alert-mentions"`
@@ -73,8 +75,21 @@ type rawClawBlock struct {
 	Surfaces     []interface{}          `yaml:"surfaces"`
 	Skills       []string               `yaml:"skills"`
 	Invoke       []rawInvokeEntry       `yaml:"invoke"`
+	Context      *rawContextConfig      `yaml:"context"`
 	ClawAPI      interface{}            `yaml:"claw-api"`
 	MCPStdio     *rawMCPStdioBlock      `yaml:"mcp-stdio"`
+}
+
+type rawContextConfig struct {
+	Channel *rawChannelContextConfig `yaml:"channel"`
+}
+
+type rawChannelContextConfig struct {
+	Since              string `yaml:"since"`
+	Limit              int    `yaml:"limit"`
+	MaxCharsHyphen     int    `yaml:"max-chars"`
+	MaxCharsUnderscore int    `yaml:"max_chars"`
+	Buffer             int    `yaml:"buffer"`
 }
 
 type rawMCPStdioBlock struct {
@@ -146,6 +161,11 @@ func Parse(r io.Reader) (*Pod, error) {
 		AlertWebhooks:         raw.XClaw.AlertWebhooks,
 		AlertMentions:         raw.XClaw.AlertMentions,
 	}
+	contextConfig, err := parseContextConfig(raw.XClaw.Context)
+	if err != nil {
+		return nil, fmt.Errorf("x-claw.context: %w", err)
+	}
+	pod.Context = contextConfig
 
 	rawServices, err := mapStringAny(root["services"])
 	if err != nil {
@@ -245,6 +265,10 @@ func Parse(r io.Reader) (*Pod, error) {
 			if err != nil {
 				return nil, fmt.Errorf("service %q: parse memory: %w", name, err)
 			}
+			contextConfig, err := parseContextConfig(svc.XClaw.Context)
+			if err != nil {
+				return nil, fmt.Errorf("service %q: context: %w", name, err)
+			}
 			mcpStdio, err := parseMCPStdio(name, svc.XClaw.MCPStdio, svc.XClaw.Agent, cllama, count)
 			if err != nil {
 				return nil, err
@@ -286,6 +310,7 @@ func Parse(r io.Reader) (*Pod, error) {
 				Surfaces:     parsedSurfaces,
 				Skills:       skills,
 				Invoke:       invoke,
+				Context:      contextConfig,
 				ClawAPIMode:  clawAPIMode,
 				MCPStdio:     mcpStdio,
 			}
@@ -596,6 +621,65 @@ func parseMemory(raw *rawMemoryEntry) (*MemoryEntry, error) {
 		Service:   service,
 		TimeoutMS: timeoutMS,
 	}, nil
+}
+
+func parseContextConfig(raw *rawContextConfig) (*ContextConfig, error) {
+	if raw == nil {
+		return nil, nil
+	}
+
+	channel, err := parseChannelContextConfig(raw.Channel)
+	if err != nil {
+		return nil, fmt.Errorf("channel: %w", err)
+	}
+	if channel == nil {
+		return &ContextConfig{}, nil
+	}
+	return &ContextConfig{Channel: channel}, nil
+}
+
+func parseChannelContextConfig(raw *rawChannelContextConfig) (*ChannelContextConfig, error) {
+	if raw == nil {
+		return nil, nil
+	}
+
+	since := strings.TrimSpace(raw.Since)
+	if since != "" {
+		d, err := time.ParseDuration(since)
+		if err != nil || d < 0 {
+			return nil, fmt.Errorf("since must be a non-negative duration")
+		}
+	}
+	if raw.Limit < 0 {
+		return nil, fmt.Errorf("limit must be >= 0")
+	}
+	if raw.Buffer < 0 {
+		return nil, fmt.Errorf("buffer must be >= 0")
+	}
+	maxChars, err := selectChannelContextMaxChars(raw.MaxCharsHyphen, raw.MaxCharsUnderscore)
+	if err != nil {
+		return nil, err
+	}
+	if maxChars < 0 {
+		return nil, fmt.Errorf("max-chars must be >= 0")
+	}
+
+	return &ChannelContextConfig{
+		Since:    since,
+		Limit:    raw.Limit,
+		MaxChars: maxChars,
+		Buffer:   raw.Buffer,
+	}, nil
+}
+
+func selectChannelContextMaxChars(hyphen, underscore int) (int, error) {
+	if hyphen != 0 && underscore != 0 && hyphen != underscore {
+		return 0, fmt.Errorf("max-chars and max_chars cannot both be set to different values")
+	}
+	if hyphen != 0 {
+		return hyphen, nil
+	}
+	return underscore, nil
 }
 
 func parseMCPStdio(serviceName string, raw *rawMCPStdioBlock, agent string, cllama []string, count int) (*MCPStdioBlock, error) {

--- a/internal/pod/parser_context_test.go
+++ b/internal/pod/parser_context_test.go
@@ -1,0 +1,127 @@
+package pod
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParsePodContextChannel(t *testing.T) {
+	p, err := Parse(strings.NewReader(`
+x-claw:
+  context:
+    channel:
+      since: 24h
+      limit: 40
+      max-chars: 8192
+      buffer: 500
+services:
+  trader:
+    image: example/trader:latest
+    x-claw:
+      agent: ./AGENTS.md
+      context:
+        channel:
+          since: 2h
+          limit: 12
+          max_chars: 4096
+`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if p.Context == nil || p.Context.Channel == nil {
+		t.Fatal("expected pod channel context config")
+	}
+	if got := p.Context.Channel.Since; got != "24h" {
+		t.Fatalf("pod since = %q", got)
+	}
+	if got := p.Context.Channel.Limit; got != 40 {
+		t.Fatalf("pod limit = %d", got)
+	}
+	if got := p.Context.Channel.MaxChars; got != 8192 {
+		t.Fatalf("pod max chars = %d", got)
+	}
+	if got := p.Context.Channel.Buffer; got != 500 {
+		t.Fatalf("pod buffer = %d", got)
+	}
+
+	trader := p.Services["trader"]
+	if trader == nil || trader.Claw == nil || trader.Claw.Context == nil || trader.Claw.Context.Channel == nil {
+		t.Fatal("expected service channel context config")
+	}
+	if got := trader.Claw.Context.Channel.Since; got != "2h" {
+		t.Fatalf("service since = %q", got)
+	}
+	if got := trader.Claw.Context.Channel.Limit; got != 12 {
+		t.Fatalf("service limit = %d", got)
+	}
+	if got := trader.Claw.Context.Channel.MaxChars; got != 4096 {
+		t.Fatalf("service max chars = %d", got)
+	}
+}
+
+func TestParsePodContextChannelRejectsInvalidValues(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "bad since",
+			yaml: `
+x-claw:
+  context:
+    channel:
+      since: later
+services:
+  trader:
+    image: example/trader:latest
+    x-claw:
+      agent: ./AGENTS.md
+`,
+			want: "since",
+		},
+		{
+			name: "negative limit",
+			yaml: `
+x-claw:
+  context:
+    channel:
+      limit: -1
+services:
+  trader:
+    image: example/trader:latest
+    x-claw:
+      agent: ./AGENTS.md
+`,
+			want: "limit",
+		},
+		{
+			name: "conflicting max chars aliases",
+			yaml: `
+x-claw:
+  context:
+    channel:
+      max-chars: 2048
+      max_chars: 4096
+services:
+  trader:
+    image: example/trader:latest
+    x-claw:
+      agent: ./AGENTS.md
+`,
+			want: "max-chars",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse(strings.NewReader(tc.yaml))
+			if err == nil {
+				t.Fatal("expected parse error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+}

--- a/internal/pod/types.go
+++ b/internal/pod/types.go
@@ -14,6 +14,7 @@ type Pod struct {
 	Compose               map[string]interface{} // preserved top-level compose keys except x-claw and services
 	ClawAPI               *ClawAPIConfig
 	Clawdash              *ClawdashConfig // runtime-only dashboard sidecar config, injected by claw up
+	Context               *ContextConfig
 	Principals            []PodPrincipal
 	AlertWebhooks         []string // pod-scoped Discord webhook URLs for pool-transition alerts
 	AlertMentions         []string // pod-scoped @-mention targets for alerts (e.g. "@wojtek", "@infra")
@@ -64,6 +65,7 @@ type ClawBlock struct {
 	Surfaces     []driver.ResolvedSurface
 	Skills       []string
 	Invoke       []InvokeEntry
+	Context      *ContextConfig
 	ClawAPIMode  string // "self" when claw-api: self is declared; empty otherwise
 	MCPStdio     *MCPStdioBlock
 }
@@ -101,6 +103,17 @@ type ToolPolicyEntry struct {
 type MemoryEntry struct {
 	Service   string
 	TimeoutMS int
+}
+
+type ContextConfig struct {
+	Channel *ChannelContextConfig
+}
+
+type ChannelContextConfig struct {
+	Since    string
+	Limit    int
+	MaxChars int
+	Buffer   int
 }
 
 type IncludeEntry struct {

--- a/site/changelog.md
+++ b/site/changelog.md
@@ -29,7 +29,7 @@ outline: deep
 
 ## Unreleased
 
-<!-- Nothing yet -->
+- Fix: `claw-wall` channel context now defaults to a non-consuming recent tail (`mode=tail`) instead of draining the oldest unread backlog for Discord invocation context ([#201](https://github.com/mostlydev/clawdapus/issues/201)). Generated feeds use a 24h window with dual caps (`limit=40`, `max_chars=8192`) and explicit coverage metadata, while legacy cursor paging remains available as `mode=delta`. Pods can tune the tail with `x-claw.context.channel`.
 
 ## v0.13.6 <Badge type="tip" text="Latest" /> {#v0-13-6}
 

--- a/skills/clawdapus/SKILL.md
+++ b/skills/clawdapus/SKILL.md
@@ -387,7 +387,7 @@ The proxy sits between agents and LLM providers. Agents get bearer tokens, proxy
 
 ### claw-wall sidecar
 
-Auto-injected by `claw up` when any cllama-enabled service has Discord channel IDs. Polls Discord channels and serves incremental message history to agents. Per-consumer cursors ensure agents only see new messages since their last turn. The service name `claw-wall` is reserved — declaring it in `claw-pod.yml` is a hard error.
+Auto-injected by `claw up` when any cllama-enabled service has Discord channel IDs. Polls Discord channels and serves the recent channel transcript to agents through `channel-context` tail feeds; legacy unread-mailbox cursor paging remains available as `mode=delta`. Configure the generated tail window with pod or service `x-claw.context.channel` (`since`, `limit`, `max-chars`, `buffer`). The service name `claw-wall` is reserved — declaring it in `claw-pod.yml` is a hard error.
 
 ## Generated Artifacts
 


### PR DESCRIPTION
## Summary

- Switches `claw-wall`'s `/channel-context` default from cursor-paged `delta` to a non-consuming `tail` mode so Discord-mention agents see the recent room transcript (the messages that prompted them) instead of draining oldest unread backlog.
- Adds dual-cap selection (`limit` count + `max_chars` bytes, whichever fires first; the single newest message is always preserved even if it exceeds `max_chars`) plus a stable one-line coverage header so silent gaps are visible inside the prompt.
- Plumbs pod/service-level `x-claw.context.channel: { since, limit, max-chars, buffer }` so operators can tune the generated tail; `buffer` flows into the auto-injected wall sidecar's `CLAW_WALL_LIMIT` (default bumped 50 → 500). Discord fetch limit is clamped to the API max of 100.
- Keeps `mode=delta` callable for any caller that genuinely wants mailbox semantics; the existing cursor/quiet-period regression is preserved verbatim.

## Why

Tiverton incident captured in #201: an agent's prompt contained a `channel-context` block, but the messages were the next page of unread backlog — not the conversation immediately before the mention. Cause was `cmd/claw-wall/store.go` truncating with `collected[:limit]` (oldest first) and advancing the cursor on every fetch, so each turn drained backlog forward instead of reading the latest tail.

Wider continuity is already covered by the trading-api feeds (`agent-scaffold` daily, `desk-chronicle` daily, `agent-memory` 10min). `channel-context` only needs to be the recent room transcript — no summarization belongs in `claw-wall`. (Salience-memory adapter, in-flight under `docs/plans/2026-04-29-salience-memory-adapter.md`, owns the wider compression story.)

## Notes for the maintainer

- No release-pin or infra-image-version changes. Changelog entry is in `## Unreleased`, no Latest badge.
- Tiverton pod-yml update is intentionally out of scope; after release, the host `tiverton-house/claw-pod.yml` should pick up `x-claw.context.channel.{since: 24h, limit: 40, buffer: 500}` and re-run `claw up -d`.
- Plan doc at `docs/plans/2026-04-29-issue-201-channel-context-tail-mode.md` captures the design and the answers to the three open questions codex raised at the start of the turn.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go test -tags integration ./...`
- [x] New focused tests pass: `go test -v -run 'Tail|TestChannelContextHandler|TestParsePodContextChannel|TestInjectConversationWall|TestConversationStoreConsumeDelta|TestConversationStoreTail' ./cmd/claw-wall/... ./cmd/claw/... ./internal/pod/...`
- [ ] `go test -tags spike -run TestSpikeRollCall ./cmd/claw/...` (not run in PR — covered by release skill before tagging)
- [ ] Manual verification on tiverton-house after release: fetch `channel-context` and confirm latest room messages are included

Closes #201