### PR TITLE
fix: picoclaw driver emits gateway defaults

### DIFF
--- a/examples/rollcall/Dockerfile.picoclaw-base
+++ b/examples/rollcall/Dockerfile.picoclaw-base
@@ -8,7 +8,7 @@ FROM golang:1.25-alpine AS builder
 RUN apk add --no-cache git make
 
 WORKDIR /src
-RUN git clone --depth 1 https://github.com/sipeed/picoclaw.git .
+RUN git clone --depth 1 --branch v0.2.7 https://github.com/sipeed/picoclaw.git .
 RUN mkdir -p workspace && make build VERSION=dev
 
 FROM alpine:3.23

--- a/internal/driver/picoclaw/config.go
+++ b/internal/driver/picoclaw/config.go
@@ -14,6 +14,8 @@ import (
 const (
 	picoclawHomeDir      = "/home/picoclaw/.picoclaw"
 	picoclawWorkspaceDir = "/home/picoclaw/.picoclaw/workspace"
+	picoclawGatewayHost  = "localhost"
+	picoclawGatewayPort  = 18790
 )
 
 var supportedPlatforms = []string{
@@ -60,6 +62,12 @@ func GenerateConfig(rc *driver.ResolvedClaw) ([]byte, error) {
 		return nil, fmt.Errorf("config generation: %w", err)
 	}
 	if err := shared.SetPath(config, "agents.defaults.workspace", picoclawWorkspaceDir); err != nil {
+		return nil, fmt.Errorf("config generation: %w", err)
+	}
+	if err := shared.SetPath(config, "gateway.host", picoclawGatewayHost); err != nil {
+		return nil, fmt.Errorf("config generation: %w", err)
+	}
+	if err := shared.SetPath(config, "gateway.port", picoclawGatewayPort); err != nil {
 		return nil, fmt.Errorf("config generation: %w", err)
 	}
 

--- a/internal/driver/picoclaw/config_test.go
+++ b/internal/driver/picoclaw/config_test.go
@@ -132,6 +132,42 @@ func TestGenerateConfigCllamaRewrite(t *testing.T) {
 	}
 }
 
+func TestGenerateConfigEmitsGatewayBlock(t *testing.T) {
+	rc := &driver.ResolvedClaw{
+		Models: map[string]string{"primary": "anthropic/claude-sonnet-4"},
+	}
+
+	data, err := GenerateConfig(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v, _ := getPath(data, "gateway.host"); v != picoclawGatewayHost {
+		t.Fatalf("unexpected gateway.host: %v", v)
+	}
+	if v, _ := getPath(data, "gateway.port"); v != float64(picoclawGatewayPort) {
+		t.Fatalf("unexpected gateway.port: %v", v)
+	}
+}
+
+func TestGenerateConfigGatewayOverridableViaConfigure(t *testing.T) {
+	rc := &driver.ResolvedClaw{
+		Models: map[string]string{"primary": "anthropic/claude-sonnet-4"},
+		Configures: []string{
+			"picoclaw config set gateway.port 19000",
+		},
+	}
+
+	data, err := GenerateConfig(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v, _ := getPath(data, "gateway.port"); v != float64(19000) {
+		t.Fatalf("expected gateway.port override from CONFIGURE, got %v", v)
+	}
+}
+
 func TestGenerateConfigHandleMappings(t *testing.T) {
 	rc := &driver.ResolvedClaw{
 		Models: map[string]string{"primary": "anthropic/claude-sonnet-4"},


### PR DESCRIPTION
## Summary

- `internal/driver/picoclaw/config.go` now emits `gateway.host=localhost` and `gateway.port=18790` so picoclaw's `preCheckConfig` (which rejects `Port <= 0`) sees a valid port instead of the Go zero value. Operator `CONFIGURE picoclaw config set gateway.port ...` still wins because CONFIGURE runs after.
- `examples/rollcall/Dockerfile.picoclaw-base` pins the upstream clone to `--branch v0.2.7` so the spike fixture stops drifting on upstream HEAD.
- Added unit tests for baseline gateway emission and CONFIGURE override.

Plan: `docs/plans/2026-04-29-issue-137-picoclaw-gateway-port.md` (drafted by Claude, design accepted by Codex via talking-stick, implementation by Codex, verified + released by Claude).

Closes #137

## Test plan

- [x] `go vet ./...`
- [x] `go test ./...`
- [ ] `go test -tags spike -run 'TestSpikeRollCall/picoclaw' ./cmd/claw/...` (manual, requires provider creds — operator gate)