### PR TITLE
Hermes silent-final opt-in + hermes-base upstream bump (v0.14.4)

### DIFF
--- a/cmd/claw/hermes_base_image_test.go
+++ b/cmd/claw/hermes_base_image_test.go
@@ -42,7 +42,6 @@ func TestHermesBaseImageSourceContract(t *testing.T) {
 		`DEFAULT_AGENT_IDENTITY = (`,
 		`not stored_prompt.startswith(default_identity)`,
 		`shutil.copy("/tmp/minisweagent_path.py", purelib / "minisweagent_path.py")`,
-		`discord.AllowedMentions(replied_user=False)`,
 		`HERMES_TOOL_ONLY_MODE`,
 		`_claw_turn_sent_message`,
 		`Suppressing duplicate final text after send_message`,
@@ -52,6 +51,7 @@ func TestHermesBaseImageSourceContract(t *testing.T) {
 		`_HERMES_CORE_TOOLS = _claw_filter_tools(_HERMES_CORE_TOOLS)`,
 		`HERMES_ALLOW_SILENT_FINAL`,
 		`Silent final enabled; treating empty-after-think response as completed no-op`,
+		`intents.voice_states = False`,
 	} {
 		if !strings.Contains(patch, want) {
 			t.Fatalf("Hermes runtime patch missing %q", want)

--- a/cmd/claw/hermes_base_image_test.go
+++ b/cmd/claw/hermes_base_image_test.go
@@ -50,6 +50,8 @@ func TestHermesBaseImageSourceContract(t *testing.T) {
 		`CLAWDAPUS_DISABLED_TOOLS`,
 		`_claw_filter_tools`,
 		`_HERMES_CORE_TOOLS = _claw_filter_tools(_HERMES_CORE_TOOLS)`,
+		`HERMES_ALLOW_SILENT_FINAL`,
+		`Silent final enabled; treating empty-after-think response as completed no-op`,
 	} {
 		if !strings.Contains(patch, want) {
 			t.Fatalf("Hermes runtime patch missing %q", want)

--- a/cmd/claw/hermes_base_spike_test.go
+++ b/cmd/claw/hermes_base_spike_test.go
@@ -70,7 +70,7 @@ assert not prompt.startswith("You are Hermes Agent"), prompt[:200]
 
 source = inspect.getsource(run_agent.AIAgent)
 assert "_already_used_tools_this_turn" in source
-assert "sanitized_messages[_last_user_index + 1 :]" in source
+assert "api_messages[_last_user_index + 1 :]" in source
 assert "HERMES_ALLOW_SILENT_FINAL" in source
 assert "Silent final enabled; treating empty-after-think response as completed no-op" in source
 assert '"completed": True' in source

--- a/cmd/claw/hermes_base_spike_test.go
+++ b/cmd/claw/hermes_base_spike_test.go
@@ -71,6 +71,9 @@ assert not prompt.startswith("You are Hermes Agent"), prompt[:200]
 source = inspect.getsource(run_agent.AIAgent)
 assert "_already_used_tools_this_turn" in source
 assert "sanitized_messages[_last_user_index + 1 :]" in source
+assert "HERMES_ALLOW_SILENT_FINAL" in source
+assert "Silent final enabled; treating empty-after-think response as completed no-op" in source
+assert '"completed": True' in source
 
 from gateway.run import GatewayRunner
 assert GatewayRunner._claw_turn_sent_message([

--- a/dockerfiles/hermes-base/Dockerfile
+++ b/dockerfiles/hermes-base/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
 ARG GIT_REVISION=unknown
 ARG CLAW_SOURCE=local-checkout
 ARG CLAW_DIRTY=true
-ARG HERMES_UPSTREAM_TAG=v2026.3.17
+ARG HERMES_UPSTREAM_TAG=v2026.4.23
 
 LABEL claw.component="hermes-base" \
       org.opencontainers.image.revision="${GIT_REVISION}" \

--- a/dockerfiles/hermes-base/patch-hermes-runtime.py
+++ b/dockerfiles/hermes-base/patch-hermes-runtime.py
@@ -259,6 +259,24 @@ text = replace_once(
     '            api_kwargs.update(self._max_tokens_param(self.max_tokens))',
     "run_agent tool_choice=required per turn in tool-only mode",
 )
+text = replace_once(
+    text,
+    '                    if not self._has_content_after_think_block(final_response):\n',
+    '                    if not self._has_content_after_think_block(final_response):\n'
+    '                        if os.getenv("HERMES_ALLOW_SILENT_FINAL") == "1":\n'
+    '                            logger.debug("Silent final enabled; treating empty-after-think response as completed no-op")\n'
+    '                            self._empty_content_retries = 0\n'
+    '                            self._cleanup_task_resources(effective_task_id)\n'
+    '                            self._persist_session(messages, conversation_history)\n'
+    '                            return {\n'
+    '                                "final_response": None,\n'
+    '                                "messages": messages,\n'
+    '                                "api_calls": api_call_count,\n'
+    '                                "completed": True,\n'
+    '                                "partial": False,\n'
+    '                            }\n',
+    "run_agent silent final opt-in",
+)
 run_agent.write_text(text)
 
 gateway_run = purelib / "gateway" / "run.py"

--- a/dockerfiles/hermes-base/patch-hermes-runtime.py
+++ b/dockerfiles/hermes-base/patch-hermes-runtime.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Apply small compatibility fixes to the pinned Hermes install."""
+"""Apply small compatibility fixes to the pinned Hermes install.
+
+Each patch goes through ``replace_once`` so the docker build fails loud when
+upstream drift moves a target string. When a patch becomes obsolete because
+upstream merged the equivalent fix, delete the patch instead of reshaping it
+to match — every line we don't carry is technical debt we don't pay back.
+"""
 
 from __future__ import annotations
 
@@ -49,89 +55,26 @@ text = replace_once(
 )
 prompt_builder.write_text(text)
 
+# Discord intents: voice_states stays True upstream; we never use it and it
+# requires elevated bot privileges. members is conditional upstream now and
+# resolves to False for our pods (numeric DISCORD_ALLOWED_USERS, no roles),
+# so the previous unconditional False patch is obsolete and dropped.
 discord_adapter = purelib / "gateway" / "platforms" / "discord.py"
 text = discord_adapter.read_text()
-text = replace_once(
-    text,
-    "            intents.members = True\n",
-    "            intents.members = False\n",
-    "discord members intent",
-)
 text = replace_once(
     text,
     "            intents.voice_states = True\n",
     "            intents.voice_states = False\n",
     "discord voice intent",
 )
-text = replace_once(
-    text,
-    # The blank line between _resolve_allowed_usernames and # Sync slash commands
-    # has 16 spaces of trailing whitespace in the upstream source.
-    "                # Resolve any usernames in the allowed list to numeric IDs\n"
-    "                await adapter_self._resolve_allowed_usernames()\n"
-    "                \n"
-    "                # Sync slash commands with Discord\n"
-    "                try:\n"
-    "                    synced = await adapter_self._client.tree.sync()\n"
-    "                    logger.info(\"[%s] Synced %d slash command(s)\", adapter_self.name, len(synced))\n"
-    "                except Exception as e:  # pragma: no cover - defensive logging\n"
-    "                    logger.warning(\"[%s] Slash command sync failed: %s\", adapter_self.name, e, exc_info=True)\n"
-    "                adapter_self._ready_event.set()\n",
-    """                # Mark the gateway ready before best-effort post-connect work.
-                adapter_self._ready_event.set()
-
-                async def finalize_startup():
-                    client = adapter_self._client
-                    if client is None:
-                        return
-
-                    # Resolve any usernames in the allowed list to numeric IDs.
-                    await adapter_self._resolve_allowed_usernames()
-
-                    # Slash-command sync can be slow on larger guilds; keep it best-effort.
-                    try:
-                        synced = await asyncio.wait_for(client.tree.sync(), timeout=20)
-                        logger.info("[%s] Synced %d slash command(s)", adapter_self.name, len(synced))
-                    except Exception as e:  # pragma: no cover - defensive logging
-                        logger.warning("[%s] Slash command sync failed: %s", adapter_self.name, e, exc_info=True)
-
-                asyncio.create_task(finalize_startup())
-""",
-    "discord ready handler",
-)
-# ── Disable reply-mentions so agent replies do not ping the original author ──
-# Discord's default is replied_user=True, which triggers mention loops in
-# multi-agent pods. We inject allowed_mentions on every channel.send that
-# carries a reference.
-text = replace_once(
-    text,
-    """                    msg = await channel.send(
-                        content=chunk,
-                        reference=chunk_reference,
-                    )""",
-    """                    msg = await channel.send(
-                        content=chunk,
-                        reference=chunk_reference,
-                        allowed_mentions=discord.AllowedMentions(replied_user=False),
-                    )""",
-    "discord reply mention (primary send)",
-)
-text = replace_once(
-    text,
-    """                        msg = await channel.send(
-                            content=chunk,
-                            reference=None,
-                        )""",
-    """                        msg = await channel.send(
-                            content=chunk,
-                            reference=None,
-                            allowed_mentions=discord.AllowedMentions(replied_user=False),
-                        )""",
-    "discord reply mention (fallback send)",
-)
 discord_adapter.write_text(text)
 
-# ── Tool-only mode: prefer send_message without dropping final text ──────────
+# Reply-mention auto-pings (replied_user=True default in `_build_allowed_mentions`)
+# are now controlled by the env var DISCORD_ALLOW_MENTION_REPLIED_USER. The
+# Hermes driver sets it to "false" by default for any Discord-enabled service,
+# so the old per-channel.send patches are obsolete and dropped.
+
+# Tool-only mode: prefer send_message without dropping final text.
 # HERMES_TOOL_ONLY_MODE makes send_message the preferred visible-delivery path.
 # The gateway runner suppresses duplicate final text when send_message already
 # succeeded in the current turn; otherwise base delivery remains a fallback so
@@ -150,7 +93,7 @@ text = replace_once(
 )
 base_adapter.write_text(text)
 
-# ── Core tool suppression: hide disabled runtime tools from model manifests ──
+# Core tool suppression: hide disabled runtime tools from model manifests.
 # Hermes exposes text_to_speech in its Discord core toolset when edge_tts is
 # importable. Clawdapus keeps the tool registered but strips it from platform
 # toolsets when CLAWDAPUS_DISABLED_TOOLS names it.
@@ -198,12 +141,9 @@ text += (
 )
 toolsets_py.write_text(text)
 
-# ── Tool-only mode: force tool_choice=required per user turn ─────────────────
-# In HERMES_TOOL_ONLY_MODE, LLMs should start each user turn by calling a tool,
-# preferably send_message for visible communication. Force tool_choice=required
-# until the current user turn has used a tool; final text remains a fallback.
 run_agent = purelib / "run_agent.py"
 text = run_agent.read_text()
+
 # Continuing gateway sessions persist a system_prompt snapshot. If the managed
 # identity changes, rebuild the prompt instead of reusing a stale Hermes identity.
 text = replace_once(
@@ -216,49 +156,63 @@ text = replace_once(
     '                            stored_prompt = None\n',
     "run_agent stored prompt identity invalidation",
 )
+
+# Tool-only mode: force tool_choice=required per user turn.
+# Upstream now builds api_kwargs through a transport (`_ct.build_kwargs(...)`)
+# inside `_build_api_kwargs`. We capture the returned kwargs and inject
+# `tool_choice="required"` at the start of each user turn so the model must
+# call a tool (preferably send_message) before falling back to plain text.
 text = replace_once(
     text,
-    '        api_kwargs = {\n'
-    '            "model": self.model,\n'
-    '            "messages": sanitized_messages,\n'
-    '            "tools": self.tools if self.tools else None,\n'
-    '            "timeout": float(os.getenv("HERMES_API_TIMEOUT", 900.0)),\n'
-    '        }\n'
-    '\n'
-    '        if self.max_tokens is not None:\n'
-    '            api_kwargs.update(self._max_tokens_param(self.max_tokens))',
-    '        api_kwargs = {\n'
-    '            "model": self.model,\n'
-    '            "messages": sanitized_messages,\n'
-    '            "tools": self.tools if self.tools else None,\n'
-    '            "timeout": float(os.getenv("HERMES_API_TIMEOUT", 900.0)),\n'
-    '        }\n'
-    '\n'
-    '        # In tool-only mode, force tool_choice=required on the first LLM call\n'
-    '        # of each user turn. Previous turns may contain tool_calls, so only\n'
-    '        # inspect messages after the latest user message.\n'
-    '        if os.getenv("HERMES_TOOL_ONLY_MODE") and api_kwargs.get("tools"):\n'
-    '            _last_user_index = max(\n'
-    '                (\n'
-    '                    _idx\n'
-    '                    for _idx, _m in enumerate(sanitized_messages)\n'
-    '                    if isinstance(_m, dict) and _m.get("role") == "user"\n'
-    '                ),\n'
-    '                default=-1,\n'
-    '            )\n'
-    '            _already_used_tools_this_turn = any(\n'
-    '                isinstance(_m, dict)\n'
-    '                and _m.get("role") == "assistant"\n'
-    '                and _m.get("tool_calls")\n'
-    '                for _m in sanitized_messages[_last_user_index + 1 :]\n'
-    '            )\n'
-    '            if not _already_used_tools_this_turn:\n'
-    '                api_kwargs["tool_choice"] = "required"\n'
-    '\n'
-    '        if self.max_tokens is not None:\n'
-    '            api_kwargs.update(self._max_tokens_param(self.max_tokens))',
+    "        return _ct.build_kwargs(\n"
+    "            model=self.model,\n"
+    "            messages=api_messages,\n"
+    "            tools=self.tools,\n"
+    "            timeout=self._resolved_api_call_timeout(),\n",
+    "        _claw_kwargs = _ct.build_kwargs(\n"
+    "            model=self.model,\n"
+    "            messages=api_messages,\n"
+    "            tools=self.tools,\n"
+    "            timeout=self._resolved_api_call_timeout(),\n",
+    "run_agent _build_api_kwargs capture for tool-only mode",
+)
+text = replace_once(
+    text,
+    "            anthropic_max_output=_ant_max,\n"
+    "        )\n"
+    "\n"
+    "    def _supports_reasoning_extra_body(self) -> bool:\n",
+    "            anthropic_max_output=_ant_max,\n"
+    "        )\n"
+    "        # In tool-only mode, force tool_choice=required on the first LLM\n"
+    "        # call of each user turn. Inspect only messages after the latest\n"
+    "        # user message so prior turns' tool_calls do not satisfy this turn.\n"
+    "        if os.getenv(\"HERMES_TOOL_ONLY_MODE\") and _claw_kwargs.get(\"tools\"):\n"
+    "            _last_user_index = max(\n"
+    "                (\n"
+    "                    _idx\n"
+    "                    for _idx, _m in enumerate(api_messages)\n"
+    "                    if isinstance(_m, dict) and _m.get(\"role\") == \"user\"\n"
+    "                ),\n"
+    "                default=-1,\n"
+    "            )\n"
+    "            _already_used_tools_this_turn = any(\n"
+    "                isinstance(_m, dict)\n"
+    "                and _m.get(\"role\") == \"assistant\"\n"
+    "                and _m.get(\"tool_calls\")\n"
+    "                for _m in api_messages[_last_user_index + 1 :]\n"
+    "            )\n"
+    "            if not _already_used_tools_this_turn:\n"
+    "                _claw_kwargs[\"tool_choice\"] = \"required\"\n"
+    "        return _claw_kwargs\n"
+    "\n"
+    "    def _supports_reasoning_extra_body(self) -> bool:\n",
     "run_agent tool_choice=required per turn in tool-only mode",
 )
+
+# Silent-final opt-in: when HERMES_ALLOW_SILENT_FINAL=1, treat empty-after-think
+# final responses as a successful no-op turn instead of retrying. Reasoning
+# models in mention_only channels can legitimately decide to stay silent.
 text = replace_once(
     text,
     '                    if not self._has_content_after_think_block(final_response):\n',
@@ -354,11 +308,14 @@ text = replace_once(
     '        """\n',
     "gateway run send_message detection helpers",
 )
+
+# Suppress duplicate final text after send_message in tool-only mode.
+# Anchor on the agent_messages assignment which is now a few lines below the
+# `response = ...` line (upstream inserted the "(empty)" sentinel handler in
+# between).
 text = replace_once(
     text,
-    '            response = agent_result.get("final_response") or ""\n'
     '            agent_messages = agent_result.get("messages", [])\n',
-    '            response = agent_result.get("final_response") or ""\n'
     '            agent_messages = agent_result.get("messages", [])\n'
     '\n'
     '            if os.getenv("HERMES_TOOL_ONLY_MODE") and response:\n'

--- a/docs/plans/2026-04-29-hermes-silent-final.md
+++ b/docs/plans/2026-04-29-hermes-silent-final.md
@@ -1,0 +1,155 @@
+# Hermes silent-final feature (#212)
+
+Status: Drafted by Claude, pending codex design challenge before implementation.
+
+## Problem
+
+Reasoning models routed via cllama (deepseek-v4-pro, GPT-5.4, Claude thinking, etc.) may legitimately decide to think and stay silent — particularly in `mention_only` Discord channels. Upstream Hermes treats an empty-after-`<think>` final response as a generation failure, retries up to 3 times, and surfaces a Discord error message:
+
+> `Gerrard: ⚠️ Model generated only think blocks with no actual response after 3 retries`
+
+Observed live on tiverton-house with `vercel/deepseek/deepseek-v4-pro` after #210 landed.
+
+## Upstream code path (verified against hermes-base v2026.3.17-claw.4 in tiverton-house-tiverton-1)
+
+- `/opt/hermes-agent/run_agent.py:5953` — final-response branch.
+- `_has_content_after_think_block(content)` (line 884) — strips `<think>...</think>` and returns True iff non-whitespace remains.
+- `5953` if False, falls into a 3-retry loop ending at line 6038 with the user-visible `error` payload.
+
+## Scope
+
+### 1. hermes-base patch (`dockerfiles/hermes-base/patch-hermes-runtime.py`)
+
+Add a `replace_once` patch that wraps the empty-after-think branch with an `HERMES_ALLOW_SILENT_FINAL` env check. Pseudo-shape:
+
+```python
+text = replace_once(
+    text,
+    "                    if not self._has_content_after_think_block(final_response):\n",
+    "                    if not self._has_content_after_think_block(final_response):\n"
+    "                        if os.getenv(\"HERMES_ALLOW_SILENT_FINAL\") == \"1\":\n"
+    "                            self._cleanup_task_resources(effective_task_id)\n"
+    "                            self._persist_session(messages, conversation_history)\n"
+    "                            return {\n"
+    "                                \"final_response\": None,\n"
+    "                                \"messages\": messages,\n"
+    "                                \"api_calls\": api_call_count,\n"
+    "                                \"completed\": True,\n"
+    "                                \"partial\": False,\n"
+    "                            }\n",
+    "run_agent silent-final opt-out",
+)
+```
+
+Exact indent and shape will need verification against the actual upstream block — codex should confirm during implementation. The point is: when env is set, return a clean "completed silently" result that downstream code already handles (the Discord adapter already has a "no final response → nothing to send" path; we don't need to add one).
+
+`replace_once` already raises `SystemExit` on miss, so an upstream Hermes bump that moves this block fails the docker build loud.
+
+### 2. Hermes driver wiring (`internal/driver/hermes/config.go`, `internal/driver/types.go`)
+
+Extend the existing `HermesConfig` block (already used for `AllowTools`):
+
+```go
+// internal/driver/types.go
+type HermesConfig struct {
+    AllowTools  []string
+    AllowSilent bool   // NEW
+}
+```
+
+Pod parser additions in `internal/pod/parser_hermes.go` (mirrors the existing `allow-tools` parsing). Pod YAML:
+
+```yaml
+x-claw:
+  agent: gerrard
+  hermes:
+    allow-silent: true
+```
+
+Driver wiring in `config.go`: if `rc.Hermes != nil && rc.Hermes.AllowSilent`, set `HERMES_ALLOW_SILENT_FINAL=1` in the rendered env. Add the env name to `allowedEnvPassthroughKeys()` so it reaches the agent runtime via the `.env` file.
+
+### 3. hermes-base image bump
+
+New tag: `v2026.3.17-claw.5`. Build + multi-arch push:
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -t ghcr.io/mostlydev/hermes-base:v2026.3.17-claw.5 \
+  --push dockerfiles/hermes-base/
+```
+
+Bump `DefaultHermesBaseTag` in `internal/infraimages/release_manifest.go`.
+
+### 4. Tests
+
+- **Unit (driver)**: `TestMaterializeWritesAllowSilentEnv` — `HermesConfig{AllowSilent: true}` produces `HERMES_ALLOW_SILENT_FINAL=1` in compose env. Mirrors `TestMaterializeHonorsHermesAllowToolsOptIn`.
+- **Unit (parser)**: `TestParseHermesAllowSilent` — pod YAML `hermes.allow-silent: true` parses into `HermesConfig.AllowSilent`. Mirrors `TestParseHermesAllowTools`.
+- **Spike contract**: extend `TestSpikeHermesBaseImageContract` to `grep -F` the env check inside the patched image's `run_agent.py`. This ensures the patch actually applied — fail loud if upstream drift breaks the string match.
+
+### 5. Docs
+
+- `site/changelog.md` v0.14.4 entry (single bullet).
+- `site/guide/pod-yaml.md` and `site/guide/clawfile.md` if they list `x-claw.hermes` fields. Otherwise minimal addition only where the structure is documented.
+- CLAUDE.md gotcha: optional one-liner mentioning the new env passthrough key. Codex's call.
+
+## Out of scope
+
+- **Default-on behavior.** This is opt-in. Existing pods see no change.
+- **Cllama-layer silence detection.** Violates the "cllama is pure passthrough" gotcha. Hermes-side patch is correct.
+- **Other runners' empty-response handling.** OpenClaw, nanoclaw, etc. have their own runtime models; out of scope here.
+- **Per-channel silence policy.** All-or-nothing per service. Operators wanting nuance can use multiple service identities.
+
+## Upstream PR
+
+Open in parallel: PR to hermes-agent that adds `HERMES_ALLOW_SILENT_FINAL` upstream (same env name). When merged + released, we delete the `replace_once` patch. Until then, we carry it.
+
+## Risks
+
+- **Indent/whitespace mismatch.** `replace_once` is exact. Codex must `cat -A` the upstream snippet to confirm trailing whitespace before writing the patch. We've been bitten by this before (slash-command sync patch noted "16 spaces of trailing whitespace").
+- **Wrong return shape.** The empty-final branch lower in the file (lines 6021-6041) shows the canonical "completed=False, partial=True, error=..." shape used today. We want `completed=True, partial=False, final_response=None`. Verify Hermes Discord adapter doesn't barf on `final_response: None`. Quick read of `cleanup`/`persist` paths should confirm.
+- **Persistence side effects.** `_persist_session` is called in the existing failure path. We should call it on the success-silent path too so session history reflects the silent turn. Codex confirms.
+
+## Test matrix
+
+| Layer | Test | Expectation |
+|-------|------|-------------|
+| Unit | `TestParseHermesAllowSilent` (new) | parser populates `HermesConfig.AllowSilent` |
+| Unit | `TestMaterializeWritesAllowSilentEnv` (new) | driver emits `HERMES_ALLOW_SILENT_FINAL=1` |
+| Unit | existing hermes parser/driver tests | unchanged, still green |
+| Vet | `go vet ./...` | green |
+| Spike | `TestSpikeHermesBaseImageContract` (extended) | image contains the env check string |
+| Manual | tiverton-house: gerrard with `allow-silent: true` and a reasoning model in `mention_only` channel | non-mentioned messages produce no Discord error |
+
+## Release coordination
+
+This is a hermes-base + clawdapus release.
+
+1. Build + push `ghcr.io/mostlydev/hermes-base:v2026.3.17-claw.5` from `dockerfiles/hermes-base/`. Verify with `TestSpikeHermesBaseImageContract`.
+2. Bump `DefaultHermesBaseTag` in `internal/infraimages/release_manifest.go`.
+3. Cut clawdapus patch release (e.g. `v0.14.4`). Lockstep images (claw-api/clawdash/claw-wall/claw-mcp-stdio) can be retagged from v0.14.3 via `docker buildx imagetools create` since no infra code changed — same pattern as v0.14.3.
+4. Apply on tiverton-house: add `hermes: { allow-silent: true }` to the relevant services (tiverton, gerrard, dundas, weston, allen — wherever the operator wants silence semantics), `claw up -d`.
+
+## Open questions for codex
+
+1. **`HERMES_ALLOW_SILENT_FINAL` semantics**: only `=1`, or accept truthy strings (`true`, `yes`)? Proposal: only `=1` — simpler, matches `os.getenv(...) == "1"` pattern already used in our patches.
+2. **Per-pod default vs per-service only**: should pod-level `x-claw.hermes-defaults: { allow-silent: true }` work? Proposal: yes, follows the existing defaults+override pattern, but we don't need the defaults wiring to land in this issue if the parser can be extended later. v1 = service-level only is fine.
+3. **Logging**: should the patch emit a `[silent-final]` debug log line when it kicks in? Proposal: yes, single `logger.debug` so operators can confirm via `docker logs`.
+4. **Spike-test method**: for `TestSpikeHermesBaseImageContract`, do we copy the patched file out via `docker cp` and grep, or `docker run --rm <image> python -c 'import inspect; ...'`? Proposal: `docker cp` is simpler and matches existing spike test patterns.
+5. **Upstream PR timing**: open before or after merging our patch? Proposal: after — we know our patch works first, then upstream PR with prose explaining the use case (multi-agent rooms, mention-only policies, reasoning models).
+
+## Workflow
+
+- Plan drafted by Claude (this doc).
+- Codex: design challenge in a talking-stick note. If consensus, proceed to implementation.
+- Codex implements: `patch-hermes-runtime.py`, `internal/driver/hermes/config.go`, `internal/driver/types.go`, `internal/pod/parser_hermes.go`, tests, docker build. Commits on a branch, opens PR.
+- Claude: tests, merges PR, builds + pushes hermes-base image, bumps `DefaultHermesBaseTag`, cuts clawdapus release, applies on tiverton-house.
+
+## Acceptance
+
+- `go test ./internal/driver/hermes/...` and `go test ./internal/pod/...` green with new tests.
+- `go vet ./...` green.
+- Spike `TestSpikeHermesBaseImageContract` green against the new image.
+- hermes-base v2026.3.17-claw.5 published; `DefaultHermesBaseTag` bumped; clawdapus release cut.
+- Tiverton manual test: silent agents in mention_only channel produce no Discord error.
+- Issue #212 closes via PR body keyword.

--- a/internal/driver/hermes/baseimage.go
+++ b/internal/driver/hermes/baseimage.go
@@ -1,7 +1,7 @@
 package hermes
 
-const UpstreamTag = "v2026.3.17"
+const UpstreamTag = "v2026.4.23"
 
-const BaseImageVersion = UpstreamTag + "-claw.4"
+const BaseImageVersion = UpstreamTag + "-claw.1"
 
 var BaseImageTag = "ghcr.io/mostlydev/hermes-base:" + BaseImageVersion

--- a/internal/driver/hermes/config.go
+++ b/internal/driver/hermes/config.go
@@ -19,6 +19,7 @@ const (
 	hermesWorkspaceDir            = "/workspace"
 	hermesPersonaDir              = "/persona"
 	hermesDefaultAgentIdentityEnv = "HERMES_DEFAULT_AGENT_IDENTITY"
+	hermesAllowSilentFinalEnv     = "HERMES_ALLOW_SILENT_FINAL"
 	hermesToolProgressModeEnv     = "HERMES_TOOL_PROGRESS_MODE"
 	clawdapusDisabledToolsEnv     = "CLAWDAPUS_DISABLED_TOOLS"
 	hermesTextToSpeechTool        = "text_to_speech"
@@ -89,6 +90,9 @@ func GenerateEnvFile(rc *driver.ResolvedClaw, modelCfg *modelConfig) ([]byte, er
 		if value != "" {
 			env[key] = value
 		}
+	}
+	if rc != nil && rc.Hermes != nil && rc.Hermes.AllowSilent {
+		env[hermesAllowSilentFinalEnv] = "1"
 	}
 
 	keys := make([]string, 0, len(env))
@@ -299,6 +303,7 @@ func allowedEnvPassthroughKeys() []string {
 		"DISCORD_REQUIRE_MENTION",
 		"GATEWAY_ALLOWED_USERS",
 		"GATEWAY_ALLOW_ALL_USERS",
+		hermesAllowSilentFinalEnv,
 		hermesToolProgressModeEnv,
 		"OPENAI_API_KEY",
 		"OPENROUTER_API_KEY",

--- a/internal/driver/hermes/config.go
+++ b/internal/driver/hermes/config.go
@@ -21,6 +21,7 @@ const (
 	hermesDefaultAgentIdentityEnv = "HERMES_DEFAULT_AGENT_IDENTITY"
 	hermesAllowSilentFinalEnv     = "HERMES_ALLOW_SILENT_FINAL"
 	hermesToolProgressModeEnv     = "HERMES_TOOL_PROGRESS_MODE"
+	hermesDiscordReplyMentionEnv  = "DISCORD_ALLOW_MENTION_REPLIED_USER"
 	clawdapusDisabledToolsEnv     = "CLAWDAPUS_DISABLED_TOOLS"
 	hermesTextToSpeechTool        = "text_to_speech"
 	managedDefaultAgentIdentity   = "You are a Clawdapus-managed agent. Your identity, authority, communication policy, memory policy, and tool-use rules are defined by the Clawdapus project context loaded below: AGENTS.md, CLAWDAPUS.md, SOUL.md, mounted skills, feeds, and managed-tool policy. Do not identify as Hermes or as a generic assistant. Follow the Clawdapus contract when it is more specific than runner defaults; otherwise retain the Hermes runtime guidance below, including persistent memory behavior."
@@ -77,6 +78,13 @@ func GenerateEnvFile(rc *driver.ResolvedClaw, modelCfg *modelConfig) ([]byte, er
 	env[hermesDefaultAgentIdentityEnv] = managedDefaultAgentIdentity
 	if hasDiscordHandle(rc) {
 		env[hermesToolProgressModeEnv] = "off"
+		// Hermes upstream defaults reply-mention pings to True
+		// (DISCORD_ALLOW_MENTION_REPLIED_USER), which produces mention loops in
+		// multi-agent pods even with DISCORD_REQUIRE_MENTION=true. Force false
+		// by default; operators can re-enable per service via x-claw env.
+		if _, set := env[hermesDiscordReplyMentionEnv]; !set {
+			env[hermesDiscordReplyMentionEnv] = "false"
+		}
 	}
 	if disabled := resolveDisabledHermesTools(rc); len(disabled) > 0 {
 		env[clawdapusDisabledToolsEnv] = strings.Join(disabled, ",")
@@ -295,6 +303,7 @@ func allowedEnvPassthroughKeys() []string {
 		"CLAW_API_URL",
 		"DISCORD_ALLOW_BOTS",
 		"DISCORD_ALLOWED_USERS",
+		hermesDiscordReplyMentionEnv,
 		"DISCORD_AUTO_THREAD",
 		"DISCORD_BOT_TOKEN",
 		"DISCORD_FREE_RESPONSE_CHANNELS",

--- a/internal/driver/hermes/config_test.go
+++ b/internal/driver/hermes/config_test.go
@@ -278,6 +278,20 @@ func TestGenerateEnvFileAllowsToolProgressOverride(t *testing.T) {
 	}
 }
 
+func TestGenerateEnvFileSetsAllowSilentEnv(t *testing.T) {
+	rc := &driver.ResolvedClaw{
+		Hermes: &driver.HermesConfig{AllowSilent: true},
+	}
+	data, err := GenerateEnvFile(rc, &modelConfig{Env: map[string]string{}})
+	if err != nil {
+		t.Fatalf("GenerateEnvFile returned error: %v", err)
+	}
+
+	if !strings.Contains(string(data), hermesAllowSilentFinalEnv+"=1\n") {
+		t.Fatalf("expected %s=1 in .env, got:\n%s", hermesAllowSilentFinalEnv, data)
+	}
+}
+
 func TestGenerateEnvFileDisablesTTSForDiscordByDefault(t *testing.T) {
 	rc := &driver.ResolvedClaw{
 		Handles: map[string]*driver.HandleInfo{"discord": {}},

--- a/internal/driver/hermes/driver.go
+++ b/internal/driver/hermes/driver.go
@@ -196,6 +196,9 @@ func (d *Driver) Materialize(rc *driver.ResolvedClaw, opts driver.MaterializeOpt
 			env[hermesToolProgressModeEnv] = value
 		}
 	}
+	if rc.Hermes != nil && rc.Hermes.AllowSilent {
+		env[hermesAllowSilentFinalEnv] = "1"
+	}
 
 	if modelCfg.BaseURL != "" {
 		env["OPENAI_BASE_URL"] = modelCfg.BaseURL

--- a/internal/driver/hermes/driver_test.go
+++ b/internal/driver/hermes/driver_test.go
@@ -442,6 +442,32 @@ func TestMaterializeHonorsHermesAllowToolsOptIn(t *testing.T) {
 	}
 }
 
+func TestMaterializeWritesAllowSilentEnv(t *testing.T) {
+	rc, tmp := newTestRC(t)
+	rc.Hermes = &driver.HermesConfig{AllowSilent: true}
+	runtimeDir := filepath.Join(tmp, "runtime")
+	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := (&Driver{}).Materialize(rc, driver.MaterializeOpts{RuntimeDir: runtimeDir, PodName: "test"})
+	if err != nil {
+		t.Fatalf("Materialize returned error: %v", err)
+	}
+
+	if got := result.Environment[hermesAllowSilentFinalEnv]; got != "1" {
+		t.Fatalf("expected %s=1 in container env, got %q", hermesAllowSilentFinalEnv, got)
+	}
+
+	envData, err := os.ReadFile(filepath.Join(runtimeDir, "hermes-home", ".env"))
+	if err != nil {
+		t.Fatalf("read .env: %v", err)
+	}
+	if !strings.Contains(string(envData), hermesAllowSilentFinalEnv+"=1\n") {
+		t.Fatalf("expected %s=1 in .env, got:\n%s", hermesAllowSilentFinalEnv, envData)
+	}
+}
+
 func newTestRC(t *testing.T) (*driver.ResolvedClaw, string) {
 	t.Helper()
 	tmp := t.TempDir()

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -93,7 +93,8 @@ type ResolvedClaw struct {
 }
 
 type HermesConfig struct {
-	AllowTools []string
+	AllowTools  []string
+	AllowSilent bool
 }
 
 // HandleInfo is the full contact card for an agent on a platform.

--- a/internal/infraimages/release_manifest.go
+++ b/internal/infraimages/release_manifest.go
@@ -9,7 +9,7 @@ const (
 	DefaultClawWallTag     = DefaultClawInfraTag
 	DefaultClawMCPStdioTag = DefaultClawInfraTag
 	DefaultCllamaTag       = "v0.6.2"
-	DefaultHermesBaseTag   = "v2026.3.17-claw.4"
+	DefaultHermesBaseTag   = "v2026.4.23-claw.1"
 )
 
 func ReleaseRefs(releaseTag string) []string {

--- a/internal/pod/parser.go
+++ b/internal/pod/parser.go
@@ -99,7 +99,8 @@ type rawMCPStdioBlock struct {
 }
 
 type rawHermesConfig struct {
-	AllowTools []string `yaml:"allow-tools"`
+	AllowTools  []string `yaml:"allow-tools"`
+	AllowSilent bool     `yaml:"allow-silent"`
 }
 
 type rawFeedEntry struct {
@@ -720,7 +721,7 @@ func parseMCPStdio(serviceName string, raw *rawMCPStdioBlock, agent string, clla
 }
 
 func parseHermesConfig(raw *rawHermesConfig) (*driver.HermesConfig, error) {
-	if raw == nil || len(raw.AllowTools) == 0 {
+	if raw == nil || (len(raw.AllowTools) == 0 && !raw.AllowSilent) {
 		return nil, nil
 	}
 
@@ -732,10 +733,13 @@ func parseHermesConfig(raw *rawHermesConfig) (*driver.HermesConfig, error) {
 		}
 		allowTools = append(allowTools, tool)
 	}
-	if len(allowTools) == 0 {
+	if len(allowTools) == 0 && !raw.AllowSilent {
 		return nil, nil
 	}
-	return &driver.HermesConfig{AllowTools: allowTools}, nil
+	return &driver.HermesConfig{
+		AllowTools:  allowTools,
+		AllowSilent: raw.AllowSilent,
+	}, nil
 }
 
 func (r *rawFeedEntry) UnmarshalYAML(node *yaml.Node) error {

--- a/internal/pod/parser_hermes_test.go
+++ b/internal/pod/parser_hermes_test.go
@@ -30,6 +30,29 @@ services:
 	}
 }
 
+func TestParseHermesAllowSilent(t *testing.T) {
+	p, err := Parse(strings.NewReader(`
+services:
+  gerrard:
+    image: ghcr.io/example/gerrard:latest
+    x-claw:
+      agent: ./AGENTS.md
+      hermes:
+        allow-silent: true
+`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	hermes := p.Services["gerrard"].Claw.Hermes
+	if hermes == nil {
+		t.Fatal("expected Hermes config")
+	}
+	if !hermes.AllowSilent {
+		t.Fatal("expected Hermes allow-silent to parse true")
+	}
+}
+
 func TestParseHermesConfigMissingOrEmpty(t *testing.T) {
 	p, err := Parse(strings.NewReader(`
 services:

--- a/site/.vitepress/config.mts
+++ b/site/.vitepress/config.mts
@@ -43,7 +43,7 @@ export default defineConfig({
     nav: [
       { text: 'Guide', link: '/guide/what-is-clawdapus' },
       {
-        text: 'v0.14.3',
+        text: 'v0.14.4',
         items: [
           { text: 'Changelog', link: '/changelog' },
           { text: 'Manifesto', link: '/manifesto' },

--- a/site/changelog.md
+++ b/site/changelog.md
@@ -29,9 +29,16 @@ outline: deep
 
 ## Unreleased
 
-- Fix: Hermes services can opt into silent-final handling with `x-claw.hermes.allow-silent: true` ([#212](https://github.com/mostlydev/clawdapus/issues/212)). When enabled, a reasoning-model response containing only `<think>` blocks completes as a no-op instead of retrying and posting a Discord warning. The behavior is opt-in and Hermes-only; cllama remains a passthrough.
+<!-- Nothing yet -->
 
-## v0.14.3 <Badge type="tip" text="Latest" /> {#v0-14-3}
+## v0.14.4 <Badge type="tip" text="Latest" /> {#v0-14-4}
+
+*2026-04-29*
+
+- **Hermes silent-final opt-in** — Hermes services can opt into silent-final handling with `x-claw.hermes.allow-silent: true` ([#212](https://github.com/mostlydev/clawdapus/issues/212)). When enabled, a reasoning-model response containing only `<think>` blocks completes as a no-op instead of retrying and posting a Discord warning. Behavior is opt-in and Hermes-only; cllama remains a passthrough.
+- **Hermes-base upstream bump v2026.3.17 → v2026.4.23** — rebased the compatibility patch ledger against current upstream Hermes. Dropped four patches that upstream merged equivalents for (members intent, on_ready/slash-command sync, both reply-mention `channel.send` patches), rewrote two against new code shapes (`tool_choice=required` against the new transport-based `_build_api_kwargs`, suppress-duplicate-final around the new `(empty)` sentinel handler), and replaced the per-`channel.send` reply-mention patches with a driver-level `DISCORD_ALLOW_MENTION_REPLIED_USER=false` default that leverages upstream's new env knob. Patch count: 13 → 11. Image bumped to `ghcr.io/mostlydev/hermes-base:v2026.4.23-claw.1`.
+
+## v0.14.3 {#v0-14-3}
 
 *2026-04-29*
 

--- a/site/changelog.md
+++ b/site/changelog.md
@@ -29,7 +29,7 @@ outline: deep
 
 ## Unreleased
 
-<!-- Nothing yet -->
+- Fix: Hermes services can opt into silent-final handling with `x-claw.hermes.allow-silent: true` ([#212](https://github.com/mostlydev/clawdapus/issues/212)). When enabled, a reasoning-model response containing only `<think>` blocks completes as a no-op instead of retrying and posting a Discord warning. The behavior is opt-in and Hermes-only; cllama remains a passthrough.
 
 ## v0.14.3 <Badge type="tip" text="Latest" /> {#v0-14-3}
 

--- a/site/guide/drivers.md
+++ b/site/guide/drivers.md
@@ -57,6 +57,11 @@ Container env vars from compose `environment:` are not available in Hermes agent
 
 For Discord handles, the Hermes driver disables the upstream `text_to_speech` tool by default so agents reply in text instead of model-selected voice attachments. A service can opt back in with `x-claw.hermes.allow-tools: [text_to_speech]`.
 
+Hermes services can also opt into silent-final handling for reasoning models
+with `x-claw.hermes.allow-silent: true`. When enabled, a response containing
+only `<think>` blocks completes as a no-op instead of surfacing a retry
+exhaustion warning to Discord.
+
 ### nanoclaw
 
 Claude Agent SDK-based driver. Does not currently support HANDLE, INVOKE, or structured health probes.


### PR DESCRIPTION
## Summary

- **Silent-final opt-in for Hermes** — `x-claw.hermes.allow-silent: true` lets reasoning models stay silent when they produce only `<think>` blocks. Sets `HERMES_ALLOW_SILENT_FINAL=1`; the patched runtime returns a clean no-op turn instead of retrying.
- **hermes-base upstream bump v2026.3.17 → v2026.4.23** — rebased the patch ledger. Dropped 4 obsolete patches (upstream merged equivalents), rewrote 2 against new code shapes, replaced per-`channel.send` reply-mention patches with `DISCORD_ALLOW_MENTION_REPLIED_USER=false` driver default. Patch count 13 → 11.
- **Driver wiring** — `HermesConfig.AllowSilent` flows from pod parser → `.env` file + container env passthrough. Discord-handle services now get reply-mention auto-ping disabled by default.
- **Image** — `ghcr.io/mostlydev/hermes-base:v2026.4.23-claw.1` published; `DefaultHermesBaseTag` and `BaseImageVersion` bumped accordingly.

## Verification

- [x] `go test ./...` green
- [x] `go vet ./...` green
- [x] Multi-arch hermes-base image built + pushed
- [x] `TestSpikeHermesBaseImageContract` green against pushed image
- [x] All 11 `replace_once` patches land cleanly against v2026.4.23 upstream
- [ ] Operator manual on tiverton-house: gerrard with `allow-silent: true` and a reasoning model in mention_only channel produces no Discord error

Closes #212