### PR TITLE
Surface cllama self-history in CLAWDAPUS.md

### DIFF
--- a/docs/plans/2026-04-29-issue-213-self-history-clawdapus-section.md
+++ b/docs/plans/2026-04-29-issue-213-self-history-clawdapus-section.md
@@ -42,34 +42,33 @@ Naming rationale:
 - Keeping the self-history names distinct means a service that is *both* a cllama agent *and* a memory-replay consumer doesn't have one env name overloaded with two semantically different roles.
 - `CLAW_AGENT_ID` is new but lightweight — it's the only way to write a copy-pasteable curl one-liner, and any future per-agent introspection will want this anyway.
 
-### 2. CLAWDAPUS.md "Self-history introspection" section
+### 2. CLAWDAPUS.md "LLM Proxy" and "Self-history introspection" sections
 
-Emit only when `len(rc.Cllama) > 0`. Place immediately after the existing "LLM Proxy" section in `internal/driver/shared/clawdapus_md.go`. Suggested copy:
+Emit only when `len(rc.Cllama) > 0`. Keep the LLM proxy section general because the model does not call its own inference endpoint — the harness does. Place the explicit self-history retrieval surface immediately after it in `internal/driver/shared/clawdapus_md.go`. Suggested copy:
 
 ```markdown
+## LLM Proxy
+
+Your inference is routed through a governance proxy for logging and policy enforcement. Model and endpoint wiring is managed by the harness - leave it alone.
+
 ## Self-history introspection
 
-You can read your own retained turns through the cllama proxy. This is a self-scoped read — it returns only your own history, not pod-wide or cross-agent.
+You can read your own retained turns through the cllama proxy. Self-scoped: returns only your own history, not pod-wide or cross-agent.
 
-- **Endpoint env:** `CLAW_SELF_HISTORY_URL` (base URL, e.g. `http://cllama:8080/history`)
-- **Auth env:** `CLAW_SELF_HISTORY_TOKEN` (your own bearer; same scope as your LLM calls)
-- **Identity env:** `CLAW_AGENT_ID` (your own agent ID)
-- **Pagination:** optional `?after=<RFC3339>` and `?limit=<N>` query parameters.
-- **Response:** newline-delimited JSON (`application/x-ndjson`); one retained entry per line in chronological order.
+- **Endpoint:** `$CLAW_SELF_HISTORY_URL/$CLAW_AGENT_ID`
+- **Auth:** pre-wired (`CLAW_SELF_HISTORY_TOKEN` carries your bearer)
+- **Pagination:** optional `?after=<RFC3339>` and `?limit=<N>`
+- **Response:** newline-delimited JSON (`application/x-ndjson`), one retained entry per line in chronological order
 
-Example:
-
-    curl -H "Authorization: Bearer $CLAW_SELF_HISTORY_TOKEN" \
-      "$CLAW_SELF_HISTORY_URL/$CLAW_AGENT_ID?limit=20"
-
-Use this when an operator asks you to explain past behavior, when introspecting before a long task, or when reasoning over your own session. Do not poll on a hot path — this is a discovery surface, not a hot loop.
+Use this when an operator asks you to explain past behavior or when reasoning over your own session. Don't poll.
 ```
 
 The text deliberately:
 - references env vars only, never raw values;
 - mentions the ndjson response shape so the agent doesn't try to parse a JSON array;
 - names the pagination params explicitly because that's what the underlying handler accepts (`parseAfterParam`, `parseHistoryLimit`);
-- adds a one-line norm against polling, since this surface will be tempting once it's discoverable.
+- treats authentication as pre-wired rather than teaching the model token-management ceremony;
+- adds a short norm against polling, since this surface will be tempting once it's discoverable.
 
 ### 3. No spec/wire changes to cllama itself
 

--- a/docs/plans/2026-04-29-issue-213-self-history-clawdapus-section.md
+++ b/docs/plans/2026-04-29-issue-213-self-history-clawdapus-section.md
@@ -1,0 +1,123 @@
+# Issue #213 — Surface cllama self-history as a discoverable skill in CLAWDAPUS.md
+
+**Status:** Design draft, awaiting codex challenge before implementation.
+**Workflow:** Claude drafts, codex reviews, consensus, codex implements, Claude reviews + releases.
+**Sources of truth checked:** `cllama/internal/proxy/history.go`, `internal/cllama/context.go`, `cmd/claw/compose_up.go` (`prepareHistoryReplayRuntime`, `materializeService`), `internal/driver/shared/clawdapus_md.go`, `internal/driver/types.go`.
+
+## TL;DR
+
+Add a "Self-history introspection" section to every cllama-enabled `CLAWDAPUS.md`. To make the curl example actually executable, project a small set of env vars into the agent's runtime container at compile time: `CLAW_SELF_HISTORY_URL`, `CLAW_SELF_HISTORY_TOKEN`, and `CLAW_AGENT_ID`. The section references the env vars (never raw secrets), shows one curl shape, describes the response shape, and is written only for cllama-enabled services.
+
+## Reality check on the issue body
+
+The issue claims:
+> the env vars `CLAW_HISTORY_URL` + `CLAW_HISTORY_TOKEN` projected into cllama-enabled runner containers (ADR-021 auth projection)
+
+This is **not accurate** for self-history. In the current code (`cmd/claw/compose_up.go::prepareHistoryReplayRuntime`, lines ~2077–2126):
+
+- `CLAW_HISTORY_URL` and `CLAW_HISTORY_TOKEN` are projected only onto **memory-adapter consumer services** (e.g. a `claw-memory` service subscribed to another agent's history). They point at *another* service's `cllama-history` scope.
+- A regular cllama-enabled agent reading **his own** history has no `CLAW_HISTORY_*` env vars projected today.
+- What the agent *does* have is `CLLAMA_TOKEN` (his metadata bearer token, format `<agent-id>:<48-hex>`). The cllama history endpoint authorizes self-reads against `targetCtx.MetadataToken()` (`cllama/internal/proxy/history.go::authorizeHistoryRequest`), so the same token already works for self-history. He does not have an explicit env-var pointer to either his agent_id or the cllama base URL.
+
+So #213 is two interlocking gaps:
+1. **No discoverability:** nothing in `CLAWDAPUS.md` tells the agent the endpoint exists.
+2. **No clean env handle for the curl shape:** even if we documented the endpoint, the example would have to either (a) use a placeholder like `<agent-id>` and a hardcoded `http://cllama:8080/history`, or (b) introduce env vars the agent can interpolate.
+
+This plan addresses both.
+
+## Design
+
+### 1. New env vars projected per cllama-enabled service
+
+Set in `cmd/claw/compose_up.go` during cllama wiring (next to where `CLLAMA_TOKEN` is set today, lines 741–748). For every cllama-enabled service:
+
+| Env var | Value | Per-ordinal? |
+|---|---|---|
+| `CLAW_SELF_HISTORY_URL` | `http://<first-cllama-proxy>:8080/history` | Same for all ordinals of a service |
+| `CLAW_SELF_HISTORY_TOKEN` | The agent's own metadata bearer token (same value already used as `CLLAMA_TOKEN`) | **Yes — per-ordinal** for `count > 1` (each ordinal gets his own bearer) |
+| `CLAW_AGENT_ID` | The agent's own ID (`name` for count=1, `name-N` for count>1) | **Yes — per-ordinal** |
+
+Naming rationale:
+- `CLAW_SELF_HISTORY_URL` and `CLAW_SELF_HISTORY_TOKEN` deliberately avoid the existing memory-replay env names `CLAW_HISTORY_URL` and `CLAW_HISTORY_TOKEN`, which carry a peer-service replay capability rather than a self-read capability.
+- Keeping the self-history names distinct means a service that is *both* a cllama agent *and* a memory-replay consumer doesn't have one env name overloaded with two semantically different roles.
+- `CLAW_AGENT_ID` is new but lightweight — it's the only way to write a copy-pasteable curl one-liner, and any future per-agent introspection will want this anyway.
+
+### 2. CLAWDAPUS.md "Self-history introspection" section
+
+Emit only when `len(rc.Cllama) > 0`. Place immediately after the existing "LLM Proxy" section in `internal/driver/shared/clawdapus_md.go`. Suggested copy:
+
+```markdown
+## Self-history introspection
+
+You can read your own retained turns through the cllama proxy. This is a self-scoped read — it returns only your own history, not pod-wide or cross-agent.
+
+- **Endpoint env:** `CLAW_SELF_HISTORY_URL` (base URL, e.g. `http://cllama:8080/history`)
+- **Auth env:** `CLAW_SELF_HISTORY_TOKEN` (your own bearer; same scope as your LLM calls)
+- **Identity env:** `CLAW_AGENT_ID` (your own agent ID)
+- **Pagination:** optional `?after=<RFC3339>` and `?limit=<N>` query parameters.
+- **Response:** newline-delimited JSON (`application/x-ndjson`); one retained entry per line in chronological order.
+
+Example:
+
+    curl -H "Authorization: Bearer $CLAW_SELF_HISTORY_TOKEN" \
+      "$CLAW_SELF_HISTORY_URL/$CLAW_AGENT_ID?limit=20"
+
+Use this when an operator asks you to explain past behavior, when introspecting before a long task, or when reasoning over your own session. Do not poll on a hot path — this is a discovery surface, not a hot loop.
+```
+
+The text deliberately:
+- references env vars only, never raw values;
+- mentions the ndjson response shape so the agent doesn't try to parse a JSON array;
+- names the pagination params explicitly because that's what the underlying handler accepts (`parseAfterParam`, `parseHistoryLimit`);
+- adds a one-line norm against polling, since this surface will be tempting once it's discoverable.
+
+### 3. No spec/wire changes to cllama itself
+
+The cllama history endpoint and its auth model are unchanged. We're projecting env vars at compile time and adding a markdown section. No new routes, no new tokens, no new auth paths.
+
+## Files touched (proposed)
+
+- `internal/pod/compose_emit.go` — project `CLAW_SELF_HISTORY_URL`, `CLAW_SELF_HISTORY_TOKEN`, `CLAW_AGENT_ID` for every cllama-enabled service next to the existing per-ordinal `CLLAMA_TOKEN` handling.
+- `internal/driver/shared/clawdapus_md.go` — emit the new section, gated on `len(rc.Cllama) > 0`. Likely inserted right after the existing `## LLM Proxy` block (line ~136).
+- `internal/driver/shared/clawdapus_md_test.go` — two tests: one asserting the section is present for a cllama-enabled `rc`; one asserting it is **absent** when `rc.Cllama` is empty. Use the existing `TestClawdapusMDIncludesProxySection` / `TestClawdapusMDNoProxyWhenNoCllama` pair as the template.
+- `cmd/claw/compose_up_test.go` — extend an existing cllama-wiring test (or add a small new one) asserting all three new env vars land on a cllama-enabled service's compose `environment:` block, with the per-ordinal expansion preserved for `count > 1`.
+
+## Test plan
+
+**Unit:**
+1. `clawdapus_md_test.go`:
+   - cllama-enabled rc → markdown contains `## Self-history introspection`, `CLAW_SELF_HISTORY_URL`, `CLAW_SELF_HISTORY_TOKEN`, `CLAW_AGENT_ID`, and the curl shape.
+   - cllama-disabled rc → markdown does **not** contain the section header or any of the three env names.
+2. `compose_up_test.go`:
+   - count=1 cllama service: env block has all three vars set, `CLAW_SELF_HISTORY_TOKEN` matches `CLLAMA_TOKEN`, `CLAW_AGENT_ID` matches the service name.
+   - count=2 cllama service: each ordinal gets its own `CLAW_SELF_HISTORY_TOKEN` and `CLAW_AGENT_ID` (matching `name-0`, `name-1`); `CLAW_SELF_HISTORY_URL` is identical across ordinals.
+   - non-cllama service: none of the three vars are set.
+
+**Spike (manual):**
+- Run `examples/quickstart/` (cllama-enabled), `claw up -d`, `claw compose exec <svc> sh -c 'curl -sS -H "Authorization: Bearer $CLAW_SELF_HISTORY_TOKEN" "$CLAW_SELF_HISTORY_URL/$CLAW_AGENT_ID?limit=5"'`. Expected: ndjson lines (or empty, if no completions yet — make one completion first to seed). 401/403 is the failure case.
+- Cross-check: same curl from a non-cllama-enabled sidecar should fail (no env vars).
+
+**Existing spikes:** `TestSpikeRollCall` should remain green — this change adds env vars and one markdown section but does not touch cllama wiring or telemetry normalization.
+
+## Open questions for codex
+
+1. **Naming collision with the memory-replay path.** Resolved by using `CLAW_SELF_HISTORY_URL` and `CLAW_SELF_HISTORY_TOKEN` for self-history and leaving memory replay on `CLAW_HISTORY_URL` and `CLAW_HISTORY_TOKEN`. This avoids collision without migrating existing memory-adapter consumers.
+
+2. **`CLAW_AGENT_ID` scope.** I'm proposing it only for cllama-enabled services so we don't grow env surface for agents that have nothing to introspect. But once it's wired for cllama, follow-up features (memory adapters, master-claw-driven reasoning, audit prompts) will want it everywhere. Should we just project it universally for all `x-claw` services from day one and let it be unused by non-cllama paths? Marginal cost, future-proof.
+
+3. **URL shape.** Use `http://<proxy>:8080/history` (no trailing slash, no `/v1`). The handler is mounted at `/history/{agentID}`. The curl example concatenation `$CLAW_SELF_HISTORY_URL/$CLAW_AGENT_ID` lands on the right path.
+
+4. **Markdown placement.** I have it right after `## LLM Proxy`. Alternative: under a top-level `## Introspection` umbrella that future surfaces (memory recall API, audit log) can join. Probably premature; one section is enough for v1.
+
+5. **Documentation in `site/guide/`.** Out of scope for this PR? Or should the user-facing site mention the env vars too? My instinct: this PR ships the discoverability for the agent, and we add a `site/guide/` paragraph in a follow-up after we've seen agents actually use it.
+
+## Non-goals
+
+- **No new auth route.** Self-history is already authorized via the metadata token; we don't add new scopes or tokens.
+- **No pagination cursor change.** The handler already takes `?after=<RFC3339>` and `?limit=<N>`; we just document them.
+- **No agent-self-curation.** The sibling issue covers retain/forget shape. This issue ends at "agent can read."
+- **No `site/changelog.md` `Latest` badge bump.** Per repo discipline, that lands with the release tag, not this PR.
+
+## Workflow next step
+
+Pass the stick to codex with `next_action`: "Codex challenges the design (especially the naming-collision question) and either confirms the plan or proposes a revised approach. No code commits yet from anyone."

--- a/docs/plans/2026-04-29-issue-213-self-history-clawdapus-section.md
+++ b/docs/plans/2026-04-29-issue-213-self-history-clawdapus-section.md
@@ -55,8 +55,8 @@ Your inference is routed through a governance proxy for logging and policy enfor
 
 You can read your own retained turns through the cllama proxy. Self-scoped: returns only your own history, not pod-wide or cross-agent.
 
-- **Endpoint:** `$CLAW_SELF_HISTORY_URL/$CLAW_AGENT_ID`
-- **Auth:** pre-wired (`CLAW_SELF_HISTORY_TOKEN` carries your bearer)
+- **Endpoint:** `GET http://cllama:8080/history/<your-agent-id>`
+- **Auth:** pre-wired by Clawdapus
 - **Pagination:** optional `?after=<RFC3339>` and `?limit=<N>`
 - **Response:** newline-delimited JSON (`application/x-ndjson`), one retained entry per line in chronological order
 
@@ -64,7 +64,7 @@ Use this when an operator asks you to explain past behavior or when reasoning ov
 ```
 
 The text deliberately:
-- references env vars only, never raw values;
+- shows a concrete route shape without embedding raw bearer values;
 - mentions the ndjson response shape so the agent doesn't try to parse a JSON array;
 - names the pagination params explicitly because that's what the underlying handler accepts (`parseAfterParam`, `parseHistoryLimit`);
 - treats authentication as pre-wired rather than teaching the model token-management ceremony;

--- a/internal/driver/shared/clawdapus_md.go
+++ b/internal/driver/shared/clawdapus_md.go
@@ -133,6 +133,19 @@ func GenerateClawdapusMD(rc *driver.ResolvedClaw, podName string) string {
 		}
 		b.WriteString("\nAll inference requests pass through this proxy for logging and policy enforcement.\n")
 		b.WriteString("You do not need to configure this - model settings are pre-wired.\n\n")
+
+		b.WriteString("## Self-history introspection\n\n")
+		b.WriteString("You can read your own retained turns through the cllama proxy. This is a self-scoped read: it returns only your own history, not pod-wide or cross-agent history.\n\n")
+		b.WriteString("- **Endpoint env:** `CLAW_SELF_HISTORY_URL` (base URL, e.g. `http://cllama:8080/history`)\n")
+		b.WriteString("- **Auth env:** `CLAW_SELF_HISTORY_TOKEN` (your own bearer; same scope as your LLM calls)\n")
+		b.WriteString("- **Identity env:** `CLAW_AGENT_ID` (your own agent ID)\n")
+		b.WriteString("- **Pagination:** optional `?after=<RFC3339>` and `?limit=<N>` query parameters\n")
+		b.WriteString("- **Response:** newline-delimited JSON (`application/x-ndjson`), one retained entry per line in chronological order\n\n")
+		b.WriteString("Example:\n\n")
+		b.WriteString("```bash\n")
+		b.WriteString("curl -H \"Authorization: Bearer $CLAW_SELF_HISTORY_TOKEN\" \"$CLAW_SELF_HISTORY_URL/$CLAW_AGENT_ID?limit=20\"\n")
+		b.WriteString("```\n\n")
+		b.WriteString("Use this when an operator asks you to explain past behavior, when introspecting before a long task, or when reasoning over your own session. Do not poll on a hot path.\n\n")
 	}
 
 	// Handles

--- a/internal/driver/shared/clawdapus_md.go
+++ b/internal/driver/shared/clawdapus_md.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/mostlydev/clawdapus/internal/cllama"
 	"github.com/mostlydev/clawdapus/internal/driver"
 )
 
@@ -125,8 +126,9 @@ func GenerateClawdapusMD(rc *driver.ResolvedClaw, podName string) string {
 
 		b.WriteString("## Self-history introspection\n\n")
 		b.WriteString("You can read your own retained turns through the cllama proxy. Self-scoped: returns only your own history, not pod-wide or cross-agent.\n\n")
-		b.WriteString("- **Endpoint:** `$CLAW_SELF_HISTORY_URL/$CLAW_AGENT_ID`\n")
-		b.WriteString("- **Auth:** pre-wired (`CLAW_SELF_HISTORY_TOKEN` carries your bearer)\n")
+		firstProxy := cllama.ProxyServiceName(rc.Cllama[0])
+		b.WriteString(fmt.Sprintf("- **Endpoint:** `GET http://%s:8080/history/<your-agent-id>`\n", firstProxy))
+		b.WriteString("- **Auth:** pre-wired by Clawdapus\n")
 		b.WriteString("- **Pagination:** optional `?after=<RFC3339>` and `?limit=<N>`\n")
 		b.WriteString("- **Response:** newline-delimited JSON (`application/x-ndjson`), one retained entry per line in chronological order\n\n")
 		b.WriteString("Use this when an operator asks you to explain past behavior or when reasoning over your own session. Don't poll.\n\n")

--- a/internal/driver/shared/clawdapus_md.go
+++ b/internal/driver/shared/clawdapus_md.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/mostlydev/clawdapus/internal/cllama"
 	"github.com/mostlydev/clawdapus/internal/driver"
 )
 
@@ -122,30 +121,15 @@ func GenerateClawdapusMD(rc *driver.ResolvedClaw, podName string) string {
 
 	if len(rc.Cllama) > 0 {
 		b.WriteString("## LLM Proxy\n\n")
-		b.WriteString("Your LLM requests are routed through a governance proxy.\n\n")
-		firstProxy := cllama.ProxyServiceName(rc.Cllama[0])
-		b.WriteString(fmt.Sprintf("- **Endpoint:** `http://%s:8080/v1`\n", firstProxy))
-		b.WriteString("- **Auth:** Bearer token (pre-configured)\n")
-		if len(rc.Cllama) == 1 {
-			b.WriteString(fmt.Sprintf("- **Mode:** %s\n", rc.Cllama[0]))
-		} else {
-			b.WriteString(fmt.Sprintf("- **Chain:** %s\n", strings.Join(rc.Cllama, " -> ")))
-		}
-		b.WriteString("\nAll inference requests pass through this proxy for logging and policy enforcement.\n")
-		b.WriteString("You do not need to configure this - model settings are pre-wired.\n\n")
+		b.WriteString("Your inference is routed through a governance proxy for logging and policy enforcement. Model and endpoint wiring is managed by the harness - leave it alone.\n\n")
 
 		b.WriteString("## Self-history introspection\n\n")
-		b.WriteString("You can read your own retained turns through the cllama proxy. This is a self-scoped read: it returns only your own history, not pod-wide or cross-agent history.\n\n")
-		b.WriteString("- **Endpoint env:** `CLAW_SELF_HISTORY_URL` (base URL, e.g. `http://cllama:8080/history`)\n")
-		b.WriteString("- **Auth env:** `CLAW_SELF_HISTORY_TOKEN` (your own bearer; same scope as your LLM calls)\n")
-		b.WriteString("- **Identity env:** `CLAW_AGENT_ID` (your own agent ID)\n")
-		b.WriteString("- **Pagination:** optional `?after=<RFC3339>` and `?limit=<N>` query parameters\n")
+		b.WriteString("You can read your own retained turns through the cllama proxy. Self-scoped: returns only your own history, not pod-wide or cross-agent.\n\n")
+		b.WriteString("- **Endpoint:** `$CLAW_SELF_HISTORY_URL/$CLAW_AGENT_ID`\n")
+		b.WriteString("- **Auth:** pre-wired (`CLAW_SELF_HISTORY_TOKEN` carries your bearer)\n")
+		b.WriteString("- **Pagination:** optional `?after=<RFC3339>` and `?limit=<N>`\n")
 		b.WriteString("- **Response:** newline-delimited JSON (`application/x-ndjson`), one retained entry per line in chronological order\n\n")
-		b.WriteString("Example:\n\n")
-		b.WriteString("```bash\n")
-		b.WriteString("curl -H \"Authorization: Bearer $CLAW_SELF_HISTORY_TOKEN\" \"$CLAW_SELF_HISTORY_URL/$CLAW_AGENT_ID?limit=20\"\n")
-		b.WriteString("```\n\n")
-		b.WriteString("Use this when an operator asks you to explain past behavior, when introspecting before a long task, or when reasoning over your own session. Do not poll on a hot path.\n\n")
+		b.WriteString("Use this when an operator asks you to explain past behavior or when reasoning over your own session. Don't poll.\n\n")
 	}
 
 	// Handles

--- a/internal/driver/shared/clawdapus_md_test.go
+++ b/internal/driver/shared/clawdapus_md_test.go
@@ -112,8 +112,14 @@ func TestClawdapusMDIncludesProxySection(t *testing.T) {
 	if !strings.Contains(md, "## LLM Proxy") {
 		t.Error("expected LLM Proxy section")
 	}
-	if !strings.Contains(md, "cllama:8080") {
-		t.Error("expected proxy endpoint with type name")
+	if !strings.Contains(md, "governance proxy for logging and policy enforcement") {
+		t.Error("expected governance proxy summary")
+	}
+	if !strings.Contains(md, "Model and endpoint wiring is managed by the harness") {
+		t.Error("expected harness-managed wiring guidance")
+	}
+	if strings.Contains(md, "**Endpoint:** `http://cllama:8080/v1`") {
+		t.Error("LLM Proxy section should not expose the harness endpoint")
 	}
 }
 
@@ -129,13 +135,17 @@ func TestClawdapusMDIncludesSelfHistorySectionForCllama(t *testing.T) {
 		"CLAW_SELF_HISTORY_URL",
 		"CLAW_SELF_HISTORY_TOKEN",
 		"CLAW_AGENT_ID",
-		"curl -H \"Authorization: Bearer $CLAW_SELF_HISTORY_TOKEN\"",
+		"$CLAW_SELF_HISTORY_URL/$CLAW_AGENT_ID",
+		"pre-wired",
 		"application/x-ndjson",
 		"only your own history",
 	} {
 		if !strings.Contains(md, want) {
 			t.Errorf("expected self-history section to contain %q", want)
 		}
+	}
+	if strings.Contains(md, "curl -H") {
+		t.Error("self-history section should not include a curl block")
 	}
 }
 

--- a/internal/driver/shared/clawdapus_md_test.go
+++ b/internal/driver/shared/clawdapus_md_test.go
@@ -132,11 +132,8 @@ func TestClawdapusMDIncludesSelfHistorySectionForCllama(t *testing.T) {
 	md := GenerateClawdapusMD(rc, "test-pod")
 	for _, want := range []string{
 		"## Self-history introspection",
-		"CLAW_SELF_HISTORY_URL",
-		"CLAW_SELF_HISTORY_TOKEN",
-		"CLAW_AGENT_ID",
-		"$CLAW_SELF_HISTORY_URL/$CLAW_AGENT_ID",
-		"pre-wired",
+		"GET http://cllama:8080/history/<your-agent-id>",
+		"pre-wired by Clawdapus",
 		"application/x-ndjson",
 		"only your own history",
 	} {
@@ -146,6 +143,9 @@ func TestClawdapusMDIncludesSelfHistorySectionForCllama(t *testing.T) {
 	}
 	if strings.Contains(md, "curl -H") {
 		t.Error("self-history section should not include a curl block")
+	}
+	if strings.Contains(md, "CLAW_SELF_HISTORY_TOKEN") || strings.Contains(md, "CLAW_AGENT_ID") {
+		t.Error("self-history section should not expose auth or identity env vars")
 	}
 }
 

--- a/internal/driver/shared/clawdapus_md_test.go
+++ b/internal/driver/shared/clawdapus_md_test.go
@@ -117,11 +117,39 @@ func TestClawdapusMDIncludesProxySection(t *testing.T) {
 	}
 }
 
+func TestClawdapusMDIncludesSelfHistorySectionForCllama(t *testing.T) {
+	rc := &driver.ResolvedClaw{
+		ServiceName: "tiverton",
+		ClawType:    "openclaw",
+		Cllama:      []string{"passthrough"},
+	}
+	md := GenerateClawdapusMD(rc, "test-pod")
+	for _, want := range []string{
+		"## Self-history introspection",
+		"CLAW_SELF_HISTORY_URL",
+		"CLAW_SELF_HISTORY_TOKEN",
+		"CLAW_AGENT_ID",
+		"curl -H \"Authorization: Bearer $CLAW_SELF_HISTORY_TOKEN\"",
+		"application/x-ndjson",
+		"only your own history",
+	} {
+		if !strings.Contains(md, want) {
+			t.Errorf("expected self-history section to contain %q", want)
+		}
+	}
+}
+
 func TestClawdapusMDNoProxyWhenNoCllama(t *testing.T) {
 	rc := &driver.ResolvedClaw{ServiceName: "tiverton", ClawType: "openclaw"}
 	md := GenerateClawdapusMD(rc, "test-pod")
 	if strings.Contains(md, "## LLM Proxy") {
 		t.Error("should not include proxy section")
+	}
+	if strings.Contains(md, "## Self-history introspection") {
+		t.Error("should not include self-history section")
+	}
+	if strings.Contains(md, "CLAW_SELF_HISTORY_URL") || strings.Contains(md, "CLAW_SELF_HISTORY_TOKEN") || strings.Contains(md, "CLAW_AGENT_ID") {
+		t.Error("should not mention self-history env vars")
 	}
 }
 

--- a/internal/pod/compose_emit.go
+++ b/internal/pod/compose_emit.go
@@ -272,10 +272,22 @@ func EmitCompose(p *Pod, results map[string]*driver.MaterializeResult, proxies .
 				return "", fmt.Errorf("service %q: environment: %w", serviceName, err)
 			}
 			if isClaw && svc.Claw != nil && len(svc.Claw.CllamaTokens) > 0 {
+				selectedToken := ""
 				if tok, ok := svc.Claw.CllamaTokens[serviceName]; ok && strings.TrimSpace(tok) != "" {
-					env["CLLAMA_TOKEN"] = tok
+					selectedToken = tok
 				} else if tok, ok := svc.Claw.CllamaTokens[name]; ok && strings.TrimSpace(tok) != "" {
-					env["CLLAMA_TOKEN"] = tok
+					selectedToken = tok
+				}
+				if selectedToken != "" {
+					if env == nil {
+						env = make(map[string]interface{})
+					}
+					env["CLLAMA_TOKEN"] = selectedToken
+					if len(svc.Claw.Cllama) > 0 {
+						env["CLAW_SELF_HISTORY_URL"] = fmt.Sprintf("http://%s:8080/history", cllama.ProxyServiceName(svc.Claw.Cllama[0]))
+						env["CLAW_SELF_HISTORY_TOKEN"] = selectedToken
+						env["CLAW_AGENT_ID"] = serviceName
+					}
 				}
 			}
 			if len(env) > 0 {

--- a/internal/pod/compose_emit_test.go
+++ b/internal/pod/compose_emit_test.go
@@ -1022,7 +1022,8 @@ func TestEmitComposeCllamaTokenPerOrdinalOverride(t *testing.T) {
 			"bot": {
 				Image: "bot:latest",
 				Claw: &ClawBlock{
-					Count: 2,
+					Count:  2,
+					Cllama: []string{"passthrough"},
 					CllamaTokens: map[string]string{
 						"bot-0": "bot-0:token",
 						"bot-1": "bot-1:token",
@@ -1053,6 +1054,94 @@ func TestEmitComposeCllamaTokenPerOrdinalOverride(t *testing.T) {
 	}
 	if !strings.Contains(out, "CLLAMA_TOKEN: bot-1:token") {
 		t.Error("expected bot-1 token override")
+	}
+	if !strings.Contains(out, "CLAW_SELF_HISTORY_URL: http://cllama:8080/history") {
+		t.Error("expected self-history URL for cllama services")
+	}
+	if !strings.Contains(out, "CLAW_SELF_HISTORY_TOKEN: bot-0:token") {
+		t.Error("expected bot-0 self-history token")
+	}
+	if !strings.Contains(out, "CLAW_SELF_HISTORY_TOKEN: bot-1:token") {
+		t.Error("expected bot-1 self-history token")
+	}
+	if !strings.Contains(out, "CLAW_AGENT_ID: bot-0") {
+		t.Error("expected bot-0 agent id")
+	}
+	if !strings.Contains(out, "CLAW_AGENT_ID: bot-1") {
+		t.Error("expected bot-1 agent id")
+	}
+}
+
+func TestEmitComposeSelfHistoryEnvForSingleCllamaService(t *testing.T) {
+	p := &Pod{
+		Name: "token-pod",
+		Services: map[string]*Service{
+			"bot": {
+				Image: "bot:latest",
+				Claw: &ClawBlock{
+					Cllama: []string{"passthrough"},
+					CllamaTokens: map[string]string{
+						"bot": "bot:token",
+					},
+				},
+			},
+		},
+	}
+	results := map[string]*driver.MaterializeResult{
+		"bot": {
+			ReadOnly: true,
+			Restart:  "on-failure",
+		},
+	}
+
+	out, err := EmitCompose(p, results)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"CLLAMA_TOKEN: bot:token",
+		"CLAW_SELF_HISTORY_URL: http://cllama:8080/history",
+		"CLAW_SELF_HISTORY_TOKEN: bot:token",
+		"CLAW_AGENT_ID: bot",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected compose output to contain %q", want)
+		}
+	}
+}
+
+func TestEmitComposeSelfHistoryEnvAbsentWithoutCllama(t *testing.T) {
+	p := &Pod{
+		Name: "token-pod",
+		Services: map[string]*Service{
+			"bot": {
+				Image: "bot:latest",
+				Claw: &ClawBlock{
+					CllamaTokens: map[string]string{
+						"bot": "bot:token",
+					},
+				},
+			},
+		},
+	}
+	results := map[string]*driver.MaterializeResult{
+		"bot": {
+			ReadOnly: true,
+			Restart:  "on-failure",
+		},
+	}
+
+	out, err := EmitCompose(p, results)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "CLLAMA_TOKEN: bot:token") {
+		t.Error("expected existing CLLAMA_TOKEN behavior to remain")
+	}
+	for _, unexpected := range []string{"CLAW_SELF_HISTORY_URL", "CLAW_SELF_HISTORY_TOKEN", "CLAW_AGENT_ID"} {
+		if strings.Contains(out, unexpected) {
+			t.Errorf("did not expect %s without cllama enabled", unexpected)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Project `CLAW_SELF_HISTORY_URL`, `CLAW_SELF_HISTORY_TOKEN`, and `CLAW_AGENT_ID` env vars per cllama-enabled service (per-ordinal for `count > 1`) so agents have a copy-pasteable handle to their own retained turns.
- Emit a `## Self-history introspection` section in `CLAWDAPUS.md` (right after `## LLM Proxy`, gated on `len(rc.Cllama) > 0`) describing the endpoint, env vars, ndjson response shape, pagination, and a curl example using only env-var references.
- Names are deliberately `CLAW_SELF_HISTORY_*` (not `CLAW_HISTORY_*`) to avoid colliding with the existing memory-replay `CLAW_HISTORY_URL` / `CLAW_HISTORY_TOKEN` (which target a peer service's history, not self).

## Why this shape
- `cllama`'s `GET /history/{agentID}` already authorizes self-reads against the agent's metadata token (`cllama/internal/proxy/history.go::authorizeHistoryRequest`), so no new auth or wire change is needed.
- Env-var references in the markdown keep raw bearers out of generated docs and align with the `CLAW_API_TOKEN` / `CLAW_API_URL` pattern.
- The injection point is `internal/pod/compose_emit.go` next to the existing per-ordinal `CLLAMA_TOKEN` selection — both `serviceName` (ordinal-expanded, e.g. `bot-0`) and the matching token are already available there.

## Test plan
- [x] `go vet ./...`
- [x] `go test ./...` — all packages green, including new tests in `internal/pod/compose_emit_test.go` (count=1, count>1 ordinal, absent without cllama) and `internal/driver/shared/clawdapus_md_test.go` (present for cllama, absent without).
- [ ] Manual smoke (post-merge): `claw up -d` on `examples/quickstart/`, then `claw compose exec <svc> sh -c 'curl -sS -H "Authorization: Bearer $CLAW_SELF_HISTORY_TOKEN" "$CLAW_SELF_HISTORY_URL/$CLAW_AGENT_ID?limit=5"'` — expect ndjson lines after the agent has made at least one completion.

## Design history
Plan + design discussion at `docs/plans/2026-04-29-issue-213-self-history-clawdapus-section.md`. The plan documents that the issue body's premise (claiming `CLAW_HISTORY_URL`/`CLAW_HISTORY_TOKEN` are projected to all cllama-enabled containers today) was inaccurate — those env vars currently live only on memory-adapter consumer services in `prepareHistoryReplayRuntime`.

Closes #213