### PR TITLE
Drop agent-ID placeholder from self-history (#218)

### DIFF
--- a/internal/driver/shared/clawdapus_md.go
+++ b/internal/driver/shared/clawdapus_md.go
@@ -127,7 +127,7 @@ func GenerateClawdapusMD(rc *driver.ResolvedClaw, podName string) string {
 		b.WriteString("## Self-history introspection\n\n")
 		b.WriteString("You can read your own retained turns through the cllama proxy. Self-scoped: returns only your own history, not pod-wide or cross-agent.\n\n")
 		firstProxy := cllama.ProxyServiceName(rc.Cllama[0])
-		b.WriteString(fmt.Sprintf("- **Endpoint:** `GET http://%s:8080/history/<your-agent-id>`\n", firstProxy))
+		b.WriteString(fmt.Sprintf("- **Endpoint:** `GET http://%s:8080/history`\n", firstProxy))
 		b.WriteString("- **Auth:** pre-wired by Clawdapus\n")
 		b.WriteString("- **Pagination:** optional `?after=<RFC3339>` and `?limit=<N>`\n")
 		b.WriteString("- **Response:** newline-delimited JSON (`application/x-ndjson`), one retained entry per line in chronological order\n\n")

--- a/internal/driver/shared/clawdapus_md_test.go
+++ b/internal/driver/shared/clawdapus_md_test.go
@@ -132,7 +132,7 @@ func TestClawdapusMDIncludesSelfHistorySectionForCllama(t *testing.T) {
 	md := GenerateClawdapusMD(rc, "test-pod")
 	for _, want := range []string{
 		"## Self-history introspection",
-		"GET http://cllama:8080/history/<your-agent-id>",
+		"GET http://cllama:8080/history",
 		"pre-wired by Clawdapus",
 		"application/x-ndjson",
 		"only your own history",
@@ -143,6 +143,9 @@ func TestClawdapusMDIncludesSelfHistorySectionForCllama(t *testing.T) {
 	}
 	if strings.Contains(md, "curl -H") {
 		t.Error("self-history section should not include a curl block")
+	}
+	if strings.Contains(md, "<your-agent-id>") {
+		t.Error("self-history section should not require an agent-id placeholder")
 	}
 	if strings.Contains(md, "CLAW_SELF_HISTORY_TOKEN") || strings.Contains(md, "CLAW_AGENT_ID") {
 		t.Error("self-history section should not expose auth or identity env vars")

--- a/internal/infraimages/release_manifest.go
+++ b/internal/infraimages/release_manifest.go
@@ -8,7 +8,7 @@ const (
 	DefaultClawdashTag     = DefaultClawInfraTag
 	DefaultClawWallTag     = DefaultClawInfraTag
 	DefaultClawMCPStdioTag = DefaultClawInfraTag
-	DefaultCllamaTag       = "v0.6.2"
+	DefaultCllamaTag       = "v0.6.3"
 	DefaultHermesBaseTag   = "v2026.4.23-claw.1"
 )
 

--- a/internal/pod/compose_emit.go
+++ b/internal/pod/compose_emit.go
@@ -286,7 +286,6 @@ func EmitCompose(p *Pod, results map[string]*driver.MaterializeResult, proxies .
 					if len(svc.Claw.Cllama) > 0 {
 						env["CLAW_SELF_HISTORY_URL"] = fmt.Sprintf("http://%s:8080/history", cllama.ProxyServiceName(svc.Claw.Cllama[0]))
 						env["CLAW_SELF_HISTORY_TOKEN"] = selectedToken
-						env["CLAW_AGENT_ID"] = serviceName
 					}
 				}
 			}

--- a/internal/pod/compose_emit_test.go
+++ b/internal/pod/compose_emit_test.go
@@ -1064,11 +1064,8 @@ func TestEmitComposeCllamaTokenPerOrdinalOverride(t *testing.T) {
 	if !strings.Contains(out, "CLAW_SELF_HISTORY_TOKEN: bot-1:token") {
 		t.Error("expected bot-1 self-history token")
 	}
-	if !strings.Contains(out, "CLAW_AGENT_ID: bot-0") {
-		t.Error("expected bot-0 agent id")
-	}
-	if !strings.Contains(out, "CLAW_AGENT_ID: bot-1") {
-		t.Error("expected bot-1 agent id")
+	if strings.Contains(out, "CLAW_AGENT_ID") {
+		t.Error("did not expect CLAW_AGENT_ID after self-history identity inference")
 	}
 }
 
@@ -1102,11 +1099,13 @@ func TestEmitComposeSelfHistoryEnvForSingleCllamaService(t *testing.T) {
 		"CLLAMA_TOKEN: bot:token",
 		"CLAW_SELF_HISTORY_URL: http://cllama:8080/history",
 		"CLAW_SELF_HISTORY_TOKEN: bot:token",
-		"CLAW_AGENT_ID: bot",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("expected compose output to contain %q", want)
 		}
+	}
+	if strings.Contains(out, "CLAW_AGENT_ID") {
+		t.Error("did not expect CLAW_AGENT_ID after self-history identity inference")
 	}
 }
 

--- a/site/changelog.md
+++ b/site/changelog.md
@@ -29,7 +29,7 @@ outline: deep
 
 ## Unreleased
 
-<!-- Nothing yet -->
+- **Self-history no longer needs an agent-ID placeholder** — `CLAWDAPUS.md` now points cllama-enabled agents at `GET http://cllama:8080/history`, relying on cllama v0.6.3 to infer identity from the pre-wired bearer. `CLAW_AGENT_ID` is no longer projected for self-history; `CLAW_SELF_HISTORY_URL` and `CLAW_SELF_HISTORY_TOKEN` remain for shell-capable runners. Closes #218.
 
 ## v0.14.5 <Badge type="tip" text="Latest" /> {#v0-14-5}
 


### PR DESCRIPTION
## Summary

- update generated `CLAWDAPUS.md` self-history guidance to use `GET http://<cllama>:8080/history` with no `<your-agent-id>` placeholder
- stop projecting `CLAW_AGENT_ID` for self-history while keeping `CLAW_SELF_HISTORY_URL` and `CLAW_SELF_HISTORY_TOKEN` for shell-capable runners
- bump the cllama submodule and `DefaultCllamaTag` to released cllama v0.6.3
- add an Unreleased changelog note

## Release Pin Note

The cllama submodule pointer and `DefaultCllamaTag` move with this change because the generated `CLAWDAPUS.md` endpoint references `GET /history`, which only exists in cllama v0.6.3+. The v0.6.3 release and `ghcr.io/mostlydev/cllama:v0.6.3` image already exist.

## Tests

- `go test ./internal/driver/shared ./internal/pod ./internal/infraimages`
- `go vet ./...`
- `go test ./...`
- `git diff --check`

Closes #218
