### PR TITLE
Allow claw compose build with stale generated compose

### DIFF
--- a/cmd/claw/compose.go
+++ b/cmd/claw/compose.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 )
@@ -9,7 +10,27 @@ import (
 var composePodFile string
 var skipStalenessCheck bool
 
+type composeStalenessPolicy int
+
+const (
+	composeStalenessError composeStalenessPolicy = iota
+	composeStalenessWarn
+	composeStalenessIgnore
+)
+
 func resolveComposeGeneratedPath() (string, error) {
+	policy := composeStalenessError
+	if skipStalenessCheck {
+		policy = composeStalenessIgnore
+	}
+	return resolveComposeGeneratedPathWithPolicy(policy, nil)
+}
+
+func resolveComposeGeneratedPathAllowStale(warningWriter io.Writer) (string, error) {
+	return resolveComposeGeneratedPathWithPolicy(composeStalenessWarn, warningWriter)
+}
+
+func resolveComposeGeneratedPathWithPolicy(policy composeStalenessPolicy, warningWriter io.Writer) (string, error) {
 	if composePodFile != "" {
 		absPodFile, err := filepath.Abs(composePodFile)
 		if err != nil {
@@ -21,12 +42,8 @@ func resolveComposeGeneratedPath() (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("no compose.generated.yml found next to %q (run 'claw up %s' first)", composePodFile, composePodFile)
 		}
-		if !skipStalenessCheck {
-			if podInfo, err := os.Stat(absPodFile); err == nil {
-				if podInfo.ModTime().After(genInfo.ModTime()) {
-					return "", fmt.Errorf("claw-pod.yml is newer than compose.generated.yml — run 'claw up' to regenerate")
-				}
-			}
+		if err := checkComposeGeneratedStaleness(absPodFile, genInfo, policy, warningWriter); err != nil {
+			return "", err
 		}
 		return generatedPath, nil
 	}
@@ -41,15 +58,34 @@ func resolveComposeGeneratedPath() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("no compose.generated.yml found in %q (rerun from pod directory or pass --file <path-to-claw-pod.yml>)", cwd)
 	}
-	if !skipStalenessCheck {
-		podPath := filepath.Join(cwd, "claw-pod.yml")
-		if podInfo, err := os.Stat(podPath); err == nil {
-			if podInfo.ModTime().After(genInfo.ModTime()) {
-				return "", fmt.Errorf("claw-pod.yml is newer than compose.generated.yml — run 'claw up' to regenerate")
-			}
-		}
+	podPath := filepath.Join(cwd, "claw-pod.yml")
+	if err := checkComposeGeneratedStaleness(podPath, genInfo, policy, warningWriter); err != nil {
+		return "", err
 	}
 	return generatedPath, nil
+}
+
+func checkComposeGeneratedStaleness(podPath string, genInfo os.FileInfo, policy composeStalenessPolicy, warningWriter io.Writer) error {
+	if policy == composeStalenessIgnore {
+		return nil
+	}
+
+	podInfo, err := os.Stat(podPath)
+	if err != nil {
+		return nil
+	}
+	if !podInfo.ModTime().After(genInfo.ModTime()) {
+		return nil
+	}
+
+	if policy == composeStalenessWarn {
+		if warningWriter != nil {
+			fmt.Fprintln(warningWriter, "[claw] warning: claw-pod.yml is newer than compose.generated.yml; building against the previously generated compose. Run 'claw up' afterward to apply the new pod config.")
+		}
+		return nil
+	}
+
+	return fmt.Errorf("claw-pod.yml is newer than compose.generated.yml — run 'claw up' to regenerate")
 }
 
 func init() {

--- a/cmd/claw/compose_passthrough.go
+++ b/cmd/claw/compose_passthrough.go
@@ -17,7 +17,13 @@ var composePassthroughCmd = &cobra.Command{
 			return fmt.Errorf("usage: claw compose <subcommand> [args...]")
 		}
 
-		generatedPath, err := resolveComposeGeneratedPath()
+		var generatedPath string
+		var err error
+		if composePassthroughAllowsStaleGenerated(args) {
+			generatedPath, err = resolveComposeGeneratedPathAllowStale(os.Stderr)
+		} else {
+			generatedPath, err = resolveComposeGeneratedPath()
+		}
 		if err != nil {
 			return err
 		}
@@ -32,6 +38,10 @@ var composePassthroughCmd = &cobra.Command{
 		}
 		return nil
 	},
+}
+
+func composePassthroughAllowsStaleGenerated(args []string) bool {
+	return len(args) > 0 && args[0] == "build"
 }
 
 func init() {

--- a/cmd/claw/compose_test.go
+++ b/cmd/claw/compose_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -105,6 +106,32 @@ func TestResolveComposeGeneratedPathStaleWithPodFile(t *testing.T) {
 	}
 }
 
+func TestResolveComposeGeneratedPathAllowStaleWarnsWithPodFile(t *testing.T) {
+	dir := t.TempDir()
+	podDir := filepath.Join(dir, "examples", "openclaw")
+	os.MkdirAll(podDir, 0755)
+
+	os.WriteFile(filepath.Join(podDir, "compose.generated.yml"), []byte("services: {}"), 0644)
+	time.Sleep(50 * time.Millisecond)
+	os.WriteFile(filepath.Join(podDir, "claw-pod.yml"), []byte("services: {}"), 0644)
+
+	composePodFile = filepath.Join(podDir, "claw-pod.yml")
+	defer func() { composePodFile = "" }()
+
+	var warnings bytes.Buffer
+	path, err := resolveComposeGeneratedPathAllowStale(&warnings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := filepath.Join(podDir, "compose.generated.yml")
+	if path != expected {
+		t.Errorf("expected %q, got %q", expected, path)
+	}
+	if got := warnings.String(); !strings.Contains(got, "warning") || !strings.Contains(got, "Run 'claw up' afterward") {
+		t.Fatalf("expected stale warning, got %q", got)
+	}
+}
+
 func TestResolveComposeGeneratedPathStaleDefaultDir(t *testing.T) {
 	orig, _ := os.Getwd()
 	dir := t.TempDir()
@@ -124,6 +151,30 @@ func TestResolveComposeGeneratedPathStaleDefaultDir(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "claw up") {
 		t.Errorf("expected error to mention 'claw up', got: %s", err.Error())
+	}
+}
+
+func TestResolveComposeGeneratedPathAllowStaleWarnsDefaultDir(t *testing.T) {
+	orig, _ := os.Getwd()
+	dir := t.TempDir()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+
+	os.WriteFile(filepath.Join(dir, "compose.generated.yml"), []byte("services: {}"), 0644)
+	time.Sleep(50 * time.Millisecond)
+	os.WriteFile(filepath.Join(dir, "claw-pod.yml"), []byte("services: {}"), 0644)
+
+	composePodFile = ""
+	var warnings bytes.Buffer
+	path, err := resolveComposeGeneratedPathAllowStale(&warnings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasSuffix(path, string(filepath.Separator)+"compose.generated.yml") {
+		t.Errorf("expected absolute compose.generated.yml path, got %q", path)
+	}
+	if got := warnings.String(); !strings.Contains(got, "warning") || !strings.Contains(got, "Run 'claw up' afterward") {
+		t.Fatalf("expected stale warning, got %q", got)
 	}
 }
 
@@ -148,6 +199,22 @@ func TestResolveComposeGeneratedPathFreshNotStale(t *testing.T) {
 	expected := filepath.Join(podDir, "compose.generated.yml")
 	if path != expected {
 		t.Errorf("expected %q, got %q", expected, path)
+	}
+}
+
+func TestComposePassthroughAllowsStaleGeneratedOnlyForBuild(t *testing.T) {
+	if !composePassthroughAllowsStaleGenerated([]string{"build", "trading-api"}) {
+		t.Fatal("expected compose build to allow stale generated compose with a warning")
+	}
+	for _, args := range [][]string{
+		nil,
+		{"ps"},
+		{"logs", "trading-api"},
+		{"up", "-d"},
+	} {
+		if composePassthroughAllowsStaleGenerated(args) {
+			t.Fatalf("did not expect %v to allow stale generated compose", args)
+		}
 	}
 }
 

--- a/site/guide/cli.md
+++ b/site/guide/cli.md
@@ -635,7 +635,10 @@ Error: claw-pod.yml is newer than compose.generated.yml — run 'claw up' to reg
 
 **Resolution:** Run `claw up` to regenerate `compose.generated.yml` from the updated pod definition.
 
-**Exemptions:** `claw down` skips the staleness check. You can always tear down a pod regardless of whether the definition has changed -- you should never be blocked from stopping containers.
+**Exemptions:**
+
+- `claw down` skips the staleness check. You can always tear down a pod regardless of whether the definition has changed -- you should never be blocked from stopping containers.
+- `claw compose build` downgrades the staleness check to a warning. Building a service image does not depend on the generated compose matching the pod file -- it only needs the existing `services.<name>.build` block. The warning reminds you to run `claw up` afterward to apply any pod-level changes. This carve-out applies only to the literal `build` subcommand; `claw compose --progress=plain build foo` (with global docker compose flags before the subcommand) still trips the strict guard. If you need that shape, invoke `docker compose -f compose.generated.yml ...` directly.
 
 ---
 
@@ -651,7 +654,7 @@ Error: claw-pod.yml is newer than compose.generated.yml — run 'claw up' to reg
 | `claw logs` | Yes | Yes | |
 | `claw health` | Yes | Yes | |
 | `claw audit` | Yes | Yes | Reads pod manifest from `.claw-runtime/` |
-| `claw compose` | Yes | Yes | Passthrough to `docker compose` |
+| `claw compose` | Yes¹ | Yes | Passthrough to `docker compose` (¹ `claw compose build` warns instead of erroring; see [Staleness Guard](#staleness-guard)) |
 | `claw inspect` | -- | No | Reads image labels directly |
 | `claw doctor` | -- | No | System prerequisite check |
 | `claw init` | -- | No | Project scaffolding |


### PR DESCRIPTION
## Summary

- Downgrade `claw compose build` staleness handling from an error to a warning so a single service image rebuild can use the existing `compose.generated.yml`.
- Keep other `claw compose <subcmd>` calls strict, including `ps`, `logs`, and `up`.
- Make the warning actionable by telling users to run `claw up` afterward to apply pod-level changes.
- Document the `claw compose build` carve-out in the CLI guide.

Partially addresses #222: this removes the build-refusal half of the circular dependency. The descriptor-staleness half for runtime-emitted `.claw-describe.json` flows still needs the larger Option 2 shape from the issue, such as `claw up --build-first <svc>` running build, descriptor refresh, regeneration, and apply as one command.

Refs #222

## Test plan

- [x] `go test ./cmd/claw -run 'TestResolveComposeGeneratedPath|TestComposePassthroughAllowsStaleGeneratedOnlyForBuild'`
- [x] `go test ./...`
- [x] `go vet ./...`
