### PR TITLE
Refresh runtime descriptors during claw up --fix

### DIFF
--- a/cmd/claw/compose_up.go
+++ b/cmd/claw/compose_up.go
@@ -67,11 +67,18 @@ var (
 	findClawdapusRepoRoot        = findRepoRoot
 	runInfraDockerCommand        = runInfraDockerCommandDefault
 	runComposeDockerCommand      = runComposeDockerCommandDefault
+	runRuntimeDescriptorCommand  = runRuntimeDescriptorCommandDefault
+	refreshRuntimeDescriptor     = refreshRuntimeDescriptorDefault
 	loadDescriptorFromFile       = describe.LoadFromFile
 	loadDescriptorFromImage      = describe.LoadFromImage
 	loadDescriptorFromBuildCtx   = describe.LoadFromBuildContext
 	resolveBuildContextFile      = describe.ResolveBuildContextFile
 	loadDockerfileMetadata       = inspect.LoadFromDockerfile
+)
+
+var (
+	runtimeDescriptorRefreshTimeout      = 45 * time.Second
+	runtimeDescriptorRefreshPollInterval = time.Second
 )
 
 var composeUpCmd = &cobra.Command{
@@ -405,28 +412,12 @@ func runComposeUp(podFile string) (err error) {
 		return err
 	}
 
-	if err := collectServiceDescriptors(podDir, p, serviceImageRefs, serviceInfos, serviceDescriptors); err != nil {
-		return err
-	}
-	feedRegistry, err := describe.BuildFeedRegistry(serviceDescriptors)
-	if err != nil {
-		return fmt.Errorf("build feed registry: %w", err)
-	}
-	toolRegistry, err := describe.BuildToolRegistry(serviceDescriptors)
-	if err != nil {
-		return fmt.Errorf("build tool registry: %w", err)
-	}
-	if err := resolveFeedSubscriptions(p, feedRegistry); err != nil {
-		return err
-	}
-	resolvedTools, err := resolveToolSubscriptions(p, toolRegistry)
+	capabilities, err := resolvePodCapabilities(podFile, podDir, p, serviceImageRefs, serviceInfos, serviceDescriptors)
 	if err != nil {
 		return err
 	}
-	resolvedMemory, err := resolveMemorySubscriptions(p, serviceDescriptors)
-	if err != nil {
-		return err
-	}
+	resolvedTools := capabilities.Tools
+	resolvedMemory := capabilities.Memory
 	if err := attachCapabilityProvidersToInternalNetwork(p, resolvedTools, resolvedMemory); err != nil {
 		return err
 	}
@@ -1214,6 +1205,114 @@ type resolvedMemorySubscription struct {
 	Config  *pod.MemoryEntry
 }
 
+type resolvedPodCapabilities struct {
+	Tools  map[string][]describe.ToolSpec
+	Memory map[string]*resolvedMemorySubscription
+}
+
+func resolvePodCapabilities(podFile, podDir string, p *pod.Pod, imageRefs map[string]string, infos map[string]*inspect.ClawInfo, descriptors map[string]*describe.ServiceDescriptor) (*resolvedPodCapabilities, error) {
+	refreshed := make(map[string]struct{})
+	for {
+		capabilities, err := resolvePodCapabilitiesOnce(podDir, p, imageRefs, infos, descriptors)
+		if err == nil {
+			return capabilities, nil
+		}
+
+		serviceName, canRefresh := runtimeDescriptorRefreshCandidate(err, p)
+		if !canRefresh {
+			return nil, err
+		}
+		if !composeUpFix {
+			return nil, remediationErrorf(upFixCommand(podFile), "%s", err)
+		}
+		if _, already := refreshed[serviceName]; already {
+			return nil, err
+		}
+		if err := refreshRuntimeDescriptor(podFile, podDir, p, serviceName, imageRefs, infos, descriptors); err != nil {
+			return nil, err
+		}
+		refreshed[serviceName] = struct{}{}
+	}
+}
+
+func resolvePodCapabilitiesOnce(podDir string, p *pod.Pod, imageRefs map[string]string, infos map[string]*inspect.ClawInfo, descriptors map[string]*describe.ServiceDescriptor) (*resolvedPodCapabilities, error) {
+	if err := collectServiceDescriptors(podDir, p, imageRefs, infos, descriptors); err != nil {
+		return nil, err
+	}
+	feedRegistry, err := describe.BuildFeedRegistry(descriptors)
+	if err != nil {
+		return nil, fmt.Errorf("build feed registry: %w", err)
+	}
+	toolRegistry, err := describe.BuildToolRegistry(descriptors)
+	if err != nil {
+		return nil, fmt.Errorf("build tool registry: %w", err)
+	}
+	if err := resolveFeedSubscriptions(p, feedRegistry); err != nil {
+		return nil, err
+	}
+	resolvedTools, err := resolveToolSubscriptions(p, toolRegistry)
+	if err != nil {
+		return nil, err
+	}
+	resolvedMemory, err := resolveMemorySubscriptions(p, descriptors)
+	if err != nil {
+		return nil, err
+	}
+	return &resolvedPodCapabilities{
+		Tools:  resolvedTools,
+		Memory: resolvedMemory,
+	}, nil
+}
+
+type toolResolutionError struct {
+	ConsumerService string
+	PolicyIndex     int
+	ToolService     string
+	ToolName        string
+}
+
+func (e *toolResolutionError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.ToolName == "" {
+		return fmt.Sprintf("service %q: tool policy %d references unknown tool service %q", e.ConsumerService, e.PolicyIndex, e.ToolService)
+	}
+	return fmt.Sprintf("service %q: tool policy for %q references unknown tool %q", e.ConsumerService, e.ToolService, e.ToolName)
+}
+
+func runtimeDescriptorRefreshCandidate(err error, p *pod.Pod) (string, bool) {
+	var toolErr *toolResolutionError
+	if !errors.As(err, &toolErr) || toolErr == nil {
+		return "", false
+	}
+	serviceName := strings.TrimSpace(toolErr.ToolService)
+	if serviceName == "" || p == nil {
+		return "", false
+	}
+	svc := p.Services[serviceName]
+	if !serviceHasBuildConfig(svc) {
+		return "", false
+	}
+	return serviceName, true
+}
+
+func serviceHasBuildConfig(svc *pod.Service) bool {
+	if svc == nil {
+		return false
+	}
+	cfg, err := parseServiceBuildConfig(svc.Compose["build"])
+	return err == nil && cfg != nil
+}
+
+func upFixCommand(podFile string) string {
+	podFile = strings.TrimSpace(podFile)
+	if podFile == "" || podFile == "claw-pod.yml" {
+		return "claw up --fix -d"
+	}
+	return "claw up --fix -d " + podFile
+}
+
 func resolveToolSubscriptions(p *pod.Pod, registry describe.ToolRegistry) (map[string][]describe.ToolSpec, error) {
 	if p == nil {
 		return nil, nil
@@ -1230,7 +1329,11 @@ func resolveToolSubscriptions(p *pod.Pod, registry describe.ToolRegistry) (map[s
 		for i, policy := range svc.Claw.Tools {
 			specs, ok := registry[policy.Service]
 			if !ok {
-				return nil, fmt.Errorf("service %q: tool policy %d references unknown tool service %q", serviceName, i, policy.Service)
+				return nil, &toolResolutionError{
+					ConsumerService: serviceName,
+					PolicyIndex:     i,
+					ToolService:     policy.Service,
+				}
 			}
 			byName := make(map[string]describe.ToolSpec, len(specs))
 			for _, spec := range specs {
@@ -1252,7 +1355,12 @@ func resolveToolSubscriptions(p *pod.Pod, registry describe.ToolRegistry) (map[s
 			for _, toolName := range policy.Allow {
 				spec, ok := byName[toolName]
 				if !ok {
-					return nil, fmt.Errorf("service %q: tool policy for %q references unknown tool %q", serviceName, policy.Service, toolName)
+					return nil, &toolResolutionError{
+						ConsumerService: serviceName,
+						PolicyIndex:     i,
+						ToolService:     policy.Service,
+						ToolName:        toolName,
+					}
 				}
 				key := spec.Service + "." + spec.Name
 				if _, exists := seen[key]; exists {
@@ -3476,12 +3584,18 @@ func resolveServiceMetadata(podDir string, p *pod.Pod, serviceName string, svc *
 		if err != nil {
 			return "", nil, nil, fmt.Errorf("load discovered descriptor %q: %w", descriptorPath, err)
 		}
-		warnDiscoveryDrift(serviceName, descriptor, svc)
-		if svc != nil && strings.TrimSpace(svc.Image) != "" {
-			imageRefs[serviceName] = strings.TrimSpace(svc.Image)
+		if svc != nil && svc.IsMCPStdioSidecar() {
+			warnDiscoveryDrift(serviceName, descriptor, svc)
+		} else if !runtimeDescriptorSnapshotUsable(descriptor, svc) {
+			descriptor = nil
 		}
-		descriptors[serviceName] = descriptor
-		return strings.TrimSpace(svc.Image), infos[serviceName], descriptor, nil
+		if descriptor != nil {
+			if svc != nil && strings.TrimSpace(svc.Image) != "" {
+				imageRefs[serviceName] = strings.TrimSpace(svc.Image)
+			}
+			descriptors[serviceName] = descriptor
+			return strings.TrimSpace(svc.Image), infos[serviceName], descriptor, nil
+		}
 	}
 
 	imageRef, info, err := inspectServiceMetadata(podDir, p, serviceName, svc, imageRefs, infos)
@@ -3538,7 +3652,7 @@ func explicitDescribeFile(podDir string, svc *pod.Service) string {
 }
 
 func discoveredDescribeFile(podDir, serviceName string, svc *pod.Service) string {
-	if svc == nil || !svc.IsMCPStdioSidecar() {
+	if svc == nil || (!svc.IsMCPStdioSidecar() && !serviceHasBuildConfig(svc)) {
 		return ""
 	}
 	path := discoveredSnapshotPath(podDir, serviceName)
@@ -3546,6 +3660,150 @@ func discoveredDescribeFile(podDir, serviceName string, svc *pod.Service) string
 		return path
 	}
 	return ""
+}
+
+func runtimeDescriptorSnapshotUsable(descriptor *describe.ServiceDescriptor, svc *pod.Service) bool {
+	if descriptor == nil || svc == nil {
+		return false
+	}
+	meta := descriptor.XClawDiscovery
+	if meta == nil || strings.TrimSpace(meta.Command) != "runtime-descriptor" {
+		return false
+	}
+	imageRef := strings.TrimSpace(svc.Image)
+	if meta.WrapperImage != "" && imageRef != "" && meta.WrapperImage != imageRef {
+		return false
+	}
+	if meta.WrapperImageID != "" && imageRef != "" {
+		currentID, _ := discoveryImageIdentity(context.Background(), imageRef)
+		if currentID != "" && currentID != meta.WrapperImageID {
+			return false
+		}
+	}
+	return true
+}
+
+func refreshRuntimeDescriptorDefault(podFile, podDir string, p *pod.Pod, serviceName string, imageRefs map[string]string, infos map[string]*inspect.ClawInfo, descriptors map[string]*describe.ServiceDescriptor) error {
+	if p == nil {
+		return fmt.Errorf("refresh runtime descriptor: pod is required")
+	}
+	svc := p.Services[serviceName]
+	if svc == nil {
+		return fmt.Errorf("refresh runtime descriptor: service %q not found", serviceName)
+	}
+	cfg, err := parseServiceBuildConfig(svc.Compose["build"])
+	if err != nil {
+		return fmt.Errorf("service %q: parse build: %w", serviceName, err)
+	}
+	if cfg == nil {
+		return fmt.Errorf("service %q: runtime descriptor refresh requires a build-backed service", serviceName)
+	}
+
+	imageRef := strings.TrimSpace(svc.Image)
+	if imageRef == "" {
+		imageRef = managedServiceImageRef(p.Name, serviceName)
+		assignServiceImageRef(svc, imageRef)
+	}
+
+	fmt.Printf("[claw] %s: refreshing runtime descriptor via --fix\n", serviceName)
+	if err := buildManagedServiceImage(podFile, podDir, imageRef, cfg); err != nil {
+		return fmt.Errorf("service %q: build before descriptor refresh: %w", serviceName, err)
+	}
+
+	delete(imageRefs, serviceName)
+	delete(infos, serviceName)
+	imageRef, info, err := inspectServiceMetadata(podDir, p, serviceName, svc, imageRefs, infos)
+	if err != nil {
+		return fmt.Errorf("service %q: inspect descriptor metadata after build: %w", serviceName, err)
+	}
+	descriptorPath, _ := resolvedImageDescriptorPath(info)
+
+	composePath := filepath.Join(podDir, "compose.generated.yml")
+	if _, err := os.Stat(composePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("service %q: cannot refresh runtime descriptor because compose.generated.yml is missing; run an initial deploy with a baked descriptor or set x-claw.describe-file", serviceName)
+		}
+		return fmt.Errorf("service %q: stat compose.generated.yml: %w", serviceName, err)
+	}
+
+	if out, err := runRuntimeDescriptorCommand("compose", "-f", composePath, "up", "-d", "--force-recreate", serviceName); err != nil {
+		return fmt.Errorf("service %q: start provider for descriptor refresh: %w%s", serviceName, err, commandOutputSuffix(out))
+	}
+
+	descriptor, err := copyRuntimeDescriptorSnapshot(composePath, serviceName, descriptorPath, imageRef)
+	if err != nil {
+		return err
+	}
+	descriptors[serviceName] = descriptor
+	fmt.Printf("[claw] %s: refreshed descriptor snapshot %s\n", serviceName, discoveredSnapshotPath(podDir, serviceName))
+	return nil
+}
+
+func copyRuntimeDescriptorSnapshot(composePath, serviceName, descriptorPath, imageRef string) (*describe.ServiceDescriptor, error) {
+	podDir := filepath.Dir(composePath)
+	snapshotPath := discoveredSnapshotPath(podDir, serviceName)
+	tmp, err := os.CreateTemp("", "claw-runtime-descriptor-*.json")
+	if err != nil {
+		return nil, fmt.Errorf("service %q: create descriptor refresh temp file: %w", serviceName, err)
+	}
+	tmpPath := tmp.Name()
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return nil, fmt.Errorf("service %q: close descriptor refresh temp file: %w", serviceName, err)
+	}
+	defer os.Remove(tmpPath)
+
+	deadline := time.Now().Add(runtimeDescriptorRefreshTimeout)
+	var lastErr error
+	for {
+		_ = os.Remove(tmpPath)
+		source := fmt.Sprintf("%s:%s", serviceName, descriptorPath)
+		if out, err := runRuntimeDescriptorCommand("compose", "-f", composePath, "cp", source, tmpPath); err != nil {
+			lastErr = fmt.Errorf("docker compose cp: %w%s", err, commandOutputSuffix(out))
+		} else if descriptor, err := loadDescriptorFromFile(tmpPath); err != nil {
+			lastErr = err
+		} else {
+			imageID, digest := discoveryImageIdentity(context.Background(), imageRef)
+			descriptor.XClawDiscovery = &describe.DiscoveryMetadata{
+				Command:            "runtime-descriptor",
+				WrapperImage:       imageRef,
+				WrapperImageDigest: digest,
+				WrapperImageID:     imageID,
+				DiscoveredAt:       time.Now().UTC().Format(time.RFC3339),
+			}
+			if err := writeDescriptorSnapshot(snapshotPath, descriptor); err != nil {
+				return nil, fmt.Errorf("service %q: write runtime descriptor snapshot: %w", serviceName, err)
+			}
+			return descriptor, nil
+		}
+
+		if runtimeDescriptorRefreshTimeout <= 0 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(runtimeDescriptorRefreshPollInterval)
+	}
+
+	logs := runtimeDescriptorLogs(composePath, serviceName)
+	return nil, fmt.Errorf("service %q: descriptor %q was not available after refresh: %v%s", serviceName, descriptorPath, lastErr, logs)
+}
+
+func runtimeDescriptorLogs(composePath, serviceName string) string {
+	out, err := runRuntimeDescriptorCommand("compose", "-f", composePath, "logs", "--tail", "80", serviceName)
+	if err != nil {
+		return fmt.Sprintf("\ncontainer logs unavailable: %v%s", err, commandOutputSuffix(out))
+	}
+	if strings.TrimSpace(string(out)) == "" {
+		return "\ncontainer logs were empty"
+	}
+	return "\ncontainer logs:\n" + string(out)
+}
+
+func commandOutputSuffix(out []byte) string {
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return ""
+	}
+	return ": " + trimmed
 }
 
 func resolvedImageDescriptorPath(info *inspect.ClawInfo) (string, bool) {
@@ -4378,6 +4636,11 @@ func runComposeDockerCommandDefault(args ...string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+func runRuntimeDescriptorCommandDefault(args ...string) ([]byte, error) {
+	cmd := exec.Command("docker", args...)
+	return cmd.CombinedOutput()
 }
 
 func warnRunnerBaseDrift(podFile string, plans []plannedServiceImage) {

--- a/cmd/claw/compose_up_test.go
+++ b/cmd/claw/compose_up_test.go
@@ -464,6 +464,93 @@ func TestResolveServiceMetadataLoadsDiscoveredSnapshot(t *testing.T) {
 	}
 }
 
+func TestResolveServiceMetadataLoadsRuntimeSnapshotForBuildService(t *testing.T) {
+	tmpDir := t.TempDir()
+	serviceDir := filepath.Join(tmpDir, "services", "trading-api")
+	if err := os.MkdirAll(serviceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(serviceDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	descriptor := &describe.ServiceDescriptor{
+		Version: 2,
+		Tools: []describe.ToolDescriptor{{
+			Name:        "update_position",
+			Description: "Update a position.",
+			InputSchema: map[string]interface{}{"type": "object"},
+			HTTP:        &describe.ToolHTTP{Method: "POST", Path: "/tools/update_position"},
+		}},
+		XClawDiscovery: &describe.DiscoveryMetadata{
+			Command:      "runtime-descriptor",
+			WrapperImage: "trading-api:latest",
+		},
+	}
+	if err := writeDescriptorSnapshot(discoveredSnapshotPath(tmpDir, "trading-api"), descriptor); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+	p := &pod.Pod{Services: map[string]*pod.Service{
+		"trading-api": {
+			Image: "trading-api:latest",
+			Compose: map[string]interface{}{
+				"build": map[string]interface{}{
+					"context":    "./services/trading-api",
+					"dockerfile": "Dockerfile",
+				},
+			},
+		},
+	}}
+
+	_, _, got, err := resolveServiceMetadata(tmpDir, p, "trading-api", p.Services["trading-api"], map[string]string{}, map[string]*inspect.ClawInfo{}, map[string]*describe.ServiceDescriptor{})
+	if err != nil {
+		t.Fatalf("resolveServiceMetadata: %v", err)
+	}
+	if got == nil || len(got.Tools) != 1 || got.Tools[0].Name != "update_position" {
+		t.Fatalf("unexpected descriptor: %+v", got)
+	}
+}
+
+func TestResolveServiceMetadataIgnoresNonRuntimeSnapshotForBuildService(t *testing.T) {
+	tmpDir := t.TempDir()
+	serviceDir := filepath.Join(tmpDir, "services", "trading-api")
+	if err := os.MkdirAll(serviceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(serviceDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	descriptor := &describe.ServiceDescriptor{
+		Version: 2,
+		Tools: []describe.ToolDescriptor{{
+			Name:        "stale_tool",
+			Description: "Stale tool.",
+			InputSchema: map[string]interface{}{"type": "object"},
+			HTTP:        &describe.ToolHTTP{Method: "POST", Path: "/tools/stale"},
+		}},
+	}
+	if err := writeDescriptorSnapshot(discoveredSnapshotPath(tmpDir, "trading-api"), descriptor); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+	p := &pod.Pod{Services: map[string]*pod.Service{
+		"trading-api": {
+			Compose: map[string]interface{}{
+				"build": map[string]interface{}{
+					"context":    "./services/trading-api",
+					"dockerfile": "Dockerfile",
+				},
+			},
+		},
+	}}
+
+	_, _, got, err := resolveServiceMetadata(tmpDir, p, "trading-api", p.Services["trading-api"], map[string]string{}, map[string]*inspect.ClawInfo{}, map[string]*describe.ServiceDescriptor{})
+	if err != nil {
+		t.Fatalf("resolveServiceMetadata: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected non-runtime snapshot to be ignored, got %+v", got)
+	}
+}
+
 func TestResolveServiceMetadataRequiresSnapshotForMCPStdio(t *testing.T) {
 	prevImageExists := imageExistsLocally
 	prevInspect := inspectClawImage
@@ -491,6 +578,108 @@ func TestResolveServiceMetadataRequiresSnapshotForMCPStdio(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "run 'claw discover echo'") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRefreshRuntimeDescriptorDefaultUsesExistingComposeAndWritesSnapshot(t *testing.T) {
+	podDir := t.TempDir()
+	serviceDir := filepath.Join(podDir, "services", "trading-api")
+	if err := os.MkdirAll(serviceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(serviceDir, "Dockerfile"), []byte("FROM scratch\nLABEL claw.describe=/app/.claw-describe.json\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	composePath := filepath.Join(podDir, "compose.generated.yml")
+	if err := os.WriteFile(composePath, []byte("services: {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	prevExists := imageExistsLocally
+	prevDockerBuild := dockerBuildTaggedImage
+	prevRun := runRuntimeDescriptorCommand
+	prevTimeout := runtimeDescriptorRefreshTimeout
+	prevPoll := runtimeDescriptorRefreshPollInterval
+	defer func() {
+		imageExistsLocally = prevExists
+		dockerBuildTaggedImage = prevDockerBuild
+		runRuntimeDescriptorCommand = prevRun
+		runtimeDescriptorRefreshTimeout = prevTimeout
+		runtimeDescriptorRefreshPollInterval = prevPoll
+	}()
+
+	imageExistsLocally = func(string) bool { return false }
+	var builtImage string
+	dockerBuildTaggedImage = func(imageRef, dockerfile, contextDir string, args map[string]buildArgValue, target string) error {
+		builtImage = imageRef
+		if dockerfile != filepath.Join(serviceDir, "Dockerfile") {
+			t.Fatalf("unexpected dockerfile: %q", dockerfile)
+		}
+		if contextDir != serviceDir {
+			t.Fatalf("unexpected build context: %q", contextDir)
+		}
+		return nil
+	}
+	runtimeDescriptorRefreshTimeout = 0
+	runtimeDescriptorRefreshPollInterval = 0
+	commands := make([]string, 0)
+	runRuntimeDescriptorCommand = func(args ...string) ([]byte, error) {
+		commands = append(commands, strings.Join(args, " "))
+		if len(args) >= 1 && args[0] == "compose" && slices.Contains(args, "cp") {
+			dest := args[len(args)-1]
+			data := `{
+  "version": 2,
+  "tools": [{
+    "name": "update_position",
+    "description": "Update a position.",
+    "inputSchema": {"type": "object"},
+    "http": {"method": "POST", "path": "/tools/update_position"}
+  }]
+}`
+			if err := os.WriteFile(dest, []byte(data), 0o644); err != nil {
+				return nil, err
+			}
+		}
+		return nil, nil
+	}
+
+	p := &pod.Pod{
+		Name: "test-pod",
+		Services: map[string]*pod.Service{
+			"trading-api": {
+				Image: "trading-api:latest",
+				Compose: map[string]interface{}{
+					"build": map[string]interface{}{
+						"context":    "./services/trading-api",
+						"dockerfile": "Dockerfile",
+					},
+				},
+			},
+		},
+	}
+	descriptors := map[string]*describe.ServiceDescriptor{}
+	if err := refreshRuntimeDescriptorDefault("claw-pod.yml", podDir, p, "trading-api", map[string]string{}, map[string]*inspect.ClawInfo{}, descriptors); err != nil {
+		t.Fatalf("refreshRuntimeDescriptorDefault: %v", err)
+	}
+	if builtImage != "trading-api:latest" {
+		t.Fatalf("expected image rebuild, got %q", builtImage)
+	}
+	if len(commands) < 2 || !strings.Contains(commands[0], "up -d --force-recreate trading-api") || !strings.Contains(commands[1], "cp trading-api:/app/.claw-describe.json") {
+		t.Fatalf("unexpected refresh commands: %+v", commands)
+	}
+	descriptor := descriptors["trading-api"]
+	if descriptor == nil || len(descriptor.Tools) != 1 || descriptor.Tools[0].Name != "update_position" {
+		t.Fatalf("unexpected refreshed descriptor: %+v", descriptor)
+	}
+	if descriptor.XClawDiscovery == nil || descriptor.XClawDiscovery.Command != "runtime-descriptor" {
+		t.Fatalf("expected runtime discovery metadata, got %+v", descriptor.XClawDiscovery)
+	}
+	snapshot, err := os.ReadFile(discoveredSnapshotPath(podDir, "trading-api"))
+	if err != nil {
+		t.Fatalf("read runtime descriptor snapshot: %v", err)
+	}
+	if !strings.Contains(string(snapshot), `"update_position"`) || !strings.Contains(string(snapshot), `"runtime-descriptor"`) {
+		t.Fatalf("snapshot missing refreshed descriptor or metadata:\n%s", snapshot)
 	}
 }
 
@@ -3149,8 +3338,173 @@ func TestResolveToolSubscriptionsRejectsUnknownTool(t *testing.T) {
 		},
 	}
 
-	if _, err := resolveToolSubscriptions(p, registry); err == nil {
+	_, err := resolveToolSubscriptions(p, registry)
+	if err == nil {
 		t.Fatal("expected unknown tool error")
+	}
+	var toolErr *toolResolutionError
+	if !errors.As(err, &toolErr) {
+		t.Fatalf("expected toolResolutionError, got %T: %v", err, err)
+	}
+	if toolErr.ToolService != "trading-api" || toolErr.ToolName != "missing_tool" {
+		t.Fatalf("unexpected tool error metadata: %+v", toolErr)
+	}
+}
+
+func TestResolvePodCapabilitiesStrictHintsFixForBuildBackedUnknownTool(t *testing.T) {
+	prevFix := composeUpFix
+	prevExists := imageExistsLocally
+	prevInspect := inspectClawImage
+	prevLoadDescriptor := loadDescriptorFromImage
+	composeUpFix = false
+	defer func() {
+		composeUpFix = prevFix
+		imageExistsLocally = prevExists
+		inspectClawImage = prevInspect
+		loadDescriptorFromImage = prevLoadDescriptor
+	}()
+	imageExistsLocally = func(image string) bool { return image == "analyst:latest" }
+	inspectClawImage = func(string) (*inspect.ClawInfo, error) {
+		return &inspect.ClawInfo{ClawType: "openclaw"}, nil
+	}
+	loadDescriptorFromImage = func(string, string) (*describe.ServiceDescriptor, error) {
+		return nil, os.ErrNotExist
+	}
+
+	podDir := t.TempDir()
+	serviceDir := filepath.Join(podDir, "services", "trading-api")
+	if err := os.MkdirAll(serviceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(serviceDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &pod.Pod{
+		Name: "test-pod",
+		Services: map[string]*pod.Service{
+			"analyst": {
+				Image: "analyst:latest",
+				Claw: &pod.ClawBlock{
+					Tools: []pod.ToolPolicyEntry{
+						{Service: "trading-api", Allow: []string{"update_position"}},
+					},
+				},
+			},
+			"trading-api": {
+				Compose: map[string]interface{}{
+					"build": map[string]interface{}{
+						"context":    "./services/trading-api",
+						"dockerfile": "Dockerfile",
+					},
+				},
+			},
+		},
+	}
+
+	_, err := resolvePodCapabilities("claw-pod.yml", podDir, p, map[string]string{}, map[string]*inspect.ClawInfo{}, map[string]*describe.ServiceDescriptor{})
+	if err == nil {
+		t.Fatal("expected strict mode remediation hint")
+	}
+	if !strings.Contains(err.Error(), "references unknown tool service \"trading-api\"") {
+		t.Fatalf("expected original tool error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "run: claw up --fix -d") {
+		t.Fatalf("expected claw up --fix remediation, got: %v", err)
+	}
+}
+
+func TestResolvePodCapabilitiesFixRefreshesAndRetriesUnknownTool(t *testing.T) {
+	prevFix := composeUpFix
+	prevRefresh := refreshRuntimeDescriptor
+	prevExists := imageExistsLocally
+	prevInspect := inspectClawImage
+	prevLoadDescriptor := loadDescriptorFromImage
+	composeUpFix = true
+	defer func() {
+		composeUpFix = prevFix
+		refreshRuntimeDescriptor = prevRefresh
+		imageExistsLocally = prevExists
+		inspectClawImage = prevInspect
+		loadDescriptorFromImage = prevLoadDescriptor
+	}()
+	imageExistsLocally = func(image string) bool { return image == "analyst:latest" }
+	inspectClawImage = func(string) (*inspect.ClawInfo, error) {
+		return &inspect.ClawInfo{ClawType: "openclaw"}, nil
+	}
+	loadDescriptorFromImage = func(string, string) (*describe.ServiceDescriptor, error) {
+		return nil, os.ErrNotExist
+	}
+
+	podDir := t.TempDir()
+	serviceDir := filepath.Join(podDir, "services", "trading-api")
+	if err := os.MkdirAll(serviceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(serviceDir, "Dockerfile"), []byte("FROM scratch\nLABEL claw.describe=/.claw-describe.json\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	staleDescriptor := `{
+  "version": 2,
+  "tools": [{
+    "name": "old_tool",
+    "description": "Old tool",
+    "inputSchema": {"type": "object"},
+    "http": {"method": "POST", "path": "/old"}
+  }]
+}`
+	if err := os.WriteFile(filepath.Join(serviceDir, ".claw-describe.json"), []byte(staleDescriptor), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &pod.Pod{
+		Name: "test-pod",
+		Services: map[string]*pod.Service{
+			"analyst": {
+				Image: "analyst:latest",
+				Claw: &pod.ClawBlock{
+					Tools: []pod.ToolPolicyEntry{
+						{Service: "trading-api", Allow: []string{"update_position"}},
+					},
+				},
+			},
+			"trading-api": {
+				Expose: []string{"4000"},
+				Compose: map[string]interface{}{
+					"build": map[string]interface{}{
+						"context":    "./services/trading-api",
+						"dockerfile": "Dockerfile",
+					},
+				},
+			},
+		},
+	}
+
+	var refreshedService string
+	refreshRuntimeDescriptor = func(_ string, _ string, _ *pod.Pod, serviceName string, _ map[string]string, _ map[string]*inspect.ClawInfo, descriptors map[string]*describe.ServiceDescriptor) error {
+		refreshedService = serviceName
+		descriptors[serviceName] = &describe.ServiceDescriptor{
+			Version: 2,
+			Tools: []describe.ToolDescriptor{{
+				Name:        "update_position",
+				Description: "Update a position.",
+				InputSchema: map[string]interface{}{"type": "object"},
+				HTTP:        &describe.ToolHTTP{Method: "POST", Path: "/tools/update_position"},
+			}},
+		}
+		return nil
+	}
+
+	capabilities, err := resolvePodCapabilities("claw-pod.yml", podDir, p, map[string]string{}, map[string]*inspect.ClawInfo{}, map[string]*describe.ServiceDescriptor{})
+	if err != nil {
+		t.Fatalf("resolvePodCapabilities: %v", err)
+	}
+	if refreshedService != "trading-api" {
+		t.Fatalf("expected trading-api refresh, got %q", refreshedService)
+	}
+	tools := capabilities.Tools["analyst"]
+	if len(tools) != 1 || tools[0].Name != "update_position" {
+		t.Fatalf("expected refreshed tool selection, got %+v", tools)
 	}
 }
 

--- a/cmd/claw/skill_data/SKILL.md
+++ b/cmd/claw/skill_data/SKILL.md
@@ -26,7 +26,7 @@ claw discover [-f <pod>.yml] [svc]   # discover stdio MCP tools into .claw-disco
 
 # Pod lifecycle (mirrors docker compose UX)
 claw up [-f <pod>.yml] [-d]         # strict: tells you to run claw pull/build when images are missing
-claw up --fix [-f <pod>.yml] [-d]   # pull/build missing images, then launch
+claw up --fix [-f <pod>.yml] [-d]   # pull/build missing images, refresh runtime descriptors, then launch
 claw up --discover-tools [-d]        # refresh missing/stale stdio MCP discovery snapshots, then launch
 claw down [-f <pod>.yml]            # tear down
 claw ps [-f <pod>.yml]              # container status
@@ -240,7 +240,7 @@ services:
 
 ## Service Self-Description (claw.describe)
 
-Services declare capabilities via a `.claw-describe.json` file (embedded in the image, discovered from Dockerfile labels, generated under `.claw-discovered/` by `claw discover`, or supplied with service-level `x-claw.describe-file`). `claw up` extracts descriptors and compiles them into pod-global registries.
+Services declare capabilities via a `.claw-describe.json` file (embedded in the image, discovered from Dockerfile labels, generated under `.claw-discovered/` by `claw discover`, refreshed there by `claw up --fix` for build-backed runtime-emitted descriptors, or supplied with service-level `x-claw.describe-file`). `claw up` extracts descriptors and compiles them into pod-global registries.
 
 ### Descriptor v2
 

--- a/site/guide/cli.md
+++ b/site/guide/cli.md
@@ -92,7 +92,7 @@ The pod file can be specified as a positional argument or via `-f`. Defaults to 
 | Flag | Description |
 |------|-------------|
 | `-d` | Detached mode. Required when the pod contains managed `x-claw` services. |
-| `--fix` | Pull and build missing images before starting. |
+| `--fix` | Pull/build missing images and refresh stale runtime-emitted descriptors before starting. |
 | `--discover-tools` | Discover missing or stale stdio MCP tool snapshots before compiling. |
 | `-f, --file <path>` | Path to `claw-pod.yml`. |
 
@@ -112,7 +112,7 @@ The pod file can be specified as a positional argument or via `-f`. Defaults to 
 
 **Dashboard URL:** When the pod declares a `clawdash` surface, `claw up` prints the dashboard URL on success (for example `[claw] dashboard:  http://localhost:8082`) so you can jump straight into the Agents / Topology / Fleet views without re-checking the compose output.
 
-`claw up` is strict by default. If an infra image is missing, it tells you to run `claw pull`. If a local runner base needs refresh, the build path tells you to run `claw pull`. If a pod service image is not built, it tells you to run `claw build`. `claw up --fix` can pull/build missing infra and service images, but runner refresh still happens through `claw pull`.
+`claw up` is strict by default. If an infra image is missing, it tells you to run `claw pull`. If a local runner base needs refresh, the build path tells you to run `claw pull`. If a pod service image is not built, it tells you to run `claw build`. If a build-backed service descriptor is stale and an allowlist references a new tool, it tells you to run `claw up --fix -d`. `claw up --fix` can pull/build missing infra and service images and refresh runtime-emitted descriptor snapshots, but runner refresh still happens through `claw pull`.
 
 **Examples:**
 

--- a/skills/clawdapus/SKILL.md
+++ b/skills/clawdapus/SKILL.md
@@ -26,7 +26,7 @@ claw discover [-f <pod>.yml] [svc]   # discover stdio MCP tools into .claw-disco
 
 # Pod lifecycle (mirrors docker compose UX)
 claw up [-f <pod>.yml] [-d]         # strict: tells you to run claw pull/build when images are missing
-claw up --fix [-f <pod>.yml] [-d]   # pull/build missing images, then launch
+claw up --fix [-f <pod>.yml] [-d]   # pull/build missing images, refresh runtime descriptors, then launch
 claw up --discover-tools [-d]        # refresh missing/stale stdio MCP discovery snapshots, then launch
 claw down [-f <pod>.yml]            # tear down
 claw ps [-f <pod>.yml]              # container status
@@ -240,7 +240,7 @@ services:
 
 ## Service Self-Description (claw.describe)
 
-Services declare capabilities via a `.claw-describe.json` file (embedded in the image, discovered from Dockerfile labels, generated under `.claw-discovered/` by `claw discover`, or supplied with service-level `x-claw.describe-file`). `claw up` extracts descriptors and compiles them into pod-global registries.
+Services declare capabilities via a `.claw-describe.json` file (embedded in the image, discovered from Dockerfile labels, generated under `.claw-discovered/` by `claw discover`, refreshed there by `claw up --fix` for build-backed runtime-emitted descriptors, or supplied with service-level `x-claw.describe-file`). `claw up` extracts descriptors and compiles them into pod-global registries.
 
 ### Descriptor v2
 


### PR DESCRIPTION
## Summary
- make capability resolution retry under `claw up --fix` when a tool allowlist points at a build-backed provider with a stale descriptor
- rebuild/start the provider through the existing `compose.generated.yml`, snapshot the runtime-emitted descriptor into `.claw-discovered/`, and retry validation before final apply
- keep plain `claw up -d` strict but add the direct `claw up --fix -d` remediation hint
- document `--fix` as the simple descriptor-refresh path and regenerate the embedded skill mirror

## Notes
- Stacked on #223 because this path depends on the stale-compose build carve-out.
- First deploys without any existing `compose.generated.yml` still fail loudly; adding a phase-1 compose emitter is left out of this narrow fix.

Closes #224

## Validation
- `go test ./cmd/claw -run 'TestResolveServiceMetadataLoadsDiscoveredSnapshot|TestResolveServiceMetadataLoadsRuntimeSnapshotForBuildService|TestResolveServiceMetadataIgnoresNonRuntimeSnapshotForBuildService|TestResolveServiceMetadataRequiresSnapshotForMCPStdio|TestRefreshRuntimeDescriptorDefaultUsesExistingComposeAndWritesSnapshot|TestResolvePodCapabilitiesStrictHintsFixForBuildBackedUnknownTool|TestResolvePodCapabilitiesFixRefreshesAndRetriesUnknownTool'`
- `go test ./cmd/claw`
- `go test ./...`
- `go vet ./...`
- `git diff --check`