### PR TITLE
Add Hermes Slack handle parity

### DIFF
--- a/cmd/claw/agent.go
+++ b/cmd/claw/agent.go
@@ -823,10 +823,8 @@ func resolveAgentAddConfig(ctx *agentAddContext, opts agentAddOptions) (*agentAd
 	prefix := envPrefixFromName(cfg.AgentName)
 	cfg.EnvExampleVars = make([]string, 0, 2)
 	if cfg.Platform != "none" {
-		tokenKey := platformTokenKey(cfg.Platform)
-		idKey := platformIDKey(cfg.Platform)
-		if tokenKey != "" && idKey != "" {
-			cfg.EnvExampleVars = append(cfg.EnvExampleVars, prefix+"_"+tokenKey, prefix+"_"+idKey)
+		for _, key := range platformEnvironmentKeys(cfg.Platform) {
+			cfg.EnvExampleVars = append(cfg.EnvExampleVars, prefix+"_"+key)
 		}
 	}
 	if owners, ok := ctx.ExistingPrefixes[prefix]; ok && len(owners) > 0 {
@@ -860,11 +858,11 @@ func serviceNodeFromConfig(cfg *agentAddResolvedConfig) (*yaml.Node, error) {
 	env := make(map[string]string)
 	if cfg.Platform != "none" {
 		prefix := envPrefixFromName(cfg.AgentName)
-		tokenKey := platformTokenKey(cfg.Platform)
 		idKey := platformIDKey(cfg.Platform)
-		if tokenKey != "" && idKey != "" {
-			env[tokenKey] = fmt.Sprintf("${%s_%s}", prefix, tokenKey)
-			env[idKey] = fmt.Sprintf("${%s_%s}", prefix, idKey)
+		if idKey != "" {
+			for _, key := range platformEnvironmentKeys(cfg.Platform) {
+				env[key] = fmt.Sprintf("${%s_%s}", prefix, key)
+			}
 			handle := scaffoldHandle{
 				ID:       fmt.Sprintf("${%s_%s}", prefix, idKey),
 				Username: cfg.AgentName,

--- a/cmd/claw/agent_test.go
+++ b/cmd/claw/agent_test.go
@@ -70,6 +70,53 @@ func TestAgentAddCreatesFilesAndUpdatesPod(t *testing.T) {
 	}
 }
 
+func TestAgentAddSlackIncludesSocketModeTokens(t *testing.T) {
+	dir := t.TempDir()
+	podPath := seedCanonicalProject(t, dir)
+
+	opts := agentAddOptions{
+		AgentName: "relay",
+		ClawType:  "hermes",
+		Model:     defaultModel,
+		Cllama:    "inherit",
+		Platform:  "slack",
+		AssumeYes: true,
+	}
+	if err := runAgentAdd(podPath, opts); err != nil {
+		t.Fatalf("runAgentAdd failed: %v", err)
+	}
+
+	podData, err := os.ReadFile(podPath)
+	if err != nil {
+		t.Fatalf("read pod file: %v", err)
+	}
+	podText := string(podData)
+	for _, expect := range []string{
+		"SLACK_BOT_TOKEN: ${RELAY_SLACK_BOT_TOKEN}",
+		"SLACK_APP_TOKEN: ${RELAY_SLACK_APP_TOKEN}",
+		"SLACK_BOT_ID: ${RELAY_SLACK_BOT_ID}",
+	} {
+		if !strings.Contains(podText, expect) {
+			t.Fatalf("expected pod to contain %q, got:\n%s", expect, podText)
+		}
+	}
+
+	envData, err := os.ReadFile(filepath.Join(dir, ".env.example"))
+	if err != nil {
+		t.Fatalf("read .env.example: %v", err)
+	}
+	envText := string(envData)
+	for _, key := range []string{
+		"RELAY_SLACK_BOT_TOKEN=",
+		"RELAY_SLACK_APP_TOKEN=",
+		"RELAY_SLACK_BOT_ID=",
+	} {
+		if !strings.Contains(envText, key) {
+			t.Fatalf("expected .env.example to contain %q, got:\n%s", key, envText)
+		}
+	}
+}
+
 func TestAgentAddDryRunWritesNothing(t *testing.T) {
 	dir := t.TempDir()
 	podPath := seedCanonicalProject(t, dir)

--- a/cmd/claw/init.go
+++ b/cmd/claw/init.go
@@ -623,20 +623,11 @@ func renderInitPod(cfg *initResolvedConfig) string {
 			b.WriteString("\"\n")
 		}
 		b.WriteString("    environment:\n")
-		tokenKey := platformTokenKey(cfg.Platform)
-		idKey := platformIDKey(cfg.Platform)
-		if tokenKey != "" {
+		for _, key := range platformEnvironmentKeys(cfg.Platform) {
 			b.WriteString("      ")
-			b.WriteString(tokenKey)
+			b.WriteString(key)
 			b.WriteString(": \"${")
-			b.WriteString(tokenKey)
-			b.WriteString("}\"\n")
-		}
-		if idKey != "" {
-			b.WriteString("      ")
-			b.WriteString(idKey)
-			b.WriteString(": \"${")
-			b.WriteString(idKey)
+			b.WriteString(key)
 			b.WriteString("}\"\n")
 		}
 	} else if cfg.VolumeName != "" {
@@ -666,8 +657,9 @@ func renderInitEnvExample(cfg *initResolvedConfig) string {
 
 	if cfg.Platform != "none" {
 		lines = append(lines, "# Platform credentials")
-		lines = append(lines, platformTokenKey(cfg.Platform)+"=")
-		lines = append(lines, platformIDKey(cfg.Platform)+"=")
+		for _, key := range platformEnvironmentKeys(cfg.Platform) {
+			lines = append(lines, key+"=")
+		}
 		if cfg.Platform == "discord" {
 			lines = append(lines, "DISCORD_GUILD_ID=")
 		}

--- a/cmd/claw/init_test.go
+++ b/cmd/claw/init_test.go
@@ -158,6 +158,47 @@ func TestInitScaffoldTypeDefaults(t *testing.T) {
 	}
 }
 
+func TestInitScaffoldHermesSlackIncludesSocketModeTokens(t *testing.T) {
+	dir := t.TempDir()
+	err := runInitWithOptions(dir, "", initScaffoldOptions{
+		ClawType: "hermes",
+		Platform: "slack",
+	}, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	podData, err := os.ReadFile(filepath.Join(dir, "claw-pod.yml"))
+	if err != nil {
+		t.Fatalf("read pod file: %v", err)
+	}
+	pod := string(podData)
+	for _, expected := range []string{
+		"SLACK_BOT_TOKEN: \"${SLACK_BOT_TOKEN}\"",
+		"SLACK_APP_TOKEN: \"${SLACK_APP_TOKEN}\"",
+		"SLACK_BOT_ID: \"${SLACK_BOT_ID}\"",
+	} {
+		if !strings.Contains(pod, expected) {
+			t.Fatalf("expected pod scaffold to include %q; got:\n%s", expected, pod)
+		}
+	}
+
+	envData, err := os.ReadFile(filepath.Join(dir, ".env.example"))
+	if err != nil {
+		t.Fatalf("read .env.example: %v", err)
+	}
+	env := string(envData)
+	for _, expected := range []string{
+		"SLACK_BOT_TOKEN=",
+		"SLACK_APP_TOKEN=",
+		"SLACK_BOT_ID=",
+	} {
+		if !strings.Contains(env, expected) {
+			t.Fatalf("expected .env.example to contain %q; got:\n%s", expected, env)
+		}
+	}
+}
+
 func TestInitTypeFlagUsageListsAllScaffoldTypes(t *testing.T) {
 	flag := initCmd.Flags().Lookup("type")
 	if flag == nil {

--- a/cmd/claw/scaffold_helpers.go
+++ b/cmd/claw/scaffold_helpers.go
@@ -252,6 +252,20 @@ func platformTokenKey(platform string) string {
 	}
 }
 
+func platformEnvironmentKeys(platform string) []string {
+	tokenKey := platformTokenKey(platform)
+	idKey := platformIDKey(platform)
+	if tokenKey == "" || idKey == "" {
+		return nil
+	}
+	keys := []string{tokenKey}
+	if platform == "slack" {
+		keys = append(keys, "SLACK_APP_TOKEN")
+	}
+	keys = append(keys, idKey)
+	return keys
+}
+
 func platformIDKey(platform string) string {
 	switch platform {
 	case "discord":

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -98,7 +98,7 @@ Replace the Discord configuration:
 
 **Telegram:** Change `HANDLE discord` to `HANDLE telegram` in `agents/assistant/Clawfile`. In `claw-pod.yml`, replace the `handles:` block with `telegram: {id: "${TELEGRAM_BOT_ID}", username: "mybot"}` and set `TELEGRAM_BOT_TOKEN` in `environment:`.
 
-**Slack:** Same pattern — `HANDLE slack`, swap the handles block, use `SLACK_BOT_TOKEN`.
+**Slack:** Same pattern — `HANDLE slack`, swap the handles block, and use `SLACK_BOT_TOKEN`. Hermes Slack uses socket mode and also requires `SLACK_APP_TOKEN`.
 
 ## Add another agent
 

--- a/internal/driver/hermes/config.go
+++ b/internal/driver/hermes/config.go
@@ -76,8 +76,10 @@ func GenerateEnvFile(rc *driver.ResolvedClaw, modelCfg *modelConfig) ([]byte, er
 	env["MESSAGING_CWD"] = hermesWorkspaceDir
 	env["TERMINAL_CWD"] = hermesWorkspaceDir
 	env[hermesDefaultAgentIdentityEnv] = managedDefaultAgentIdentity
-	if hasDiscordHandle(rc) {
+	if hasDiscordHandle(rc) || hasSlackHandle(rc) {
 		env[hermesToolProgressModeEnv] = "off"
+	}
+	if hasDiscordHandle(rc) {
 		// Hermes upstream defaults reply-mention pings to True
 		// (DISCORD_ALLOW_MENTION_REPLIED_USER), which produces mention loops in
 		// multi-agent pods even with DISCORD_REQUIRE_MENTION=true. Force false
@@ -317,10 +319,15 @@ func allowedEnvPassthroughKeys() []string {
 		"OPENAI_API_KEY",
 		"OPENROUTER_API_KEY",
 		"SLACK_ALLOWED_USERS",
+		"SLACK_ALLOW_ALL_USERS",
+		"SLACK_ALLOW_BOTS",
 		"SLACK_APP_TOKEN",
 		"SLACK_BOT_TOKEN",
+		"SLACK_FREE_RESPONSE_CHANNELS",
 		"SLACK_HOME_CHANNEL",
 		"SLACK_HOME_CHANNEL_NAME",
+		"SLACK_REACTIONS",
+		"SLACK_REQUIRE_MENTION",
 		"TELEGRAM_ALLOWED_USERS",
 		"TELEGRAM_BOT_TOKEN",
 		"TELEGRAM_HOME_CHANNEL",
@@ -329,11 +336,19 @@ func allowedEnvPassthroughKeys() []string {
 }
 
 func hasDiscordHandle(rc *driver.ResolvedClaw) bool {
+	return hasHandle(rc, "discord")
+}
+
+func hasSlackHandle(rc *driver.ResolvedClaw) bool {
+	return hasHandle(rc, "slack")
+}
+
+func hasHandle(rc *driver.ResolvedClaw, platform string) bool {
 	if rc == nil {
 		return false
 	}
 	for rawPlatform := range rc.Handles {
-		if strings.ToLower(strings.TrimSpace(rawPlatform)) == "discord" {
+		if strings.ToLower(strings.TrimSpace(rawPlatform)) == platform {
 			return true
 		}
 	}
@@ -341,7 +356,7 @@ func hasDiscordHandle(rc *driver.ResolvedClaw) bool {
 }
 
 func resolveDisabledHermesTools(rc *driver.ResolvedClaw) []string {
-	if !hasDiscordHandle(rc) {
+	if !hasDiscordHandle(rc) && !hasSlackHandle(rc) {
 		return nil
 	}
 

--- a/internal/driver/hermes/config.go
+++ b/internal/driver/hermes/config.go
@@ -391,6 +391,17 @@ func resolvedEnvValue(rc *driver.ResolvedClaw, key string) (string, error) {
 	return value, nil
 }
 
+func resolvedEnvOrDefault(rc *driver.ResolvedClaw, key, fallback string) (string, error) {
+	value, err := resolvedEnvValue(rc, key)
+	if err != nil {
+		return "", err
+	}
+	if value == "" {
+		return fallback, nil
+	}
+	return value, nil
+}
+
 func dotenvValue(value string) string {
 	if value == "" {
 		return `""`

--- a/internal/driver/hermes/config_test.go
+++ b/internal/driver/hermes/config_test.go
@@ -275,6 +275,55 @@ func TestGenerateEnvFileDefaultsToolProgressOffForSlack(t *testing.T) {
 	}
 }
 
+func TestGenerateEnvFileDefaultsDiscordReplyMentionFalse(t *testing.T) {
+	rc := &driver.ResolvedClaw{
+		Handles: map[string]*driver.HandleInfo{"discord": {}},
+	}
+	data, err := GenerateEnvFile(rc, &modelConfig{Env: map[string]string{}})
+	if err != nil {
+		t.Fatalf("GenerateEnvFile returned error: %v", err)
+	}
+
+	if !strings.Contains(string(data), hermesDiscordReplyMentionEnv+"=false\n") {
+		t.Fatalf("expected %s=false in .env, got:\n%s", hermesDiscordReplyMentionEnv, data)
+	}
+}
+
+func TestGenerateEnvFileRespectsDiscordReplyMentionOverride(t *testing.T) {
+	rc := &driver.ResolvedClaw{
+		Handles: map[string]*driver.HandleInfo{"discord": {}},
+		Environment: map[string]string{
+			hermesDiscordReplyMentionEnv: "true",
+		},
+	}
+	data, err := GenerateEnvFile(rc, &modelConfig{Env: map[string]string{}})
+	if err != nil {
+		t.Fatalf("GenerateEnvFile returned error: %v", err)
+	}
+
+	env := string(data)
+	if !strings.Contains(env, hermesDiscordReplyMentionEnv+"=true\n") {
+		t.Fatalf("expected %s override in .env, got:\n%s", hermesDiscordReplyMentionEnv, env)
+	}
+	if strings.Contains(env, hermesDiscordReplyMentionEnv+"=false\n") {
+		t.Fatalf("expected no default %s=false when override is set, got:\n%s", hermesDiscordReplyMentionEnv, env)
+	}
+}
+
+func TestGenerateEnvFileDoesNotSetReplyMentionForSlackOnly(t *testing.T) {
+	rc := &driver.ResolvedClaw{
+		Handles: map[string]*driver.HandleInfo{"slack": {}},
+	}
+	data, err := GenerateEnvFile(rc, &modelConfig{Env: map[string]string{}})
+	if err != nil {
+		t.Fatalf("GenerateEnvFile returned error: %v", err)
+	}
+
+	if strings.Contains(string(data), hermesDiscordReplyMentionEnv+"=") {
+		t.Fatalf("expected no %s for Slack-only Hermes agent, got:\n%s", hermesDiscordReplyMentionEnv, data)
+	}
+}
+
 func TestGenerateEnvFileAllowsToolProgressOverride(t *testing.T) {
 	rc := &driver.ResolvedClaw{
 		Handles: map[string]*driver.HandleInfo{"discord": {}},

--- a/internal/driver/hermes/config_test.go
+++ b/internal/driver/hermes/config_test.go
@@ -261,6 +261,20 @@ func TestGenerateEnvFileDefaultsToolProgressOffForDiscord(t *testing.T) {
 	}
 }
 
+func TestGenerateEnvFileDefaultsToolProgressOffForSlack(t *testing.T) {
+	rc := &driver.ResolvedClaw{
+		Handles: map[string]*driver.HandleInfo{"slack": {}},
+	}
+	data, err := GenerateEnvFile(rc, &modelConfig{Env: map[string]string{}})
+	if err != nil {
+		t.Fatalf("GenerateEnvFile returned error: %v", err)
+	}
+
+	if !strings.Contains(string(data), hermesToolProgressModeEnv+"=off\n") {
+		t.Fatalf("expected %s=off in .env, got:\n%s", hermesToolProgressModeEnv, data)
+	}
+}
+
 func TestGenerateEnvFileAllowsToolProgressOverride(t *testing.T) {
 	rc := &driver.ResolvedClaw{
 		Handles: map[string]*driver.HandleInfo{"discord": {}},
@@ -275,6 +289,37 @@ func TestGenerateEnvFileAllowsToolProgressOverride(t *testing.T) {
 
 	if !strings.Contains(string(data), hermesToolProgressModeEnv+"=verbose\n") {
 		t.Fatalf("expected %s override in .env, got:\n%s", hermesToolProgressModeEnv, data)
+	}
+}
+
+func TestGenerateEnvFilePassesThroughSlackRuntimeKnobs(t *testing.T) {
+	rc := &driver.ResolvedClaw{
+		Environment: map[string]string{
+			"SLACK_ALLOWED_USERS":          "U111,U222",
+			"SLACK_ALLOW_ALL_USERS":        "false",
+			"SLACK_ALLOW_BOTS":             "true",
+			"SLACK_FREE_RESPONSE_CHANNELS": "C111,C222",
+			"SLACK_REACTIONS":              "false",
+			"SLACK_REQUIRE_MENTION":        "true",
+		},
+	}
+	data, err := GenerateEnvFile(rc, &modelConfig{Env: map[string]string{}})
+	if err != nil {
+		t.Fatalf("GenerateEnvFile returned error: %v", err)
+	}
+
+	env := string(data)
+	for _, expected := range []string{
+		"SLACK_ALLOWED_USERS=U111,U222\n",
+		"SLACK_ALLOW_ALL_USERS=false\n",
+		"SLACK_ALLOW_BOTS=true\n",
+		"SLACK_FREE_RESPONSE_CHANNELS=C111,C222\n",
+		"SLACK_REACTIONS=false\n",
+		"SLACK_REQUIRE_MENTION=true\n",
+	} {
+		if !strings.Contains(env, expected) {
+			t.Fatalf("expected %q in .env, got:\n%s", expected, env)
+		}
 	}
 }
 
@@ -306,9 +351,40 @@ func TestGenerateEnvFileDisablesTTSForDiscordByDefault(t *testing.T) {
 	}
 }
 
+func TestGenerateEnvFileDisablesTTSForSlackByDefault(t *testing.T) {
+	rc := &driver.ResolvedClaw{
+		Handles: map[string]*driver.HandleInfo{"slack": {}},
+	}
+	data, err := GenerateEnvFile(rc, &modelConfig{Env: map[string]string{}})
+	if err != nil {
+		t.Fatalf("GenerateEnvFile returned error: %v", err)
+	}
+
+	if !strings.Contains(string(data), clawdapusDisabledToolsEnv+"="+hermesTextToSpeechTool+"\n") {
+		t.Fatalf("expected %s=%s in .env, got:\n%s", clawdapusDisabledToolsEnv, hermesTextToSpeechTool, data)
+	}
+}
+
 func TestGenerateEnvFileAllowsTTSOptInForDiscord(t *testing.T) {
 	rc := &driver.ResolvedClaw{
 		Handles: map[string]*driver.HandleInfo{"discord": {}},
+		Hermes: &driver.HermesConfig{
+			AllowTools: []string{hermesTextToSpeechTool},
+		},
+	}
+	data, err := GenerateEnvFile(rc, &modelConfig{Env: map[string]string{}})
+	if err != nil {
+		t.Fatalf("GenerateEnvFile returned error: %v", err)
+	}
+
+	if strings.Contains(string(data), clawdapusDisabledToolsEnv+"=") {
+		t.Fatalf("expected no %s when text_to_speech is allowed, got:\n%s", clawdapusDisabledToolsEnv, data)
+	}
+}
+
+func TestGenerateEnvFileAllowsTTSOptInForSlack(t *testing.T) {
+	rc := &driver.ResolvedClaw{
+		Handles: map[string]*driver.HandleInfo{"slack": {}},
 		Hermes: &driver.HermesConfig{
 			AllowTools: []string{hermesTextToSpeechTool},
 		},

--- a/internal/driver/hermes/driver.go
+++ b/internal/driver/hermes/driver.go
@@ -180,9 +180,9 @@ func (d *Driver) Materialize(rc *driver.ResolvedClaw, opts driver.MaterializeOpt
 		"DISCORD_AUTO_THREAD":         "false",
 	}
 
-	// Discord needs deliberate communication behavior, and Clawdapus keeps
+	// Chat handles need deliberate communication behavior, and Clawdapus keeps
 	// runner-native tool progress silent by default so only real replies post.
-	if hasDiscordHandle(rc) {
+	if hasDiscordHandle(rc) || hasSlackHandle(rc) {
 		env["HERMES_TOOL_ONLY_MODE"] = "1"
 		env[hermesToolProgressModeEnv] = "off"
 		if disabled := resolveDisabledHermesTools(rc); len(disabled) > 0 {
@@ -194,6 +194,20 @@ func (d *Driver) Materialize(rc *driver.ResolvedClaw, opts driver.MaterializeOpt
 		}
 		if value != "" {
 			env[hermesToolProgressModeEnv] = value
+		}
+	}
+	if hasSlackHandle(rc) {
+		value, err := resolvedEnvOrDefault(rc, "SLACK_REQUIRE_MENTION", "true")
+		if err != nil {
+			return nil, fmt.Errorf("hermes driver: %w", err)
+		}
+		env["SLACK_REQUIRE_MENTION"] = value
+		value, err = resolvedEnvValue(rc, "SLACK_ALLOW_BOTS")
+		if err != nil {
+			return nil, fmt.Errorf("hermes driver: %w", err)
+		}
+		if value != "" {
+			env["SLACK_ALLOW_BOTS"] = value
 		}
 	}
 	if rc.Hermes != nil && rc.Hermes.AllowSilent {

--- a/internal/driver/hermes/driver_test.go
+++ b/internal/driver/hermes/driver_test.go
@@ -390,6 +390,67 @@ func TestMaterializeDefaultsAutoThreadOff(t *testing.T) {
 	}
 }
 
+func TestMaterializeSlackAppliesTextChannelDefaults(t *testing.T) {
+	rc, tmp := newTestRC(t)
+	rc.Handles = map[string]*driver.HandleInfo{"slack": {}}
+	runtimeDir := filepath.Join(tmp, "runtime")
+	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := (&Driver{}).Materialize(rc, driver.MaterializeOpts{RuntimeDir: runtimeDir, PodName: "test"})
+	if err != nil {
+		t.Fatalf("Materialize returned error: %v", err)
+	}
+
+	if got := result.Environment["HERMES_TOOL_ONLY_MODE"]; got != "1" {
+		t.Fatalf("expected HERMES_TOOL_ONLY_MODE=1, got %q", got)
+	}
+	if got := result.Environment[hermesToolProgressModeEnv]; got != "off" {
+		t.Fatalf("expected %s=off, got %q", hermesToolProgressModeEnv, got)
+	}
+	if got := result.Environment[clawdapusDisabledToolsEnv]; got != hermesTextToSpeechTool {
+		t.Fatalf("expected %s=%s, got %q", clawdapusDisabledToolsEnv, hermesTextToSpeechTool, got)
+	}
+	if got := result.Environment["SLACK_REQUIRE_MENTION"]; got != "true" {
+		t.Fatalf("expected SLACK_REQUIRE_MENTION=true, got %q", got)
+	}
+}
+
+func TestMaterializeSlackAllowsMentionDefaultOverride(t *testing.T) {
+	rc, tmp := newTestRC(t)
+	rc.Handles = map[string]*driver.HandleInfo{"slack": {}}
+	rc.Environment["SLACK_REQUIRE_MENTION"] = "false"
+	rc.Environment["SLACK_ALLOW_BOTS"] = "mentions"
+	runtimeDir := filepath.Join(tmp, "runtime")
+	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := (&Driver{}).Materialize(rc, driver.MaterializeOpts{RuntimeDir: runtimeDir, PodName: "test"})
+	if err != nil {
+		t.Fatalf("Materialize returned error: %v", err)
+	}
+
+	if got := result.Environment["SLACK_REQUIRE_MENTION"]; got != "false" {
+		t.Fatalf("expected SLACK_REQUIRE_MENTION override, got %q", got)
+	}
+	if got := result.Environment["SLACK_ALLOW_BOTS"]; got != "mentions" {
+		t.Fatalf("expected SLACK_ALLOW_BOTS override, got %q", got)
+	}
+
+	envData, err := os.ReadFile(filepath.Join(runtimeDir, "hermes-home", ".env"))
+	if err != nil {
+		t.Fatalf("read .env: %v", err)
+	}
+	if !strings.Contains(string(envData), "SLACK_REQUIRE_MENTION=false\n") {
+		t.Fatalf("expected SLACK_REQUIRE_MENTION override in .env, got:\n%s", envData)
+	}
+	if !strings.Contains(string(envData), "SLACK_ALLOW_BOTS=mentions\n") {
+		t.Fatalf("expected SLACK_ALLOW_BOTS override in .env, got:\n%s", envData)
+	}
+}
+
 func TestMaterializeAllowsToolProgressOverride(t *testing.T) {
 	rc, tmp := newTestRC(t)
 	rc.Environment[hermesToolProgressModeEnv] = "verbose"


### PR DESCRIPTION
## Summary

- Apply Hermes quiet text-channel defaults to Slack handles: tool progress off and text-to-speech disabled unless explicitly allowed.
- Pass through upstream-supported Slack runtime knobs for Hermes-managed agents.
- Include `SLACK_APP_TOKEN` in Slack scaffolds and update the quickstart Slack note for Hermes socket mode.

## Verification

- `go test ./internal/driver/hermes`
- `go test ./cmd/claw`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

Closes #229
