### PR TITLE
Support same-runtime imports in claw init

### DIFF
--- a/cmd/claw/init.go
+++ b/cmd/claw/init.go
@@ -2,13 +2,12 @@ package main
 
 import (
 	"bufio"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 
+	"github.com/mostlydev/clawdapus/internal/initimport"
 	"github.com/spf13/cobra"
 )
 
@@ -21,6 +20,8 @@ var (
 	initCllama     string
 	initPlatform   string
 	initVolumeSpec string
+	initSource     string
+	initAcceptLoss string
 )
 
 type initScaffoldOptions struct {
@@ -31,6 +32,8 @@ type initScaffoldOptions struct {
 	Cllama      string
 	Platform    string
 	VolumeSpec  string
+	Source      string
+	AcceptLoss  string
 }
 
 type initResolvedConfig struct {
@@ -67,6 +70,8 @@ var initCmd = &cobra.Command{
 			Cllama:      initCllama,
 			Platform:    initPlatform,
 			VolumeSpec:  initVolumeSpec,
+			Source:      initSource,
+			AcceptLoss:  initAcceptLoss,
 		}
 
 		return runInitWithOptions(absTarget, initFromPath, opts, shouldPromptInteractively())
@@ -79,239 +84,71 @@ func runInit(dir, fromPath string) error {
 
 func runInitWithOptions(dir, fromPath string, opts initScaffoldOptions, interactive bool) error {
 	if fromPath != "" {
-		// Intentional: keep --from migration on the legacy flat scaffold.
-		// We do not force existing OpenClaw users into the canonical agents/<name>/ layout.
-		return runInitFrom(dir, fromPath)
+		return runInitFromImport(dir, fromPath, opts)
 	}
 	return runInitScaffold(dir, opts, interactive)
 }
 
 func runInitFrom(dir, fromPath string) error {
+	return runInitFromImport(dir, fromPath, initScaffoldOptions{})
+}
+
+func runInitFromImport(dir, fromPath string, opts initScaffoldOptions) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("create target directory: %w", err)
 	}
-
-	// Look for openclaw.json at fromPath, fromPath/openclaw.json, or fromPath/config/openclaw.json.
-	configPath := findOpenClawConfig(fromPath)
-	if configPath == "" {
-		return fmt.Errorf("no openclaw.json found in %q or its subdirectories", fromPath)
-	}
-
-	data, err := os.ReadFile(configPath)
+	sourceOverride := initimport.SourceKind(strings.ToLower(strings.TrimSpace(opts.Source)))
+	src, err := initimport.Detect(fromPath, sourceOverride)
 	if err != nil {
-		return fmt.Errorf("read config: %w", err)
+		return err
 	}
-
-	var config map[string]interface{}
-	if err := json.Unmarshal(data, &config); err != nil {
-		return fmt.Errorf("parse openclaw.json: %w", err)
+	target, err := initimport.ResolveImportTarget(opts.ClawType, src.Kind)
+	if err != nil {
+		return err
 	}
-
-	channels := detectChannels(config)
-	models := detectModels(config)
-
-	return generateMigrationScaffold(dir, channels, models)
-}
-
-func findOpenClawConfig(path string) string {
-	// Check direct path.
-	if filepath.Base(path) == "openclaw.json" {
-		if _, err := os.Stat(path); err == nil {
-			return path
+	projectName := strings.TrimSpace(opts.ProjectName)
+	if projectName == "" {
+		projectName = filepath.Base(dir)
+	}
+	plan, err := initimport.Translate(src, target, initimport.Options{
+		ProjectName:    projectName,
+		AgentName:      opts.AgentName,
+		ModelOverride:  opts.Model,
+		CllamaOverride: opts.Cllama,
+		AcceptLoss:     parseAcceptLoss(opts.AcceptLoss),
+	})
+	if err != nil {
+		return err
+	}
+	accepted := parseAcceptLoss(opts.AcceptLoss)
+	if plan.Notes.HasFatal() && !initimport.AcceptLossAllows(accepted, plan.Notes.FatalFeatures()) {
+		for _, loss := range plan.Notes.FatalLosses {
+			fmt.Printf("[claw] note: %s (accept with --accept-loss=%s)\n", loss.Reason, loss.Feature)
 		}
+		return fmt.Errorf("import would lose unsupported source features; re-run with --accept-loss=%s or adjust the source/target", strings.Join(plan.Notes.FatalFeatures(), ","))
 	}
-	// Check in path/openclaw.json.
-	candidate := filepath.Join(path, "openclaw.json")
-	if _, err := os.Stat(candidate); err == nil {
-		return candidate
+	if err := initimport.Emit(plan, dir); err != nil {
+		return err
 	}
-	// Check in path/config/openclaw.json.
-	candidate = filepath.Join(path, "config", "openclaw.json")
-	if _, err := os.Stat(candidate); err == nil {
-		return candidate
-	}
-	return ""
-}
-
-func detectChannels(config map[string]interface{}) []string {
-	channels := make([]string, 0)
-	channelsMap, ok := config["channels"].(map[string]interface{})
-	if !ok {
-		return channels
-	}
-	for platform, v := range channelsMap {
-		m, ok := v.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		if enabled, ok := m["enabled"].(bool); ok && enabled {
-			channels = append(channels, platform)
-		}
-	}
-	sort.Strings(channels)
-	return channels
-}
-
-func detectModels(config map[string]interface{}) []string {
-	models := make([]string, 0)
-	// OpenClaw stores model as agents.defaults.model.primary: "provider/model-name".
-	if primary, ok := getNestedString(config, "agents", "defaults", "model", "primary"); ok && primary != "" {
-		models = append(models, primary)
-	}
-	return models
-}
-
-func getNestedString(m map[string]interface{}, keys ...string) (string, bool) {
-	if len(keys) == 0 {
-		return "", false
-	}
-	current := m
-	for _, key := range keys[:len(keys)-1] {
-		next, ok := current[key].(map[string]interface{})
-		if !ok {
-			return "", false
-		}
-		current = next
-	}
-	s, ok := current[keys[len(keys)-1]].(string)
-	return s, ok
-}
-
-func generateMigrationScaffold(dir string, channels, models []string) error {
-	modelDirective := defaultModel
-	if len(models) > 0 {
-		modelDirective = models[0]
-	}
-
-	// Build HANDLE lines.
-	var handleLines []string
-	for _, ch := range channels {
-		handleLines = append(handleLines, fmt.Sprintf("HANDLE %s", ch))
-	}
-	// Add commented-out handles for platforms not detected.
-	allPlatforms := []string{"discord", "telegram", "slack"}
-	for _, p := range allPlatforms {
-		found := false
-		for _, ch := range channels {
-			if ch == p {
-				found = true
-				break
-			}
-		}
-		if !found {
-			handleLines = append(handleLines, fmt.Sprintf("# HANDLE %s", p))
-		}
-	}
-
-	clawfileContent := fmt.Sprintf(`FROM openclaw:latest
-
-CLAW_TYPE openclaw
-AGENT AGENTS.md
-
-MODEL primary %s
-
-CLLAMA passthrough
-
-%s
-`, modelDirective, strings.Join(handleLines, "\n"))
-
-	// Build handle block for claw-pod.yml.
-	var handleBlock strings.Builder
-	for _, ch := range channels {
-		tokenVar := strings.ToUpper(ch) + "_BOT_ID"
-		handleBlock.WriteString(fmt.Sprintf("      %s:\n", ch))
-		handleBlock.WriteString(fmt.Sprintf("        id: \"${%s}\"\n", tokenVar))
-		handleBlock.WriteString("        username: \"my-bot\"\n")
-	}
-
-	// Build environment block.
-	var envLines []string
-	for _, ch := range channels {
-		tokenVar := strings.ToUpper(ch) + "_BOT_TOKEN"
-		idVar := strings.ToUpper(ch) + "_BOT_ID"
-		envLines = append(envLines, fmt.Sprintf("      %s: \"${%s}\"", tokenVar, tokenVar))
-		envLines = append(envLines, fmt.Sprintf("      %s: \"${%s}\"", idVar, idVar))
-	}
-
-	handlesSection := ""
-	if len(channels) > 0 {
-		handlesSection = fmt.Sprintf("      handles:\n%s", handleBlock.String())
-	}
-
-	envSection := ""
-	if len(envLines) > 0 {
-		envSection = fmt.Sprintf("    environment:\n%s\n", strings.Join(envLines, "\n"))
-	}
-
-	podContent := fmt.Sprintf(`services:
-  my-agent:
-    image: my-claw:latest
-    x-claw:
-      agent: ./AGENTS.md
-      cllama: passthrough
-      cllama-env:
-        OPENROUTER_API_KEY: "${OPENROUTER_API_KEY}"
-%s%s`, handlesSection, envSection)
-
-	// Build .env.example with detected platforms uncommented.
-	var envExampleLines []string
-	envExampleLines = append(envExampleLines, "# LLM Provider (required — used by cllama proxy, never by agent directly)")
-	envExampleLines = append(envExampleLines, "OPENROUTER_API_KEY=sk-or-...")
-	envExampleLines = append(envExampleLines, "")
-
-	enabledSet := make(map[string]bool)
-	for _, ch := range channels {
-		enabledSet[ch] = true
-	}
-
-	envExampleLines = append(envExampleLines, "# Platform credentials")
-	for _, p := range allPlatforms {
-		prefix := "# "
-		if enabledSet[p] {
-			prefix = ""
-		}
-		upper := strings.ToUpper(p)
-		envExampleLines = append(envExampleLines, fmt.Sprintf("%s%s_BOT_TOKEN=", prefix, upper))
-		envExampleLines = append(envExampleLines, fmt.Sprintf("%s%s_BOT_ID=", prefix, upper))
-	}
-	envExampleLines = append(envExampleLines, "")
-
-	files := map[string]string{
-		"Clawfile":     clawfileContent,
-		"claw-pod.yml": podContent,
-		"AGENTS.md": `# Agent Contract
-
-You are a helpful assistant. Follow these rules:
-
-1. Be concise and direct
-2. Stay on topic
-3. Ask for clarification when instructions are ambiguous
-`,
-		".env.example": strings.Join(envExampleLines, "\n"),
-	}
-
-	for name := range files {
-		path := filepath.Join(dir, name)
-		if _, err := os.Stat(path); err == nil {
-			return fmt.Errorf("%s already exists; refusing to overwrite (delete it first or use a new directory)", name)
-		}
-	}
-
-	for name, content := range files {
-		path := filepath.Join(dir, name)
-		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-			return fmt.Errorf("write %s: %w", name, err)
-		}
-		fmt.Printf("[claw] created %s\n", name)
-	}
-
-	fmt.Printf("\n[claw] migrated from OpenClaw config (detected: %s)\n", strings.Join(channels, ", "))
+	fmt.Printf("[claw] imported %s config as %s project\n", src.Kind, target)
 	fmt.Println("[claw] scaffold ready. Next steps:")
 	fmt.Println("  1. cp .env.example .env && edit .env")
-	fmt.Println("  2. edit AGENTS.md (your bot's behavioral contract)")
-	fmt.Println("  3. claw build -t my-claw .")
+	fmt.Printf("  2. claw build -t %s-%s:latest ./agents/%s\n", plan.ProjectName, plan.AgentName, plan.AgentName)
+	fmt.Println("  3. review MIGRATION.md")
 	fmt.Println("  4. claw up -d")
 	return nil
+}
+
+func parseAcceptLoss(value string) []string {
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.ToLower(strings.TrimSpace(part))
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
 }
 
 func runInitScaffold(dir string, opts initScaffoldOptions, interactive bool) error {
@@ -684,7 +521,9 @@ You are a helpful assistant. Follow these rules:
 }
 
 func init() {
-	initCmd.Flags().StringVar(&initFromPath, "from", "", "Path to existing OpenClaw config directory to migrate from")
+	initCmd.Flags().StringVar(&initFromPath, "from", "", "Path to existing OpenClaw or Hermes config directory to import")
+	initCmd.Flags().StringVar(&initSource, "source", "", "Source runtime for --from autodetect override (openclaw, hermes)")
+	initCmd.Flags().StringVar(&initAcceptLoss, "accept-loss", "", "Comma-separated unsupported import features to accept (slack-routing, discord-routing, custom-provider, cron, identity-env, all)")
 	initCmd.Flags().StringVar(&initProject, "project", "", "Project name used for x-claw.pod and image prefix")
 	initCmd.Flags().StringVar(&initAgent, "agent", "", "Primary agent name (service + directory name)")
 	initCmd.Flags().StringVar(&initType, "type", "", "Claw type ("+strings.Join(scaffoldClawTypes, ", ")+")")

--- a/cmd/claw/init.go
+++ b/cmd/claw/init.go
@@ -89,10 +89,6 @@ func runInitWithOptions(dir, fromPath string, opts initScaffoldOptions, interact
 	return runInitScaffold(dir, opts, interactive)
 }
 
-func runInitFrom(dir, fromPath string) error {
-	return runInitFromImport(dir, fromPath, initScaffoldOptions{})
-}
-
 func runInitFromImport(dir, fromPath string, opts initScaffoldOptions) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("create target directory: %w", err)
@@ -116,6 +112,7 @@ func runInitFromImport(dir, fromPath string, opts initScaffoldOptions) error {
 		ModelOverride:  opts.Model,
 		CllamaOverride: opts.Cllama,
 		AcceptLoss:     parseAcceptLoss(opts.AcceptLoss),
+		BaseImage:      defaultBaseImageForClawType(string(target)),
 	})
 	if err != nil {
 		return err

--- a/cmd/claw/init.go
+++ b/cmd/claw/init.go
@@ -21,7 +21,6 @@ var (
 	initPlatform   string
 	initVolumeSpec string
 	initSource     string
-	initAcceptLoss string
 )
 
 type initScaffoldOptions struct {
@@ -33,7 +32,6 @@ type initScaffoldOptions struct {
 	Platform    string
 	VolumeSpec  string
 	Source      string
-	AcceptLoss  string
 }
 
 type initResolvedConfig struct {
@@ -71,7 +69,6 @@ var initCmd = &cobra.Command{
 			Platform:    initPlatform,
 			VolumeSpec:  initVolumeSpec,
 			Source:      initSource,
-			AcceptLoss:  initAcceptLoss,
 		}
 
 		return runInitWithOptions(absTarget, initFromPath, opts, shouldPromptInteractively())
@@ -93,12 +90,11 @@ func runInitFromImport(dir, fromPath string, opts initScaffoldOptions) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("create target directory: %w", err)
 	}
+	if strings.TrimSpace(opts.ClawType) != "" {
+		return fmt.Errorf("--type is only supported for new scaffolds; --from imports preserve the detected source runtime")
+	}
 	sourceOverride := initimport.SourceKind(strings.ToLower(strings.TrimSpace(opts.Source)))
 	src, err := initimport.Detect(fromPath, sourceOverride)
-	if err != nil {
-		return err
-	}
-	target, err := initimport.ResolveImportTarget(opts.ClawType, src.Kind)
 	if err != nil {
 		return err
 	}
@@ -106,46 +102,26 @@ func runInitFromImport(dir, fromPath string, opts initScaffoldOptions) error {
 	if projectName == "" {
 		projectName = filepath.Base(dir)
 	}
-	plan, err := initimport.Translate(src, target, initimport.Options{
+	plan, err := initimport.Translate(src, initimport.Options{
 		ProjectName:    projectName,
 		AgentName:      opts.AgentName,
 		ModelOverride:  opts.Model,
 		CllamaOverride: opts.Cllama,
-		AcceptLoss:     parseAcceptLoss(opts.AcceptLoss),
-		BaseImage:      defaultBaseImageForClawType(string(target)),
+		BaseImage:      defaultBaseImageForClawType(string(src.Kind)),
 	})
 	if err != nil {
 		return err
 	}
-	accepted := parseAcceptLoss(opts.AcceptLoss)
-	if plan.Notes.HasFatal() && !initimport.AcceptLossAllows(accepted, plan.Notes.FatalFeatures()) {
-		for _, loss := range plan.Notes.FatalLosses {
-			fmt.Printf("[claw] note: %s (accept with --accept-loss=%s)\n", loss.Reason, loss.Feature)
-		}
-		return fmt.Errorf("import would lose unsupported source features; re-run with --accept-loss=%s or adjust the source/target", strings.Join(plan.Notes.FatalFeatures(), ","))
-	}
 	if err := initimport.Emit(plan, dir); err != nil {
 		return err
 	}
-	fmt.Printf("[claw] imported %s config as %s project\n", src.Kind, target)
+	fmt.Printf("[claw] imported %s config as claw-managed %s project\n", src.Kind, plan.Target)
 	fmt.Println("[claw] scaffold ready. Next steps:")
 	fmt.Println("  1. cp .env.example .env && edit .env")
 	fmt.Printf("  2. claw build -t %s-%s:latest ./agents/%s\n", plan.ProjectName, plan.AgentName, plan.AgentName)
 	fmt.Println("  3. review MIGRATION.md")
 	fmt.Println("  4. claw up -d")
 	return nil
-}
-
-func parseAcceptLoss(value string) []string {
-	parts := strings.Split(value, ",")
-	out := make([]string, 0, len(parts))
-	for _, part := range parts {
-		part = strings.ToLower(strings.TrimSpace(part))
-		if part != "" {
-			out = append(out, part)
-		}
-	}
-	return out
 }
 
 func runInitScaffold(dir string, opts initScaffoldOptions, interactive bool) error {
@@ -518,9 +494,8 @@ You are a helpful assistant. Follow these rules:
 }
 
 func init() {
-	initCmd.Flags().StringVar(&initFromPath, "from", "", "Path to existing OpenClaw or Hermes config directory to import")
+	initCmd.Flags().StringVar(&initFromPath, "from", "", "Path to existing OpenClaw or Hermes config directory to import into the same runtime")
 	initCmd.Flags().StringVar(&initSource, "source", "", "Source runtime for --from autodetect override (openclaw, hermes)")
-	initCmd.Flags().StringVar(&initAcceptLoss, "accept-loss", "", "Comma-separated unsupported import features to accept (slack-routing, discord-routing, custom-provider, cron, identity-env, all)")
 	initCmd.Flags().StringVar(&initProject, "project", "", "Project name used for x-claw.pod and image prefix")
 	initCmd.Flags().StringVar(&initAgent, "agent", "", "Primary agent name (service + directory name)")
 	initCmd.Flags().StringVar(&initType, "type", "", "Claw type ("+strings.Join(scaffoldClawTypes, ", ")+")")

--- a/cmd/claw/init_test.go
+++ b/cmd/claw/init_test.go
@@ -88,14 +88,125 @@ func TestInitFromOpenClawConfig(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Verify generated Clawfile has detected handles
-	clawfile, _ := os.ReadFile(filepath.Join(destDir, "Clawfile"))
+	for _, name := range []string{
+		"agents/assistant/Clawfile",
+		"agents/assistant/AGENTS.md",
+		"claw-pod.yml",
+		".env.example",
+		"MIGRATION.md",
+	} {
+		if _, err := os.Stat(filepath.Join(destDir, name)); err != nil {
+			t.Fatalf("expected %s to exist: %v", name, err)
+		}
+	}
+
+	clawfile, err := os.ReadFile(filepath.Join(destDir, "agents", "assistant", "Clawfile"))
+	if err != nil {
+		t.Fatalf("read imported Clawfile: %v", err)
+	}
 	content := string(clawfile)
 	if !strings.Contains(content, "HANDLE discord") {
 		t.Error("expected Clawfile to contain HANDLE discord")
 	}
 	if !strings.Contains(content, "HANDLE telegram") {
 		t.Error("expected Clawfile to contain HANDLE telegram")
+	}
+	if _, err := os.Stat(filepath.Join(destDir, "Clawfile")); !os.IsNotExist(err) {
+		t.Fatalf("expected no legacy root Clawfile, got err=%v", err)
+	}
+}
+
+func TestInitFromOpenClawWithHermesTarget(t *testing.T) {
+	srcDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(srcDir, "openclaw.json"), []byte(`{
+		"channels": {
+			"slack": {"enabled": true, "token": "${SLACK_BOT_TOKEN}"}
+		},
+		"agents": {
+			"defaults": {
+				"model": {"primary": "openrouter/anthropic/claude-sonnet-4"}
+			}
+		}
+	}`), 0o644); err != nil {
+		t.Fatalf("write source config: %v", err)
+	}
+
+	destDir := t.TempDir()
+	err := runInitWithOptions(destDir, srcDir, initScaffoldOptions{ClawType: "hermes"}, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clawfile, err := os.ReadFile(filepath.Join(destDir, "agents", "assistant", "Clawfile"))
+	if err != nil {
+		t.Fatalf("read Clawfile: %v", err)
+	}
+	for _, expected := range []string{
+		"CLAW_TYPE hermes",
+		"HANDLE slack",
+	} {
+		if !strings.Contains(string(clawfile), expected) {
+			t.Fatalf("expected imported Hermes Clawfile to contain %q, got:\n%s", expected, clawfile)
+		}
+	}
+	env, err := os.ReadFile(filepath.Join(destDir, ".env.example"))
+	if err != nil {
+		t.Fatalf("read .env.example: %v", err)
+	}
+	for _, expected := range []string{"SLACK_BOT_TOKEN=", "SLACK_APP_TOKEN=", "SLACK_BOT_ID="} {
+		if !strings.Contains(string(env), expected) {
+			t.Fatalf("expected .env.example to contain %q, got:\n%s", expected, env)
+		}
+	}
+}
+
+func TestInitFromHermesWithOpenClawTarget(t *testing.T) {
+	srcDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(srcDir, "config.yaml"), []byte(`model:
+  provider: openrouter
+  default: anthropic/claude-sonnet-4
+`), 0o644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, ".env"), []byte(`DISCORD_BOT_TOKEN=token
+DISCORD_BOT_ID=111
+DISCORD_ALLOWED_USERS=222,333
+`), 0o600); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+
+	destDir := t.TempDir()
+	err := runInitWithOptions(destDir, srcDir, initScaffoldOptions{ClawType: "openclaw"}, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	pod, err := os.ReadFile(filepath.Join(destDir, "claw-pod.yml"))
+	if err != nil {
+		t.Fatalf("read pod: %v", err)
+	}
+	for _, expected := range []string{
+		"channel://discord",
+		`- "222"`,
+		`- "333"`,
+	} {
+		if !strings.Contains(string(pod), expected) {
+			t.Fatalf("expected pod to contain %q, got:\n%s", expected, pod)
+		}
+	}
+}
+
+func TestInitFromRejectsUnsupportedTargetType(t *testing.T) {
+	srcDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(srcDir, "openclaw.json"), []byte(`{"channels":{}}`), 0o644); err != nil {
+		t.Fatalf("write source config: %v", err)
+	}
+
+	err := runInitWithOptions(t.TempDir(), srcDir, initScaffoldOptions{ClawType: "nanobot"}, false)
+	if err == nil {
+		t.Fatal("expected unsupported import target to fail")
+	}
+	if !strings.Contains(err.Error(), "import target") {
+		t.Fatalf("expected import target error, got: %v", err)
 	}
 }
 

--- a/cmd/claw/init_test.go
+++ b/cmd/claw/init_test.go
@@ -193,6 +193,20 @@ DISCORD_ALLOWED_USERS=222,333
 			t.Fatalf("expected pod to contain %q, got:\n%s", expected, pod)
 		}
 	}
+	migration, err := os.ReadFile(filepath.Join(destDir, "MIGRATION.md"))
+	if err != nil {
+		t.Fatalf("read MIGRATION.md: %v", err)
+	}
+	for _, expected := range []string{
+		"Target: openclaw",
+		"Discord routing mapped to channel://discord",
+		"Secret placeholders",
+		"Discord bot token contained a literal secret",
+	} {
+		if !strings.Contains(string(migration), expected) {
+			t.Fatalf("expected MIGRATION.md to contain %q, got:\n%s", expected, migration)
+		}
+	}
 }
 
 func TestInitFromRejectsUnsupportedTargetType(t *testing.T) {
@@ -207,6 +221,62 @@ func TestInitFromRejectsUnsupportedTargetType(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "import target") {
 		t.Fatalf("expected import target error, got: %v", err)
+	}
+}
+
+func TestInitFromSlackRoutingRequiresAcceptLoss(t *testing.T) {
+	srcDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(srcDir, "openclaw.json"), []byte(`{
+		"channels": {
+			"slack": {
+				"enabled": true,
+				"token": "${SLACK_BOT_TOKEN}",
+				"allowedUsers": ["U111"]
+			}
+		}
+	}`), 0o644); err != nil {
+		t.Fatalf("write source config: %v", err)
+	}
+
+	err := runInitWithOptions(t.TempDir(), srcDir, initScaffoldOptions{ClawType: "openclaw"}, false)
+	if err == nil {
+		t.Fatal("expected Slack routing import to fail without accept-loss")
+	}
+	if !strings.Contains(err.Error(), "slack-routing") {
+		t.Fatalf("expected slack-routing accept-loss error, got: %v", err)
+	}
+}
+
+func TestInitFromCustomProviderAcceptLossAddsEnvPlaceholder(t *testing.T) {
+	srcDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(srcDir, "config.yaml"), []byte(`model:
+  provider: mistral-ai
+  default: large
+`), 0o644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+
+	destDir := t.TempDir()
+	err := runInitWithOptions(destDir, srcDir, initScaffoldOptions{
+		ClawType:   "hermes",
+		AcceptLoss: "custom-provider",
+	}, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	env, err := os.ReadFile(filepath.Join(destDir, ".env.example"))
+	if err != nil {
+		t.Fatalf("read .env.example: %v", err)
+	}
+	if !strings.Contains(string(env), "MISTRAL_AI_API_KEY=") {
+		t.Fatalf("expected custom provider placeholder, got:\n%s", env)
+	}
+	migration, err := os.ReadFile(filepath.Join(destDir, "MIGRATION.md"))
+	if err != nil {
+		t.Fatalf("read MIGRATION.md: %v", err)
+	}
+	if !strings.Contains(string(migration), "custom provider") || !strings.Contains(string(migration), "MISTRAL_AI_API_KEY") {
+		t.Fatalf("expected custom provider note, got:\n%s", migration)
 	}
 }
 

--- a/cmd/claw/init_test.go
+++ b/cmd/claw/init_test.go
@@ -116,51 +116,7 @@ func TestInitFromOpenClawConfig(t *testing.T) {
 	}
 }
 
-func TestInitFromOpenClawWithHermesTarget(t *testing.T) {
-	srcDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(srcDir, "openclaw.json"), []byte(`{
-		"channels": {
-			"slack": {"enabled": true, "token": "${SLACK_BOT_TOKEN}"}
-		},
-		"agents": {
-			"defaults": {
-				"model": {"primary": "openrouter/anthropic/claude-sonnet-4"}
-			}
-		}
-	}`), 0o644); err != nil {
-		t.Fatalf("write source config: %v", err)
-	}
-
-	destDir := t.TempDir()
-	err := runInitWithOptions(destDir, srcDir, initScaffoldOptions{ClawType: "hermes"}, false)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	clawfile, err := os.ReadFile(filepath.Join(destDir, "agents", "assistant", "Clawfile"))
-	if err != nil {
-		t.Fatalf("read Clawfile: %v", err)
-	}
-	for _, expected := range []string{
-		"CLAW_TYPE hermes",
-		"HANDLE slack",
-	} {
-		if !strings.Contains(string(clawfile), expected) {
-			t.Fatalf("expected imported Hermes Clawfile to contain %q, got:\n%s", expected, clawfile)
-		}
-	}
-	env, err := os.ReadFile(filepath.Join(destDir, ".env.example"))
-	if err != nil {
-		t.Fatalf("read .env.example: %v", err)
-	}
-	for _, expected := range []string{"SLACK_BOT_TOKEN=", "SLACK_APP_TOKEN=", "SLACK_BOT_ID="} {
-		if !strings.Contains(string(env), expected) {
-			t.Fatalf("expected .env.example to contain %q, got:\n%s", expected, env)
-		}
-	}
-}
-
-func TestInitFromHermesWithOpenClawTarget(t *testing.T) {
+func TestInitFromHermesConfig(t *testing.T) {
 	srcDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(srcDir, "config.yaml"), []byte(`model:
   provider: openrouter
@@ -176,18 +132,29 @@ DISCORD_ALLOWED_USERS=222,333
 	}
 
 	destDir := t.TempDir()
-	err := runInitWithOptions(destDir, srcDir, initScaffoldOptions{ClawType: "openclaw"}, false)
+	err := runInitWithOptions(destDir, srcDir, initScaffoldOptions{}, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	clawfile, err := os.ReadFile(filepath.Join(destDir, "agents", "assistant", "Clawfile"))
+	if err != nil {
+		t.Fatalf("read Clawfile: %v", err)
+	}
+	for _, expected := range []string{
+		"CLAW_TYPE hermes",
+		"HANDLE discord",
+	} {
+		if !strings.Contains(string(clawfile), expected) {
+			t.Fatalf("expected imported Hermes Clawfile to contain %q, got:\n%s", expected, clawfile)
+		}
 	}
 	pod, err := os.ReadFile(filepath.Join(destDir, "claw-pod.yml"))
 	if err != nil {
 		t.Fatalf("read pod: %v", err)
 	}
 	for _, expected := range []string{
-		"channel://discord",
-		`- "222"`,
-		`- "333"`,
+		"DISCORD_ALLOWED_USERS: \"222,333\"",
+		"DISCORD_BOT_TOKEN: \"${DISCORD_BOT_TOKEN}\"",
 	} {
 		if !strings.Contains(string(pod), expected) {
 			t.Fatalf("expected pod to contain %q, got:\n%s", expected, pod)
@@ -198,8 +165,8 @@ DISCORD_ALLOWED_USERS=222,333
 		t.Fatalf("read MIGRATION.md: %v", err)
 	}
 	for _, expected := range []string{
-		"Target: openclaw",
-		"Discord routing mapped to channel://discord",
+		"Target: hermes",
+		"DISCORD_ALLOWED_USERS preserved",
 		"Secret placeholders",
 		"Discord bot token contained a literal secret",
 	} {
@@ -209,22 +176,22 @@ DISCORD_ALLOWED_USERS=222,333
 	}
 }
 
-func TestInitFromRejectsUnsupportedTargetType(t *testing.T) {
+func TestInitFromRejectsTypeFlag(t *testing.T) {
 	srcDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(srcDir, "openclaw.json"), []byte(`{"channels":{}}`), 0o644); err != nil {
 		t.Fatalf("write source config: %v", err)
 	}
 
-	err := runInitWithOptions(t.TempDir(), srcDir, initScaffoldOptions{ClawType: "nanobot"}, false)
+	err := runInitWithOptions(t.TempDir(), srcDir, initScaffoldOptions{ClawType: "openclaw"}, false)
 	if err == nil {
-		t.Fatal("expected unsupported import target to fail")
+		t.Fatal("expected --type with --from to fail")
 	}
-	if !strings.Contains(err.Error(), "import target") {
-		t.Fatalf("expected import target error, got: %v", err)
+	if !strings.Contains(err.Error(), "--type is only supported for new scaffolds") {
+		t.Fatalf("expected --type error, got: %v", err)
 	}
 }
 
-func TestInitFromSlackRoutingRequiresAcceptLoss(t *testing.T) {
+func TestInitFromSlackRoutingWritesMigrationNote(t *testing.T) {
 	srcDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(srcDir, "openclaw.json"), []byte(`{
 		"channels": {
@@ -238,16 +205,21 @@ func TestInitFromSlackRoutingRequiresAcceptLoss(t *testing.T) {
 		t.Fatalf("write source config: %v", err)
 	}
 
-	err := runInitWithOptions(t.TempDir(), srcDir, initScaffoldOptions{ClawType: "openclaw"}, false)
-	if err == nil {
-		t.Fatal("expected Slack routing import to fail without accept-loss")
+	destDir := t.TempDir()
+	err := runInitWithOptions(destDir, srcDir, initScaffoldOptions{}, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "slack-routing") {
-		t.Fatalf("expected slack-routing accept-loss error, got: %v", err)
+	migration, err := os.ReadFile(filepath.Join(destDir, "MIGRATION.md"))
+	if err != nil {
+		t.Fatalf("read MIGRATION.md: %v", err)
+	}
+	if !strings.Contains(string(migration), "Slack allowed-user routing has no channel://slack surface") {
+		t.Fatalf("expected Slack routing note, got:\n%s", migration)
 	}
 }
 
-func TestInitFromCustomProviderAcceptLossAddsEnvPlaceholder(t *testing.T) {
+func TestInitFromCustomProviderRequiresModelOverride(t *testing.T) {
 	srcDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(srcDir, "config.yaml"), []byte(`model:
   provider: mistral-ai
@@ -256,27 +228,30 @@ func TestInitFromCustomProviderAcceptLossAddsEnvPlaceholder(t *testing.T) {
 		t.Fatalf("write config.yaml: %v", err)
 	}
 
-	destDir := t.TempDir()
-	err := runInitWithOptions(destDir, srcDir, initScaffoldOptions{
-		ClawType:   "hermes",
-		AcceptLoss: "custom-provider",
-	}, false)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	err := runInitWithOptions(t.TempDir(), srcDir, initScaffoldOptions{}, false)
+	if err == nil {
+		t.Fatal("expected custom provider import to fail")
 	}
-	env, err := os.ReadFile(filepath.Join(destDir, ".env.example"))
-	if err != nil {
-		t.Fatalf("read .env.example: %v", err)
+	if !strings.Contains(err.Error(), "pass --model") {
+		t.Fatalf("expected --model recovery hint, got: %v", err)
 	}
-	if !strings.Contains(string(env), "MISTRAL_AI_API_KEY=") {
-		t.Fatalf("expected custom provider placeholder, got:\n%s", env)
+}
+
+func TestInitFromHermesRequiresHandleEnv(t *testing.T) {
+	srcDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(srcDir, "config.yaml"), []byte(`model:
+  provider: openrouter
+  default: anthropic/claude-sonnet-4
+`), 0o644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
 	}
-	migration, err := os.ReadFile(filepath.Join(destDir, "MIGRATION.md"))
-	if err != nil {
-		t.Fatalf("read MIGRATION.md: %v", err)
+
+	err := runInitWithOptions(t.TempDir(), srcDir, initScaffoldOptions{}, false)
+	if err == nil {
+		t.Fatal("expected Hermes import without handles to fail")
 	}
-	if !strings.Contains(string(migration), "custom provider") || !strings.Contains(string(migration), "MISTRAL_AI_API_KEY") {
-		t.Fatalf("expected custom provider note, got:\n%s", migration)
+	if !strings.Contains(err.Error(), "Hermes import requires at least one supported handle") {
+		t.Fatalf("expected handle recovery hint, got: %v", err)
 	}
 }
 

--- a/docs/plans/2026-05-11-issue-230-init-from-cross-runtime.md
+++ b/docs/plans/2026-05-11-issue-230-init-from-cross-runtime.md
@@ -1,348 +1,76 @@
-# Plan: `claw init --from` cross-runtime and same-runtime imports
-
-Issue: https://github.com/mostlydev/clawdapus/issues/230
-
-Author: Claude (claude:5379be30). v2 — converged with codex adversarial review (https://github.com/mostlydev/clawdapus/issues/230#issuecomment-4426381993).
-
-## 1. Problem
-
-`claw init --from <path>` is currently:
-
-- **Source-locked.** Only `openclaw.json` is recognized. Hermes users have no import path.
-- **Target-locked.** Hard-codes `FROM openclaw:latest`, `CLAW_TYPE openclaw`. `--type` is silently ignored when `--from` is present.
-- **Layout-locked.** Emits the legacy flat scaffold instead of the ADR-011 canonical `agents/<name>/` layout.
-- **Lossy.** Drops platform-specific routing, forgets Hermes Slack socket-mode needs both `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` (#229/#231 now on master), and copies provider refs even when the target runtime cannot use them.
-- **Secret-discoverability is poor.** Token-shaped fields ride through as literal `${VAR}` placeholders without ever being inventoried in `.env.example`.
-
-## 2. Goals
-
-A first-class migration UX with four covered paths:
-
-| Source         | Target         | Behavior                                                                            |
-| -------------- | -------------- | ----------------------------------------------------------------------------------- |
-| OpenClaw cfg   | `openclaw`     | Preserve structurally identical: handles, channels routing, model slots.            |
-| OpenClaw cfg   | `hermes`       | Map what Hermes supports; emit migration notes for unmappable features.             |
-| Hermes cfg+env | `hermes`       | Preserve model/provider, identity (SOUL.md), channel env vars, allowed users.       |
-| Hermes cfg+env | `openclaw`     | Same mapping discipline as the reverse direction.                                   |
-
-Non-goals (per issue):
-
-- No deployment-specific scaffolds.
-- No new `channel://slack` SURFACE in the data model.
-- No inlining of secrets into tracked files.
-- No support for `--from <X> --type nanobot|microclaw|nanoclaw|...`. v1 limits import targets to `openclaw` and `hermes`. Other `--type` values with `--from` fail fast with "import target not supported yet."
-
-## 3. Source detection
-
-Replace `findOpenClawConfig` with `Detect(fromPath, override SourceKind) (Descriptor, error)`. Recognizes:
-
-| Marker                                                                                  | Source kind |
-| --------------------------------------------------------------------------------------- | ----------- |
-| `openclaw.json` at path, `<path>/openclaw.json`, or `<path>/config/openclaw.json`       | `openclaw`  |
-| `config.yaml` with a `model:` block (containing `default` and/or `provider`), optionally with sibling `SOUL.md`, `.env`, `skills/`, `cron/`, `memory/` | `hermes`    |
-| Both present                                                                            | error: ambiguous; require explicit `--source` |
-| Neither                                                                                 | current error: nothing recognized              |
-
-A `.env` file next to the detected config is consumed as additional input (channel tokens, allowed-users, identity-overrides) but never copied verbatim. Its values are extracted into `.env.example` placeholders only.
-
-`--source <openclaw|hermes>` exists as an explicit override when detection is ambiguous or the operator points at an unusual location.
-
-## 4. Target selection
-
-- `--type <openclaw|hermes>` is honored regardless of `--from`.
-- If `--type` is omitted, target defaults to the source runtime (same-runtime import).
-- `--type` outside `{openclaw, hermes}` with `--from` → `"import target %q not supported yet; use --type openclaw|hermes for --from"`.
-- If the chosen target cannot represent a source feature, importer fails with a migration note unless the operator passes `--accept-loss=<feature,...>` (or `--accept-loss=all`). Each fatal note names the exact token needed.
-
-## 5. Output layout
-
-ADR-011 canonical layout, no opt-outs. The legacy flat scaffold is gone in v1.
-
-```
-project-root/
-  agents/<agent-name>/
-    Clawfile
-    AGENTS.md
-    SOUL.md             (only when source had one)
-    skills/             (only when source had importable skills)
-  claw-pod.yml
-  .env.example
-  .gitignore
-  MIGRATION.md          (always emitted for --from runs)
-```
-
-Agent name source:
-
-- OpenClaw → `agents.list[0].id` if present, normalized; else `assistant`.
-- Hermes → `SOUL.md` first heading (kebab-cased) if present, else service hint, else `assistant`.
-
-## 6. Translation matrix
-
-### 6.1 Handles, channels, routing
-
-The IR carries platform-specific typed structs (§9). The translator dispatches on platform, so Slack routing cannot accidentally map into Discord routing.
-
-| Source feature                                          | OpenClaw target                       | Hermes target                          |
-| ------------------------------------------------------- | ------------------------------------- | -------------------------------------- |
-| OC `channels.discord.enabled=true`                      | `HANDLE discord`                      | `HANDLE discord`                       |
-| OC `channels.discord.token` ($DISCORD_BOT_TOKEN)        | env placeholder                       | env placeholder                        |
-| OC `channels.discord.dmPolicy`                          | `channel://discord` SURFACE           | env `DISCORD_REQUIRE_MENTION` / Hermes runtime knobs where matching exists; else fatal note (`--accept-loss=discord-routing`) |
-| OC `channels.discord.guilds.<id>.requireMention=true`   | `channel://discord` SURFACE           | env `DISCORD_REQUIRE_MENTION=true`     |
-| OC `channels.discord.allowFrom` / users allowlist       | `channel://discord allowFrom`         | env `DISCORD_ALLOWED_USERS` (comma-joined) |
-| OC `channels.slack.enabled=true`                        | `HANDLE slack`                        | `HANDLE slack` + scaffold both `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` |
-| OC `channels.slack.token` ($SLACK_BOT_TOKEN)            | env placeholder                       | env placeholder + `SLACK_APP_TOKEN` placeholder |
-| OC Slack routing fields (allowed channels, users, etc.) | fatal note: "no channel://slack SURFACE in v1; pass --accept-loss=slack-routing to drop, or wait for runtime support" | env `SLACK_ALLOWED_USERS` (comma-joined) |
-| OC `agents.list[0].name`                                | preserved as HANDLE username + display name | preserved (SOUL.md identity)            |
-
-| Source feature (Hermes env)                             | OpenClaw target                                                   | Hermes target          |
-| ------------------------------------------------------- | ----------------------------------------------------------------- | ---------------------- |
-| `DISCORD_BOT_TOKEN`/`DISCORD_BOT_ID`                    | placeholder in `.env.example`                                     | placeholder            |
-| `DISCORD_REQUIRE_MENTION=true`                          | implied by `HANDLE discord` (OpenClaw enforces tool-only natively) | preserved env          |
-| `DISCORD_ALLOWED_USERS`                                 | `channel://discord allowFrom` SURFACE                              | preserved env          |
-| `SLACK_BOT_TOKEN`/`SLACK_APP_TOKEN`/`SLACK_BOT_ID`      | placeholders                                                      | placeholders           |
-| `SLACK_ALLOWED_USERS`                                   | fatal note: `--accept-loss=slack-routing` to drop                  | preserved env          |
-| `HERMES_DEFAULT_AGENT_IDENTITY`                         | folded into generated `AGENTS.md` (and `SOUL.md` if source had one)| folded into generated `AGENTS.md` / `SOUL.md`; **not** passed through as raw env. Migration note records the source value and target file. |
-| Any other `HERMES_*`                                    | dropped, migration note                                            | dropped except canonical passthrough keys recognized by Clawdapus Hermes driver |
-
-The Clawdapus Hermes driver materializes its own managed default identity (`managedDefaultAgentIdentity` in `internal/driver/hermes/config.go`). Round-tripping `HERMES_DEFAULT_AGENT_IDENTITY` as env passthrough would conflict with that. Folding into `AGENTS.md`/`SOUL.md` is the supported way to express operator identity intent.
-
-### 6.2 Model + provider
-
-Default discipline: **preserve native provider routes where the target supports them.** cllama is opt-in unless the source's existing wiring requires it.
-
-`translateModel(source, target, opts) → (Clawfile MODEL/CLLAMA directives, env requirements, notes)` follows:
-
-1. **Source already routes through a proxy** (OC `models.providers.<p>.baseUrl` pointing at non-vendor host, Hermes `model.base_url` non-empty):
-   - Emit `MODEL primary <provider>/<model>` + `CLLAMA passthrough` regardless of target. Carry the upstream URL/key into a migration note ("verify cllama can reach <url>") rather than the Clawfile.
-2. **Source uses a native provider Clawdapus knows** (`openrouter`, `anthropic`, `openai`):
-   - Hermes target: native (Hermes driver `resolveModelConfig` already supports each → no cllama).
-   - OpenClaw target: native via `models.providers.<provider>` (OpenClaw can carry the provider directly). Add env placeholder for the required API key (`OPENROUTER_API_KEY` / `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`).
-3. **Operator explicitly passes `--cllama`**: emit `CLLAMA passthrough` regardless of source state.
-4. **Source provider unknown to Clawdapus, no base_url**: fatal note ("provider %q is not natively supported; pass --model <alt> or --accept-loss=custom-provider").
-
-`--model <provider/model>` overrides source detection. `--cllama` forces proxy route.
-
-This replaces the v1 draft's "openrouter/... always works through cllama" — which was too aggressive and would have broken Hermes/OpenClaw's existing native paths.
-
-### 6.3 Skills, contracts, persona, cron
-
-- OpenClaw `agents.defaults.workspace` → ignored (canonical layout owns the path).
-- Skill files under `<source>/skills/*.md` (both runtimes) → copied to `agents/<name>/skills/`.
-- Hermes `SOUL.md` → copied verbatim to `agents/<name>/SOUL.md`. Hermes target materializes it; OpenClaw target ignores it harmlessly.
-- Hermes `cron/*.yaml` → **not** copied to `agents/<name>/cron/` (would imply Clawdapus runs them; it doesn't — `INVOKE` is the supported path). Instead, copied under `imported/cron/` (reference only, gitignored) and surfaced in `MIGRATION.md` with "translate each entry to an `INVOKE` directive in `Clawfile`."
-- Persona refs: not handled in v1. Migration note recommends re-declaring via `PERSONA` directive.
-
-### 6.4 cllama wiring
-
-Derived from §6.2 rules, not a separate decision. The translator emits exactly one `CLLAMA passthrough` directive when rule 1 or rule 3 fires; otherwise none.
-
-## 7. Migration notes UX
-
-Importer always writes `MIGRATION.md` next to the scaffold:
-
-```
-# Migration notes — generated by `claw init --from`
-
-Source: hermes (config: /path/to/hermes-home)
-Target: openclaw
-
-## Applied
-- HANDLE discord (token + id placeholders in .env.example)
-- HANDLE slack (token, app-token, id placeholders in .env.example)
-- MODEL primary openrouter/anthropic/claude-sonnet-4 (native OpenRouter provider; OPENROUTER_API_KEY required)
-- DISCORD_ALLOWED_USERS → channel://discord allowFrom [<list>]
-- SOUL.md folded operator identity from HERMES_DEFAULT_AGENT_IDENTITY
-
-## Action required
-- cron/daily-summary.yaml: rewrite as `INVOKE` directive in Clawfile. Reference copy left at imported/cron/daily-summary.yaml.
-- SLACK_ALLOWED_USERS: no channel://slack policy in Clawdapus v1. Re-run with `--accept-loss=slack-routing` to drop, or wait for runtime support.
-
-## Verify before `claw up`
-- OPENROUTER_API_KEY is set in .env
-- Slack socket mode: SLACK_APP_TOKEN obtained from your Slack app
-```
-
-Each fatal action item is also surfaced as a `[claw] note:` line during init and is what blocks the run when `--accept-loss` is missing.
-
-## 8. Secret extraction
-
-A value matching `${VAR}`, or matching a known token pattern (`xoxb-…`, `xapp-…`, `sk-…`, `sk-or-…`, Discord bot-token regex, OpenAI keys, Anthropic keys), is replaced in generated tracked files (`Clawfile`, `claw-pod.yml`) with a `${VAR}` placeholder, and the var name is appended (deduped, sorted) to `.env.example`. Source files are read-only; we never write back.
-
-Literal-token values that don't match any known pattern get a `${UNKNOWN_TOKEN_N}` placeholder and a migration note flagging "we saw a token-shaped string we couldn't classify."
-
-## 9. Implementation sketch
-
-New package `internal/initimport/` rooted under `cmd/claw/`-callable surface:
-
-```
-internal/initimport/
-  detect.go        // Detect(fromPath, override SourceKind) -> Descriptor
-  openclaw.go      // readOpenClaw(path) -> Descriptor
-  hermes.go        // readHermes(path) -> Descriptor  (config.yaml + .env + SOUL.md; ignores unknown keys, records them in RawNotes)
-  translate.go     // Translate(src Descriptor, target TargetRuntime, opts Options) -> (Plan, Notes)
-  emit.go          // Emit(plan Plan, dir string) -> error
-  envscan.go       // ExtractSecrets(values) -> placeholderMap, []EnvExampleEntry
-  testdata/        // OpenClaw + Hermes fixture trees, one per scenario
-```
-
-`cmd/claw/init.go` shrinks to:
-
-```go
-func runInitWithOptions(dir, fromPath string, opts initScaffoldOptions, interactive bool) error {
-    if fromPath != "" {
-        return runInitFromImport(dir, fromPath, opts)
-    }
-    return runInitScaffold(dir, opts, interactive)
-}
-```
-
-`runInitFromImport`:
-
-1. `src, err := initimport.Detect(fromPath, opts.SourceOverride)`
-2. `target, err := resolveImportTarget(opts.ClawType, src.Kind)` — rejects targets outside `{openclaw, hermes}`.
-3. `plan, notes := initimport.Translate(src, target, opts)`
-4. If `notes.HasFatal() && !opts.AcceptLossSatisfies(notes.FatalFeatures())`: print, return error.
-5. `initimport.Emit(plan, dir)` writes files.
-6. Print summary + next steps (mirroring current scaffold output).
-
-`Descriptor` is the runtime-agnostic IR. Channel info is a typed sum, so the translator cannot conflate platforms:
-
-```go
-type Descriptor struct {
-    Kind        SourceKind
-    AgentName   string
-    Identity    string                // SOUL.md contents, or HERMES_DEFAULT_AGENT_IDENTITY value
-    Models      ModelSlots            // primary, fallback
-    Cllama      bool                  // source already wired a proxy
-    Channels    Channels              // typed sum
-    EnvVars     map[string]string     // raw, from sibling .env
-    SkillsDir   string                // optional source path
-    CronDir     string                // optional source path (hermes only)
-    RawNotes    []string              // unrecognized fields/keys from the reader
-}
-
-type Channels struct {
-    Discord  *DiscordChannel
-    Slack    *SlackChannel
-    Telegram *TelegramChannel
-}
-
-type DiscordChannel struct {
-    Token         string   // raw ($VAR or literal)
-    BotID         string
-    RequireMention bool
-    AllowFrom     []string
-    DMPolicy      string
-    Guilds        []DiscordGuild
-}
-
-type SlackChannel struct {
-    BotToken      string
-    AppToken      string
-    BotID         string
-    AllowedUsers  []string
-    // No DM/guild equivalents; Slack policy is intentionally separated.
-}
-
-type TelegramChannel struct {
-    Token string
-    BotID string
-}
-
-type ModelSlots struct {
-    Primary  ModelRef
-    Fallback []ModelRef
-}
-
-type ModelRef struct {
-    Provider string  // "openrouter" | "anthropic" | "openai" | "custom" | ...
-    Model    string
-    BaseURL  string  // empty unless source had a custom base_url
-    APIKey   string  // raw — never written to tracked files (extracted to .env.example)
-}
-```
-
-`Notes` distinguishes informational from fatal:
-
-```go
-type Notes struct {
-    Applied      []string
-    Action       []string  // human-readable migration items
-    FatalLosses  []FatalLoss
-}
-
-type FatalLoss struct {
-    Feature  string  // canonical token used by --accept-loss
-    Reason   string
-}
-```
-
-Canonical `--accept-loss` tokens: `slack-routing`, `discord-routing`, `custom-provider`, `cron`, `identity-env`. `all` is the omnibus.
-
-Hermes config schema fidelity: `readHermes` only consumes fields documented in `internal/driver/hermes/config.go` (`model.{default,provider,base_url,api_key}`, `terminal.*` is ignored as runtime). Unknown top-level keys land in `RawNotes` rather than failing the import.
-
-### 9.1 Tests
-
-`internal/initimport/*_test.go` (per-package unit tests using `testdata/`):
-
-- detect: openclaw-only, hermes-only, ambiguous (both), neither, explicit `--source` override.
-- openclaw reader: structural fields populated; unknown keys land in RawNotes.
-- hermes reader: model.default + .env merge; unknown keys → RawNotes; missing SOUL.md is fine.
-- translate (happy paths):
-  - openclaw → openclaw: structural preservation
-  - hermes → hermes: env passthrough, SOUL.md preserved
-  - openclaw → hermes: Discord routing folded into env, Slack routing flagged fatal without accept-loss
-  - hermes → openclaw: Discord allowFrom routing surfaces, Slack policy fatal without accept-loss
-- translate (negative paths):
-  - unsupported `--type nanobot` with `--from` → error from `resolveImportTarget`
-  - unknown provider, no base_url, no `--accept-loss=custom-provider` → fatal
-  - `--accept-loss=slack-routing` swallows the Slack fatal
-  - source provider routed through proxy → `CLLAMA passthrough` emitted regardless of target
-- envscan: known token shapes redacted; unknown tokens become `${UNKNOWN_TOKEN_N}` with note.
-- emit: writes canonical layout, refuses overwrite, copies SOUL.md verbatim, places cron under `imported/cron/`, sorts `.env.example` deterministically.
-
-`cmd/claw/init_test.go` integration test layer:
-
-- Keep `TestInitFromOpenClawConfig`, expand to assert canonical layout (not flat) and new MIGRATION.md presence.
-- Add `TestInitFromOpenClawWithHermesTarget` and `TestInitFromHermesWithOpenClawTarget` end-to-end.
-- Add `TestInitFromRejectsUnsupportedTargetType`.
-- Add `TestInitFromHermesSlackEmitsBothTokens`.
-
-### 9.2 Files touched
-
-- `cmd/claw/init.go` — replace `runInitFrom`, retire `findOpenClawConfig`, `detectChannels`, `detectModels`, `generateMigrationScaffold` (~150 LOC deleted; ~40 LOC added wrapper).
-- `cmd/claw/init_test.go` — expand per §9.1.
-- New: `internal/initimport/` package (~500-700 LOC including tests + fixtures).
-- `site/guide/` — short migration page referencing the four paths (Phase 3, may follow in a separate PR).
-
-## 10. Verification
-
-- `go test ./...`
-- `go vet ./...`
-- Manual: `claw init <dst> --from <openclaw-fixture> --type hermes`, then `claw build` + `claw up -d` against fixture. Same in reverse.
-- `MIGRATION.md` content asserted in tests for at least one cross-runtime case.
-
-## 11. Decisions (converged from review)
-
-Codex's 10 review points have been applied verbatim:
-
-1. **No `--legacy-flat`.** Canonical layout only (§5).
-2. **No `channel://slack` stub.** Slack routing fields are fatal without `--accept-loss=slack-routing` (§6.1, §7).
-3. **Granular `--accept-loss=<token,...>`** with `all` as the omnibus. Canonical tokens listed in §9.
-4. **Typed channel IR.** `DiscordChannel`/`SlackChannel`/`TelegramChannel` sum-type prevents cross-platform mapping bugs (§9).
-5. **Hermes schema fidelity.** Reader consumes only documented fields; unknowns land in `RawNotes` (§9, §6).
-6. **`HERMES_DEFAULT_AGENT_IDENTITY` is not passed through as env.** Folded into `AGENTS.md`/`SOUL.md` (§6.1).
-7. **Native provider routes preserved.** cllama is opt-in unless source already used proxy semantics or operator requests it (§6.2). v1 draft's aggressive openrouter→cllama rule is gone.
-8. **Target scope limited to `{openclaw, hermes}`** for `--from`. Other `--type` values fail with a clear message (§2, §4).
-9. **Hermes cron is migration evidence, not active import.** Files land under `imported/cron/` and are flagged in `MIGRATION.md` for translation to `INVOKE` (§6.3).
-10. **Negative-path tests are first-class.** See §9.1 negative paths list.
-
-The MIGRATION.md typo from the v1 draft (`SLACK_ALLOWED_USERS → channel://discord allowFrom`) is fixed in §7's revised example.
-
-## 12. Phasing
-
-- Phase 1: `internal/initimport/` package + `cmd/claw/init.go` wiring + same-runtime tests (openclaw→openclaw, hermes→hermes).
-- Phase 2: cross-runtime translation + migration notes + negative-path tests.
-- Phase 3: docs/guide page.
-
-Phases 1+2 ship in one PR (issue acceptance criteria require cross-runtime). Phase 3 may lag by one PR.
+# Plan: `claw init --from` same-runtime imports
+
+Issue #230 originally explored both same-runtime imports and cross-runtime
+translation. After implementation review, the cross-runtime path was cut from
+scope: automated OpenClaw -> Hermes or Hermes -> OpenClaw translation is too
+lossy to be a trustworthy operator workflow. Operators switching runtimes should
+start from a fresh scaffold and hand-port the contract deliberately.
+
+## Scope
+
+Keep:
+
+- OpenClaw config -> claw-managed OpenClaw.
+- Hermes config + `.env` -> claw-managed Hermes.
+- Canonical `agents/<name>/` layout.
+- Source autodetection for `openclaw.json` or Hermes `config.yaml`.
+- `--source openclaw|hermes` for ambiguous source directories.
+- Secret extraction into `.env.example`.
+- A slim `MIGRATION.md` with applied mappings, action notes, secret placeholders,
+  and pre-`claw up` checks.
+
+Drop:
+
+- OpenClaw -> Hermes translation.
+- Hermes -> OpenClaw translation.
+- `--accept-loss`.
+- `--type` target selection during `--from` imports. With `--from`, `--type`
+  is an error; imports preserve the detected source runtime.
+- Cross-runtime routing conversions and loss-token machinery.
+
+## Source Detection
+
+`claw init --from <path>` accepts:
+
+- `<path>/openclaw.json`
+- `<path>/config/openclaw.json`
+- `<path>/config.yaml` or `<path>/config.yml` that looks like a Hermes config
+  with a `model:` block
+
+If both source markers are present, the command fails and asks for
+`--source openclaw` or `--source hermes`.
+
+## Translation Rules
+
+OpenClaw imports preserve the same runtime shape:
+
+- model primary and first runtime-effective fallback
+- cllama when the source provider used a custom `baseUrl`
+- Discord, Slack, and Telegram handles
+- Discord routing that maps to current `channel://discord`
+- source `skills/*.md`
+
+Hermes imports preserve the same runtime shape:
+
+- model provider/default/base_url/api_key where supported
+- cllama when the source used `model.base_url`
+- Discord, Slack, and Telegram handle env vars
+- Hermes `SOUL.md` and source identity intent in generated agent material
+- source `skills/*.md`
+- `cron/` files as gitignored references under `imported/cron/`, with a note to
+  translate them to `INVOKE`
+
+Unsupported same-runtime details are not hidden. Non-critical drops become
+`MIGRATION.md` action notes. Provider choices that would create a known-broken
+scaffold fail early with a `--model <provider/model>` recovery hint.
+
+## Tests
+
+- OpenClaw import emits canonical layout, handles, `.env.example`, and no legacy
+  root `Clawfile`.
+- Hermes import emits canonical Hermes layout and preserves required handle env.
+- `--type` with `--from` fails clearly.
+- Ambiguous source detection requires `--source`.
+- Custom unsupported providers without `base_url` fail with a `--model` hint.
+- Migration notes cover copied cron references and non-preserved same-runtime
+  routing details.

--- a/docs/plans/2026-05-11-issue-230-init-from-cross-runtime.md
+++ b/docs/plans/2026-05-11-issue-230-init-from-cross-runtime.md
@@ -1,0 +1,348 @@
+# Plan: `claw init --from` cross-runtime and same-runtime imports
+
+Issue: https://github.com/mostlydev/clawdapus/issues/230
+
+Author: Claude (claude:5379be30). v2 — converged with codex adversarial review (https://github.com/mostlydev/clawdapus/issues/230#issuecomment-4426381993).
+
+## 1. Problem
+
+`claw init --from <path>` is currently:
+
+- **Source-locked.** Only `openclaw.json` is recognized. Hermes users have no import path.
+- **Target-locked.** Hard-codes `FROM openclaw:latest`, `CLAW_TYPE openclaw`. `--type` is silently ignored when `--from` is present.
+- **Layout-locked.** Emits the legacy flat scaffold instead of the ADR-011 canonical `agents/<name>/` layout.
+- **Lossy.** Drops platform-specific routing, forgets Hermes Slack socket-mode needs both `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` (#229/#231 now on master), and copies provider refs even when the target runtime cannot use them.
+- **Secret-discoverability is poor.** Token-shaped fields ride through as literal `${VAR}` placeholders without ever being inventoried in `.env.example`.
+
+## 2. Goals
+
+A first-class migration UX with four covered paths:
+
+| Source         | Target         | Behavior                                                                            |
+| -------------- | -------------- | ----------------------------------------------------------------------------------- |
+| OpenClaw cfg   | `openclaw`     | Preserve structurally identical: handles, channels routing, model slots.            |
+| OpenClaw cfg   | `hermes`       | Map what Hermes supports; emit migration notes for unmappable features.             |
+| Hermes cfg+env | `hermes`       | Preserve model/provider, identity (SOUL.md), channel env vars, allowed users.       |
+| Hermes cfg+env | `openclaw`     | Same mapping discipline as the reverse direction.                                   |
+
+Non-goals (per issue):
+
+- No deployment-specific scaffolds.
+- No new `channel://slack` SURFACE in the data model.
+- No inlining of secrets into tracked files.
+- No support for `--from <X> --type nanobot|microclaw|nanoclaw|...`. v1 limits import targets to `openclaw` and `hermes`. Other `--type` values with `--from` fail fast with "import target not supported yet."
+
+## 3. Source detection
+
+Replace `findOpenClawConfig` with `Detect(fromPath, override SourceKind) (Descriptor, error)`. Recognizes:
+
+| Marker                                                                                  | Source kind |
+| --------------------------------------------------------------------------------------- | ----------- |
+| `openclaw.json` at path, `<path>/openclaw.json`, or `<path>/config/openclaw.json`       | `openclaw`  |
+| `config.yaml` with a `model:` block (containing `default` and/or `provider`), optionally with sibling `SOUL.md`, `.env`, `skills/`, `cron/`, `memory/` | `hermes`    |
+| Both present                                                                            | error: ambiguous; require explicit `--source` |
+| Neither                                                                                 | current error: nothing recognized              |
+
+A `.env` file next to the detected config is consumed as additional input (channel tokens, allowed-users, identity-overrides) but never copied verbatim. Its values are extracted into `.env.example` placeholders only.
+
+`--source <openclaw|hermes>` exists as an explicit override when detection is ambiguous or the operator points at an unusual location.
+
+## 4. Target selection
+
+- `--type <openclaw|hermes>` is honored regardless of `--from`.
+- If `--type` is omitted, target defaults to the source runtime (same-runtime import).
+- `--type` outside `{openclaw, hermes}` with `--from` → `"import target %q not supported yet; use --type openclaw|hermes for --from"`.
+- If the chosen target cannot represent a source feature, importer fails with a migration note unless the operator passes `--accept-loss=<feature,...>` (or `--accept-loss=all`). Each fatal note names the exact token needed.
+
+## 5. Output layout
+
+ADR-011 canonical layout, no opt-outs. The legacy flat scaffold is gone in v1.
+
+```
+project-root/
+  agents/<agent-name>/
+    Clawfile
+    AGENTS.md
+    SOUL.md             (only when source had one)
+    skills/             (only when source had importable skills)
+  claw-pod.yml
+  .env.example
+  .gitignore
+  MIGRATION.md          (always emitted for --from runs)
+```
+
+Agent name source:
+
+- OpenClaw → `agents.list[0].id` if present, normalized; else `assistant`.
+- Hermes → `SOUL.md` first heading (kebab-cased) if present, else service hint, else `assistant`.
+
+## 6. Translation matrix
+
+### 6.1 Handles, channels, routing
+
+The IR carries platform-specific typed structs (§9). The translator dispatches on platform, so Slack routing cannot accidentally map into Discord routing.
+
+| Source feature                                          | OpenClaw target                       | Hermes target                          |
+| ------------------------------------------------------- | ------------------------------------- | -------------------------------------- |
+| OC `channels.discord.enabled=true`                      | `HANDLE discord`                      | `HANDLE discord`                       |
+| OC `channels.discord.token` ($DISCORD_BOT_TOKEN)        | env placeholder                       | env placeholder                        |
+| OC `channels.discord.dmPolicy`                          | `channel://discord` SURFACE           | env `DISCORD_REQUIRE_MENTION` / Hermes runtime knobs where matching exists; else fatal note (`--accept-loss=discord-routing`) |
+| OC `channels.discord.guilds.<id>.requireMention=true`   | `channel://discord` SURFACE           | env `DISCORD_REQUIRE_MENTION=true`     |
+| OC `channels.discord.allowFrom` / users allowlist       | `channel://discord allowFrom`         | env `DISCORD_ALLOWED_USERS` (comma-joined) |
+| OC `channels.slack.enabled=true`                        | `HANDLE slack`                        | `HANDLE slack` + scaffold both `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` |
+| OC `channels.slack.token` ($SLACK_BOT_TOKEN)            | env placeholder                       | env placeholder + `SLACK_APP_TOKEN` placeholder |
+| OC Slack routing fields (allowed channels, users, etc.) | fatal note: "no channel://slack SURFACE in v1; pass --accept-loss=slack-routing to drop, or wait for runtime support" | env `SLACK_ALLOWED_USERS` (comma-joined) |
+| OC `agents.list[0].name`                                | preserved as HANDLE username + display name | preserved (SOUL.md identity)            |
+
+| Source feature (Hermes env)                             | OpenClaw target                                                   | Hermes target          |
+| ------------------------------------------------------- | ----------------------------------------------------------------- | ---------------------- |
+| `DISCORD_BOT_TOKEN`/`DISCORD_BOT_ID`                    | placeholder in `.env.example`                                     | placeholder            |
+| `DISCORD_REQUIRE_MENTION=true`                          | implied by `HANDLE discord` (OpenClaw enforces tool-only natively) | preserved env          |
+| `DISCORD_ALLOWED_USERS`                                 | `channel://discord allowFrom` SURFACE                              | preserved env          |
+| `SLACK_BOT_TOKEN`/`SLACK_APP_TOKEN`/`SLACK_BOT_ID`      | placeholders                                                      | placeholders           |
+| `SLACK_ALLOWED_USERS`                                   | fatal note: `--accept-loss=slack-routing` to drop                  | preserved env          |
+| `HERMES_DEFAULT_AGENT_IDENTITY`                         | folded into generated `AGENTS.md` (and `SOUL.md` if source had one)| folded into generated `AGENTS.md` / `SOUL.md`; **not** passed through as raw env. Migration note records the source value and target file. |
+| Any other `HERMES_*`                                    | dropped, migration note                                            | dropped except canonical passthrough keys recognized by Clawdapus Hermes driver |
+
+The Clawdapus Hermes driver materializes its own managed default identity (`managedDefaultAgentIdentity` in `internal/driver/hermes/config.go`). Round-tripping `HERMES_DEFAULT_AGENT_IDENTITY` as env passthrough would conflict with that. Folding into `AGENTS.md`/`SOUL.md` is the supported way to express operator identity intent.
+
+### 6.2 Model + provider
+
+Default discipline: **preserve native provider routes where the target supports them.** cllama is opt-in unless the source's existing wiring requires it.
+
+`translateModel(source, target, opts) → (Clawfile MODEL/CLLAMA directives, env requirements, notes)` follows:
+
+1. **Source already routes through a proxy** (OC `models.providers.<p>.baseUrl` pointing at non-vendor host, Hermes `model.base_url` non-empty):
+   - Emit `MODEL primary <provider>/<model>` + `CLLAMA passthrough` regardless of target. Carry the upstream URL/key into a migration note ("verify cllama can reach <url>") rather than the Clawfile.
+2. **Source uses a native provider Clawdapus knows** (`openrouter`, `anthropic`, `openai`):
+   - Hermes target: native (Hermes driver `resolveModelConfig` already supports each → no cllama).
+   - OpenClaw target: native via `models.providers.<provider>` (OpenClaw can carry the provider directly). Add env placeholder for the required API key (`OPENROUTER_API_KEY` / `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`).
+3. **Operator explicitly passes `--cllama`**: emit `CLLAMA passthrough` regardless of source state.
+4. **Source provider unknown to Clawdapus, no base_url**: fatal note ("provider %q is not natively supported; pass --model <alt> or --accept-loss=custom-provider").
+
+`--model <provider/model>` overrides source detection. `--cllama` forces proxy route.
+
+This replaces the v1 draft's "openrouter/... always works through cllama" — which was too aggressive and would have broken Hermes/OpenClaw's existing native paths.
+
+### 6.3 Skills, contracts, persona, cron
+
+- OpenClaw `agents.defaults.workspace` → ignored (canonical layout owns the path).
+- Skill files under `<source>/skills/*.md` (both runtimes) → copied to `agents/<name>/skills/`.
+- Hermes `SOUL.md` → copied verbatim to `agents/<name>/SOUL.md`. Hermes target materializes it; OpenClaw target ignores it harmlessly.
+- Hermes `cron/*.yaml` → **not** copied to `agents/<name>/cron/` (would imply Clawdapus runs them; it doesn't — `INVOKE` is the supported path). Instead, copied under `imported/cron/` (reference only, gitignored) and surfaced in `MIGRATION.md` with "translate each entry to an `INVOKE` directive in `Clawfile`."
+- Persona refs: not handled in v1. Migration note recommends re-declaring via `PERSONA` directive.
+
+### 6.4 cllama wiring
+
+Derived from §6.2 rules, not a separate decision. The translator emits exactly one `CLLAMA passthrough` directive when rule 1 or rule 3 fires; otherwise none.
+
+## 7. Migration notes UX
+
+Importer always writes `MIGRATION.md` next to the scaffold:
+
+```
+# Migration notes — generated by `claw init --from`
+
+Source: hermes (config: /path/to/hermes-home)
+Target: openclaw
+
+## Applied
+- HANDLE discord (token + id placeholders in .env.example)
+- HANDLE slack (token, app-token, id placeholders in .env.example)
+- MODEL primary openrouter/anthropic/claude-sonnet-4 (native OpenRouter provider; OPENROUTER_API_KEY required)
+- DISCORD_ALLOWED_USERS → channel://discord allowFrom [<list>]
+- SOUL.md folded operator identity from HERMES_DEFAULT_AGENT_IDENTITY
+
+## Action required
+- cron/daily-summary.yaml: rewrite as `INVOKE` directive in Clawfile. Reference copy left at imported/cron/daily-summary.yaml.
+- SLACK_ALLOWED_USERS: no channel://slack policy in Clawdapus v1. Re-run with `--accept-loss=slack-routing` to drop, or wait for runtime support.
+
+## Verify before `claw up`
+- OPENROUTER_API_KEY is set in .env
+- Slack socket mode: SLACK_APP_TOKEN obtained from your Slack app
+```
+
+Each fatal action item is also surfaced as a `[claw] note:` line during init and is what blocks the run when `--accept-loss` is missing.
+
+## 8. Secret extraction
+
+A value matching `${VAR}`, or matching a known token pattern (`xoxb-…`, `xapp-…`, `sk-…`, `sk-or-…`, Discord bot-token regex, OpenAI keys, Anthropic keys), is replaced in generated tracked files (`Clawfile`, `claw-pod.yml`) with a `${VAR}` placeholder, and the var name is appended (deduped, sorted) to `.env.example`. Source files are read-only; we never write back.
+
+Literal-token values that don't match any known pattern get a `${UNKNOWN_TOKEN_N}` placeholder and a migration note flagging "we saw a token-shaped string we couldn't classify."
+
+## 9. Implementation sketch
+
+New package `internal/initimport/` rooted under `cmd/claw/`-callable surface:
+
+```
+internal/initimport/
+  detect.go        // Detect(fromPath, override SourceKind) -> Descriptor
+  openclaw.go      // readOpenClaw(path) -> Descriptor
+  hermes.go        // readHermes(path) -> Descriptor  (config.yaml + .env + SOUL.md; ignores unknown keys, records them in RawNotes)
+  translate.go     // Translate(src Descriptor, target TargetRuntime, opts Options) -> (Plan, Notes)
+  emit.go          // Emit(plan Plan, dir string) -> error
+  envscan.go       // ExtractSecrets(values) -> placeholderMap, []EnvExampleEntry
+  testdata/        // OpenClaw + Hermes fixture trees, one per scenario
+```
+
+`cmd/claw/init.go` shrinks to:
+
+```go
+func runInitWithOptions(dir, fromPath string, opts initScaffoldOptions, interactive bool) error {
+    if fromPath != "" {
+        return runInitFromImport(dir, fromPath, opts)
+    }
+    return runInitScaffold(dir, opts, interactive)
+}
+```
+
+`runInitFromImport`:
+
+1. `src, err := initimport.Detect(fromPath, opts.SourceOverride)`
+2. `target, err := resolveImportTarget(opts.ClawType, src.Kind)` — rejects targets outside `{openclaw, hermes}`.
+3. `plan, notes := initimport.Translate(src, target, opts)`
+4. If `notes.HasFatal() && !opts.AcceptLossSatisfies(notes.FatalFeatures())`: print, return error.
+5. `initimport.Emit(plan, dir)` writes files.
+6. Print summary + next steps (mirroring current scaffold output).
+
+`Descriptor` is the runtime-agnostic IR. Channel info is a typed sum, so the translator cannot conflate platforms:
+
+```go
+type Descriptor struct {
+    Kind        SourceKind
+    AgentName   string
+    Identity    string                // SOUL.md contents, or HERMES_DEFAULT_AGENT_IDENTITY value
+    Models      ModelSlots            // primary, fallback
+    Cllama      bool                  // source already wired a proxy
+    Channels    Channels              // typed sum
+    EnvVars     map[string]string     // raw, from sibling .env
+    SkillsDir   string                // optional source path
+    CronDir     string                // optional source path (hermes only)
+    RawNotes    []string              // unrecognized fields/keys from the reader
+}
+
+type Channels struct {
+    Discord  *DiscordChannel
+    Slack    *SlackChannel
+    Telegram *TelegramChannel
+}
+
+type DiscordChannel struct {
+    Token         string   // raw ($VAR or literal)
+    BotID         string
+    RequireMention bool
+    AllowFrom     []string
+    DMPolicy      string
+    Guilds        []DiscordGuild
+}
+
+type SlackChannel struct {
+    BotToken      string
+    AppToken      string
+    BotID         string
+    AllowedUsers  []string
+    // No DM/guild equivalents; Slack policy is intentionally separated.
+}
+
+type TelegramChannel struct {
+    Token string
+    BotID string
+}
+
+type ModelSlots struct {
+    Primary  ModelRef
+    Fallback []ModelRef
+}
+
+type ModelRef struct {
+    Provider string  // "openrouter" | "anthropic" | "openai" | "custom" | ...
+    Model    string
+    BaseURL  string  // empty unless source had a custom base_url
+    APIKey   string  // raw — never written to tracked files (extracted to .env.example)
+}
+```
+
+`Notes` distinguishes informational from fatal:
+
+```go
+type Notes struct {
+    Applied      []string
+    Action       []string  // human-readable migration items
+    FatalLosses  []FatalLoss
+}
+
+type FatalLoss struct {
+    Feature  string  // canonical token used by --accept-loss
+    Reason   string
+}
+```
+
+Canonical `--accept-loss` tokens: `slack-routing`, `discord-routing`, `custom-provider`, `cron`, `identity-env`. `all` is the omnibus.
+
+Hermes config schema fidelity: `readHermes` only consumes fields documented in `internal/driver/hermes/config.go` (`model.{default,provider,base_url,api_key}`, `terminal.*` is ignored as runtime). Unknown top-level keys land in `RawNotes` rather than failing the import.
+
+### 9.1 Tests
+
+`internal/initimport/*_test.go` (per-package unit tests using `testdata/`):
+
+- detect: openclaw-only, hermes-only, ambiguous (both), neither, explicit `--source` override.
+- openclaw reader: structural fields populated; unknown keys land in RawNotes.
+- hermes reader: model.default + .env merge; unknown keys → RawNotes; missing SOUL.md is fine.
+- translate (happy paths):
+  - openclaw → openclaw: structural preservation
+  - hermes → hermes: env passthrough, SOUL.md preserved
+  - openclaw → hermes: Discord routing folded into env, Slack routing flagged fatal without accept-loss
+  - hermes → openclaw: Discord allowFrom routing surfaces, Slack policy fatal without accept-loss
+- translate (negative paths):
+  - unsupported `--type nanobot` with `--from` → error from `resolveImportTarget`
+  - unknown provider, no base_url, no `--accept-loss=custom-provider` → fatal
+  - `--accept-loss=slack-routing` swallows the Slack fatal
+  - source provider routed through proxy → `CLLAMA passthrough` emitted regardless of target
+- envscan: known token shapes redacted; unknown tokens become `${UNKNOWN_TOKEN_N}` with note.
+- emit: writes canonical layout, refuses overwrite, copies SOUL.md verbatim, places cron under `imported/cron/`, sorts `.env.example` deterministically.
+
+`cmd/claw/init_test.go` integration test layer:
+
+- Keep `TestInitFromOpenClawConfig`, expand to assert canonical layout (not flat) and new MIGRATION.md presence.
+- Add `TestInitFromOpenClawWithHermesTarget` and `TestInitFromHermesWithOpenClawTarget` end-to-end.
+- Add `TestInitFromRejectsUnsupportedTargetType`.
+- Add `TestInitFromHermesSlackEmitsBothTokens`.
+
+### 9.2 Files touched
+
+- `cmd/claw/init.go` — replace `runInitFrom`, retire `findOpenClawConfig`, `detectChannels`, `detectModels`, `generateMigrationScaffold` (~150 LOC deleted; ~40 LOC added wrapper).
+- `cmd/claw/init_test.go` — expand per §9.1.
+- New: `internal/initimport/` package (~500-700 LOC including tests + fixtures).
+- `site/guide/` — short migration page referencing the four paths (Phase 3, may follow in a separate PR).
+
+## 10. Verification
+
+- `go test ./...`
+- `go vet ./...`
+- Manual: `claw init <dst> --from <openclaw-fixture> --type hermes`, then `claw build` + `claw up -d` against fixture. Same in reverse.
+- `MIGRATION.md` content asserted in tests for at least one cross-runtime case.
+
+## 11. Decisions (converged from review)
+
+Codex's 10 review points have been applied verbatim:
+
+1. **No `--legacy-flat`.** Canonical layout only (§5).
+2. **No `channel://slack` stub.** Slack routing fields are fatal without `--accept-loss=slack-routing` (§6.1, §7).
+3. **Granular `--accept-loss=<token,...>`** with `all` as the omnibus. Canonical tokens listed in §9.
+4. **Typed channel IR.** `DiscordChannel`/`SlackChannel`/`TelegramChannel` sum-type prevents cross-platform mapping bugs (§9).
+5. **Hermes schema fidelity.** Reader consumes only documented fields; unknowns land in `RawNotes` (§9, §6).
+6. **`HERMES_DEFAULT_AGENT_IDENTITY` is not passed through as env.** Folded into `AGENTS.md`/`SOUL.md` (§6.1).
+7. **Native provider routes preserved.** cllama is opt-in unless source already used proxy semantics or operator requests it (§6.2). v1 draft's aggressive openrouter→cllama rule is gone.
+8. **Target scope limited to `{openclaw, hermes}`** for `--from`. Other `--type` values fail with a clear message (§2, §4).
+9. **Hermes cron is migration evidence, not active import.** Files land under `imported/cron/` and are flagged in `MIGRATION.md` for translation to `INVOKE` (§6.3).
+10. **Negative-path tests are first-class.** See §9.1 negative paths list.
+
+The MIGRATION.md typo from the v1 draft (`SLACK_ALLOWED_USERS → channel://discord allowFrom`) is fixed in §7's revised example.
+
+## 12. Phasing
+
+- Phase 1: `internal/initimport/` package + `cmd/claw/init.go` wiring + same-runtime tests (openclaw→openclaw, hermes→hermes).
+- Phase 2: cross-runtime translation + migration notes + negative-path tests.
+- Phase 3: docs/guide page.
+
+Phases 1+2 ship in one PR (issue acceptance criteria require cross-runtime). Phase 3 may lag by one PR.

--- a/internal/initimport/detect.go
+++ b/internal/initimport/detect.go
@@ -1,0 +1,96 @@
+package initimport
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+func Detect(fromPath string, override SourceKind) (Descriptor, error) {
+	if strings.TrimSpace(fromPath) == "" {
+		return Descriptor{}, fmt.Errorf("--from path is required")
+	}
+	openclawPath := findOpenClawConfig(fromPath)
+	hermesPath := findHermesConfig(fromPath)
+
+	switch override {
+	case SourceOpenClaw:
+		if openclawPath == "" {
+			return Descriptor{}, fmt.Errorf("--source=openclaw but no openclaw.json found in %q", fromPath)
+		}
+		return readOpenClaw(openclawPath)
+	case SourceHermes:
+		if hermesPath == "" {
+			return Descriptor{}, fmt.Errorf("--source=hermes but no Hermes config.yaml found in %q", fromPath)
+		}
+		return readHermes(hermesPath)
+	case "":
+	default:
+		return Descriptor{}, fmt.Errorf("unsupported --source %q (allowed: openclaw, hermes)", override)
+	}
+
+	if openclawPath != "" && hermesPath != "" {
+		return Descriptor{}, fmt.Errorf("ambiguous import source %q: found both openclaw.json and Hermes config.yaml; pass --source openclaw or --source hermes", fromPath)
+	}
+	if openclawPath != "" {
+		return readOpenClaw(openclawPath)
+	}
+	if hermesPath != "" {
+		return readHermes(hermesPath)
+	}
+	return Descriptor{}, fmt.Errorf("no OpenClaw or Hermes config found in %q", fromPath)
+}
+
+func findOpenClawConfig(path string) string {
+	if info, err := os.Stat(path); err == nil && !info.IsDir() && filepath.Base(path) == "openclaw.json" {
+		return path
+	}
+	for _, candidate := range []string{
+		filepath.Join(path, "openclaw.json"),
+		filepath.Join(path, "config", "openclaw.json"),
+	} {
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func findHermesConfig(path string) string {
+	if info, err := os.Stat(path); err == nil && !info.IsDir() {
+		base := filepath.Base(path)
+		if (base == "config.yaml" || base == "config.yml") && looksLikeHermesConfig(path) {
+			return path
+		}
+	}
+	for _, candidate := range []string{
+		filepath.Join(path, "config.yaml"),
+		filepath.Join(path, "config.yml"),
+	} {
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() && looksLikeHermesConfig(candidate) {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func looksLikeHermesConfig(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return false
+	}
+	model, ok := raw["model"].(map[string]any)
+	if !ok {
+		return false
+	}
+	_, hasDefault := model["default"]
+	_, hasProvider := model["provider"]
+	return hasDefault || hasProvider
+}

--- a/internal/initimport/emit.go
+++ b/internal/initimport/emit.go
@@ -259,9 +259,6 @@ func renderMigration(plan Plan) string {
 	}
 	writeList("Applied", uniqueSorted(plan.Notes.Applied))
 	actions := append([]string(nil), plan.Notes.Action...)
-	for _, loss := range plan.Notes.FatalLosses {
-		actions = append(actions, fmt.Sprintf("%s (accept with --accept-loss=%s)", loss.Reason, loss.Feature))
-	}
 	writeList("Action required", uniqueSorted(actions))
 	writeList("Secret placeholders", uniqueSorted(plan.Notes.SecretNotes))
 	verify := make([]string, 0)

--- a/internal/initimport/emit.go
+++ b/internal/initimport/emit.go
@@ -1,0 +1,321 @@
+package initimport
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func Emit(plan Plan, dir string) error {
+	agentDir := filepath.Join(dir, "agents", plan.AgentName)
+	targets := []string{
+		filepath.Join(agentDir, "Clawfile"),
+		filepath.Join(agentDir, "AGENTS.md"),
+		filepath.Join(dir, "claw-pod.yml"),
+		filepath.Join(dir, ".env.example"),
+		filepath.Join(dir, "MIGRATION.md"),
+	}
+	if plan.SoulContent != "" {
+		targets = append(targets, filepath.Join(agentDir, "SOUL.md"))
+	}
+	for _, target := range targets {
+		if _, err := os.Stat(target); err == nil {
+			rel, _ := filepath.Rel(dir, target)
+			return fmt.Errorf("%s already exists; refusing to overwrite (delete it first or use a new directory)", filepath.ToSlash(rel))
+		} else if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("check existing %s: %w", target, err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(agentDir, "skills"), 0o755); err != nil {
+		return fmt.Errorf("create agent directory: %w", err)
+	}
+
+	files := map[string]string{
+		filepath.Join(agentDir, "Clawfile"):  renderClawfile(plan),
+		filepath.Join(agentDir, "AGENTS.md"): plan.AgentContract,
+		filepath.Join(dir, "claw-pod.yml"):   renderPod(plan),
+		filepath.Join(dir, ".env.example"):   renderEnvExample(plan),
+		filepath.Join(dir, "MIGRATION.md"):   renderMigration(plan),
+	}
+	if plan.SoulContent != "" {
+		files[filepath.Join(agentDir, "SOUL.md")] = plan.SoulContent
+	}
+	for path, content := range files {
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", path, err)
+		}
+	}
+	if plan.SkillsDir != "" {
+		if err := copyDirFiles(plan.SkillsDir, filepath.Join(agentDir, "skills")); err != nil {
+			return fmt.Errorf("copy skills: %w", err)
+		}
+	}
+	if plan.CronDir != "" {
+		if err := copyDirFiles(plan.CronDir, filepath.Join(dir, "imported", "cron")); err != nil {
+			return fmt.Errorf("copy cron references: %w", err)
+		}
+	}
+	if err := writeGitignore(filepath.Join(dir, ".gitignore")); err != nil {
+		return err
+	}
+	return nil
+}
+
+func renderClawfile(plan Plan) string {
+	var b strings.Builder
+	b.WriteString("FROM ")
+	b.WriteString(plan.BaseImage)
+	b.WriteString("\n\n")
+	b.WriteString("CLAW_TYPE ")
+	b.WriteString(string(plan.Target))
+	b.WriteString("\n")
+	b.WriteString("AGENT AGENTS.md\n\n")
+	b.WriteString("MODEL primary ")
+	b.WriteString(plan.Model.String())
+	b.WriteString("\n")
+	if plan.Cllama {
+		b.WriteString("\nCLLAMA passthrough\n")
+	}
+	for _, handle := range plan.Handles {
+		b.WriteString("\nHANDLE ")
+		b.WriteString(handle.Platform)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func renderPod(plan Plan) string {
+	var b strings.Builder
+	b.WriteString("x-claw:\n")
+	b.WriteString("  pod: ")
+	b.WriteString(plan.ProjectName)
+	b.WriteString("\n")
+	b.WriteString("services:\n")
+	b.WriteString("  ")
+	b.WriteString(plan.AgentName)
+	b.WriteString(":\n")
+	b.WriteString("    image: ")
+	b.WriteString(plan.ProjectName)
+	b.WriteString("-")
+	b.WriteString(plan.AgentName)
+	b.WriteString(":latest\n")
+	b.WriteString("    build:\n")
+	b.WriteString("      context: ./agents/")
+	b.WriteString(plan.AgentName)
+	b.WriteString("\n")
+	b.WriteString("    x-claw:\n")
+	b.WriteString("      agent: ./agents/")
+	b.WriteString(plan.AgentName)
+	b.WriteString("/AGENTS.md\n")
+	if plan.Cllama {
+		b.WriteString("      cllama: passthrough\n")
+		if len(plan.CllamaEnv) > 0 {
+			b.WriteString("      cllama-env:\n")
+			for _, key := range sortedMapKeys(plan.CllamaEnv) {
+				b.WriteString("        ")
+				b.WriteString(key)
+				b.WriteString(": \"")
+				b.WriteString(plan.CllamaEnv[key])
+				b.WriteString("\"\n")
+			}
+		}
+	}
+	if len(plan.Handles) > 0 {
+		b.WriteString("      handles:\n")
+		for _, handle := range plan.Handles {
+			b.WriteString("        ")
+			b.WriteString(handle.Platform)
+			b.WriteString(":\n")
+			b.WriteString("          id: \"${")
+			b.WriteString(handle.IDEnv)
+			b.WriteString("}\"\n")
+			b.WriteString("          username: \"")
+			b.WriteString(plan.AgentName)
+			b.WriteString("\"\n")
+			if handle.Platform == "discord" && len(handle.Guilds) > 0 {
+				b.WriteString("          guilds:\n")
+				for _, guild := range handle.Guilds {
+					b.WriteString("            - id: \"")
+					b.WriteString(guild.ID)
+					b.WriteString("\"\n")
+				}
+			}
+		}
+	}
+	if len(plan.Surfaces) > 0 {
+		b.WriteString("      surfaces:\n")
+		for _, surface := range plan.Surfaces {
+			if surface.Platform == "discord" && surface.Discord != nil {
+				renderDiscordSurface(&b, surface.Discord)
+			}
+		}
+	}
+	env := serviceEnvironment(plan)
+	if len(env) > 0 {
+		b.WriteString("    environment:\n")
+		for _, key := range sortedMapKeys(env) {
+			b.WriteString("      ")
+			b.WriteString(key)
+			b.WriteString(": \"")
+			b.WriteString(env[key])
+			b.WriteString("\"\n")
+		}
+	}
+	return b.String()
+}
+
+func renderDiscordSurface(b *strings.Builder, surface *DiscordSurface) {
+	b.WriteString("        - channel://discord:\n")
+	if surface.DMPolicy != "" || len(surface.DMAllowFrom) > 0 {
+		b.WriteString("            dm:\n")
+		if surface.DMPolicy != "" {
+			b.WriteString("              policy: ")
+			b.WriteString(surface.DMPolicy)
+			b.WriteString("\n")
+		}
+		if len(surface.DMAllowFrom) > 0 {
+			b.WriteString("              allow_from:\n")
+			for _, id := range surface.DMAllowFrom {
+				b.WriteString("                - \"")
+				b.WriteString(id)
+				b.WriteString("\"\n")
+			}
+		}
+	}
+	if len(surface.Guilds) > 0 {
+		b.WriteString("            guilds:\n")
+		for _, guild := range surface.Guilds {
+			b.WriteString("              \"")
+			b.WriteString(guild.ID)
+			b.WriteString("\":\n")
+			if guild.RequireMention {
+				b.WriteString("                require_mention: true\n")
+			}
+			if len(guild.Users) > 0 {
+				b.WriteString("                users:\n")
+				for _, user := range guild.Users {
+					b.WriteString("                  - \"")
+					b.WriteString(user)
+					b.WriteString("\"\n")
+				}
+			}
+		}
+	}
+}
+
+func renderEnvExample(plan Plan) string {
+	keys := map[string]struct{}{}
+	for key := range plan.Environment {
+		keys[key] = struct{}{}
+	}
+	for key := range plan.CllamaEnv {
+		keys[key] = struct{}{}
+	}
+	out := make([]string, 0, len(keys))
+	for key := range keys {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	var b strings.Builder
+	for _, key := range out {
+		b.WriteString(key)
+		b.WriteString("=\n")
+	}
+	return b.String()
+}
+
+func renderMigration(plan Plan) string {
+	var b strings.Builder
+	b.WriteString("# Migration notes -- generated by `claw init --from`\n\n")
+	b.WriteString("Source: ")
+	b.WriteString(string(plan.Source.Kind))
+	b.WriteString(" (config: ")
+	b.WriteString(plan.Source.Config)
+	b.WriteString(")\n")
+	b.WriteString("Target: ")
+	b.WriteString(string(plan.Target))
+	b.WriteString("\n\n")
+	writeList := func(title string, values []string) {
+		b.WriteString("## ")
+		b.WriteString(title)
+		b.WriteString("\n\n")
+		if len(values) == 0 {
+			b.WriteString("- None\n\n")
+			return
+		}
+		for _, value := range values {
+			b.WriteString("- ")
+			b.WriteString(value)
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
+	writeList("Applied", uniqueSorted(plan.Notes.Applied))
+	actions := append([]string(nil), plan.Notes.Action...)
+	for _, loss := range plan.Notes.FatalLosses {
+		actions = append(actions, fmt.Sprintf("%s (accept with --accept-loss=%s)", loss.Reason, loss.Feature))
+	}
+	actions = append(actions, plan.Notes.SecretNotes...)
+	writeList("Action required", uniqueSorted(actions))
+	verify := make([]string, 0)
+	for _, key := range sortedMapKeys(plan.Environment) {
+		if strings.HasSuffix(key, "_API_KEY") || strings.HasSuffix(key, "_TOKEN") || strings.HasSuffix(key, "_ID") {
+			verify = append(verify, key+" is set in .env")
+		}
+	}
+	writeList("Verify before `claw up`", uniqueSorted(verify))
+	return b.String()
+}
+
+func serviceEnvironment(plan Plan) map[string]string {
+	out := make(map[string]string, len(plan.Environment))
+	for key, value := range plan.Environment {
+		if _, cllamaOnly := plan.CllamaEnv[key]; cllamaOnly {
+			continue
+		}
+		out[key] = value
+	}
+	return out
+}
+
+func sortedMapKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func writeGitignore(path string) error {
+	existing := ""
+	if data, err := os.ReadFile(path); err == nil {
+		existing = string(data)
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read .gitignore: %w", err)
+	}
+	lines := strings.Split(strings.ReplaceAll(existing, "\r\n", "\n"), "\n")
+	seen := make(map[string]struct{}, len(lines))
+	for _, line := range lines {
+		if strings.TrimSpace(line) != "" {
+			seen[strings.TrimSpace(line)] = struct{}{}
+		}
+	}
+	for _, entry := range []string{".env", "*.generated.*", "imported/"} {
+		if _, ok := seen[entry]; !ok {
+			lines = append(lines, entry)
+			seen[entry] = struct{}{}
+		}
+	}
+	output := strings.Join(lines, "\n")
+	output = strings.TrimLeft(output, "\n")
+	if !strings.HasSuffix(output, "\n") {
+		output += "\n"
+	}
+	if err := os.WriteFile(path, []byte(output), 0o644); err != nil {
+		return fmt.Errorf("write .gitignore: %w", err)
+	}
+	return nil
+}

--- a/internal/initimport/emit.go
+++ b/internal/initimport/emit.go
@@ -75,10 +75,8 @@ func renderClawfile(plan Plan) string {
 	b.WriteString("MODEL primary ")
 	b.WriteString(plan.Model.String())
 	b.WriteString("\n")
-	for i, fallback := range plan.Fallback {
-		b.WriteString("MODEL ")
-		b.WriteString(fallbackSlot(i))
-		b.WriteString(" ")
+	for _, fallback := range plan.Fallback {
+		b.WriteString("MODEL fallback ")
 		b.WriteString(fallback.String())
 		b.WriteString("\n")
 	}

--- a/internal/initimport/emit.go
+++ b/internal/initimport/emit.go
@@ -75,6 +75,13 @@ func renderClawfile(plan Plan) string {
 	b.WriteString("MODEL primary ")
 	b.WriteString(plan.Model.String())
 	b.WriteString("\n")
+	for i, fallback := range plan.Fallback {
+		b.WriteString("MODEL ")
+		b.WriteString(fallbackSlot(i))
+		b.WriteString(" ")
+		b.WriteString(fallback.String())
+		b.WriteString("\n")
+	}
 	if plan.Cllama {
 		b.WriteString("\nCLLAMA passthrough\n")
 	}
@@ -257,8 +264,8 @@ func renderMigration(plan Plan) string {
 	for _, loss := range plan.Notes.FatalLosses {
 		actions = append(actions, fmt.Sprintf("%s (accept with --accept-loss=%s)", loss.Reason, loss.Feature))
 	}
-	actions = append(actions, plan.Notes.SecretNotes...)
 	writeList("Action required", uniqueSorted(actions))
+	writeList("Secret placeholders", uniqueSorted(plan.Notes.SecretNotes))
 	verify := make([]string, 0)
 	for _, key := range sortedMapKeys(plan.Environment) {
 		if strings.HasSuffix(key, "_API_KEY") || strings.HasSuffix(key, "_TOKEN") || strings.HasSuffix(key, "_ID") {

--- a/internal/initimport/envscan.go
+++ b/internal/initimport/envscan.go
@@ -74,3 +74,28 @@ func providerEnvKey(provider string) string {
 		return ""
 	}
 }
+
+func bestEffortProviderEnvKey(provider string) string {
+	var b strings.Builder
+	lastUnderscore := false
+	for _, r := range strings.TrimSpace(provider) {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r - ('a' - 'A'))
+			lastUnderscore = false
+		case r >= 'A' && r <= 'Z' || r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastUnderscore = false
+		default:
+			if !lastUnderscore && b.Len() > 0 {
+				b.WriteRune('_')
+				lastUnderscore = true
+			}
+		}
+	}
+	name := strings.Trim(b.String(), "_")
+	if name == "" {
+		name = "CUSTOM_PROVIDER"
+	}
+	return name + "_API_KEY"
+}

--- a/internal/initimport/envscan.go
+++ b/internal/initimport/envscan.go
@@ -1,0 +1,76 @@
+package initimport
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var envRefPattern = regexp.MustCompile(`^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$`)
+
+type envBuilder struct {
+	values       map[string]string
+	exampleKeys  map[string]struct{}
+	secretNotes  []string
+	unknownIndex int
+}
+
+func newEnvBuilder() *envBuilder {
+	return &envBuilder{values: map[string]string{}, exampleKeys: map[string]struct{}{}}
+}
+
+func (b *envBuilder) addPlaceholder(key string) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return
+	}
+	b.values[key] = "${" + key + "}"
+	b.exampleKeys[key] = struct{}{}
+}
+
+func (b *envBuilder) addLiteral(key, value string) {
+	key = strings.TrimSpace(key)
+	value = strings.TrimSpace(value)
+	if key == "" || value == "" {
+		return
+	}
+	b.values[key] = value
+	b.exampleKeys[key] = struct{}{}
+}
+
+func (b *envBuilder) addSecret(preferredKey, raw, label string) string {
+	raw = strings.TrimSpace(raw)
+	preferredKey = strings.TrimSpace(preferredKey)
+	if raw == "" {
+		if preferredKey != "" {
+			b.addPlaceholder(preferredKey)
+			return preferredKey
+		}
+		return ""
+	}
+	if match := envRefPattern.FindStringSubmatch(raw); match != nil {
+		b.addPlaceholder(match[1])
+		return match[1]
+	}
+	key := preferredKey
+	if key == "" {
+		b.unknownIndex++
+		key = fmt.Sprintf("UNKNOWN_TOKEN_%d", b.unknownIndex)
+	}
+	b.addPlaceholder(key)
+	b.secretNotes = append(b.secretNotes, fmt.Sprintf("%s contained a literal secret; generated ${%s} placeholder", label, key))
+	return key
+}
+
+func providerEnvKey(provider string) string {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "openrouter":
+		return "OPENROUTER_API_KEY"
+	case "anthropic":
+		return "ANTHROPIC_API_KEY"
+	case "openai":
+		return "OPENAI_API_KEY"
+	default:
+		return ""
+	}
+}

--- a/internal/initimport/hermes.go
+++ b/internal/initimport/hermes.go
@@ -43,8 +43,10 @@ func readHermes(configPath string) (Descriptor, error) {
 			desc.AgentName = normalizeName(heading, "assistant")
 		}
 	}
-	if desc.Identity == "" {
-		if value := strings.TrimSpace(env["HERMES_DEFAULT_AGENT_IDENTITY"]); value != "" {
+	if value := strings.TrimSpace(env["HERMES_DEFAULT_AGENT_IDENTITY"]); value != "" {
+		if desc.Identity != "" {
+			desc.Identity = strings.TrimRight(desc.Identity, "\n") + "\n\n# Imported Hermes Default Identity\n\n" + value
+		} else {
 			desc.Identity = value
 		}
 	}
@@ -90,7 +92,7 @@ func readHermes(configPath string) (Descriptor, error) {
 	}
 	for key := range raw {
 		switch key {
-		case "model", "terminal", "platform_toolsets":
+		case "model", "terminal":
 		default:
 			desc.RawNotes = append(desc.RawNotes, fmt.Sprintf("unrecognized Hermes config key %q was not imported", key))
 		}

--- a/internal/initimport/hermes.go
+++ b/internal/initimport/hermes.go
@@ -1,0 +1,126 @@
+package initimport
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+func readHermes(configPath string) (Descriptor, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return Descriptor{}, fmt.Errorf("read Hermes config: %w", err)
+	}
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return Descriptor{}, fmt.Errorf("parse Hermes config.yaml: %w", err)
+	}
+
+	root := filepath.Dir(configPath)
+	env, err := readDotEnv(filepath.Join(root, ".env"))
+	if err != nil {
+		return Descriptor{}, fmt.Errorf("read source .env: %w", err)
+	}
+
+	desc := Descriptor{
+		Kind:      SourceHermes,
+		Config:    configPath,
+		Root:      root,
+		AgentName: "assistant",
+		EnvVars:   env,
+	}
+
+	if soulPath := filepath.Join(root, "SOUL.md"); fileExists(soulPath) {
+		soul, err := os.ReadFile(soulPath)
+		if err != nil {
+			return Descriptor{}, fmt.Errorf("read SOUL.md: %w", err)
+		}
+		desc.Identity = strings.TrimSpace(string(soul))
+		if heading := firstMarkdownHeading(desc.Identity); heading != "" {
+			desc.AgentName = normalizeName(heading, "assistant")
+		}
+	}
+	if desc.Identity == "" {
+		if value := strings.TrimSpace(env["HERMES_DEFAULT_AGENT_IDENTITY"]); value != "" {
+			desc.Identity = value
+		}
+	}
+
+	model, _ := raw["model"].(map[string]any)
+	provider, _ := model["provider"].(string)
+	defaultModel, _ := model["default"].(string)
+	baseURL, _ := model["base_url"].(string)
+	apiKey, _ := model["api_key"].(string)
+	desc.Models.Primary = hermesModelRef(provider, defaultModel, baseURL, apiKey)
+	if desc.Models.Primary.Provider == "" {
+		desc.Models.Primary = ModelRef{Provider: "openrouter", Model: "anthropic/claude-sonnet-4"}
+	}
+	if strings.TrimSpace(baseURL) != "" {
+		desc.Cllama = true
+	}
+
+	if env["DISCORD_BOT_TOKEN"] != "" || env["DISCORD_BOT_ID"] != "" || env["DISCORD_ALLOWED_USERS"] != "" {
+		desc.Channels.Discord = &DiscordChannel{
+			Token:          env["DISCORD_BOT_TOKEN"],
+			BotID:          env["DISCORD_BOT_ID"],
+			RequireMention: strings.EqualFold(env["DISCORD_REQUIRE_MENTION"], "true"),
+			AllowFrom:      stringSlice(env["DISCORD_ALLOWED_USERS"]),
+		}
+	}
+	if env["SLACK_BOT_TOKEN"] != "" || env["SLACK_APP_TOKEN"] != "" || env["SLACK_BOT_ID"] != "" || env["SLACK_ALLOWED_USERS"] != "" {
+		desc.Channels.Slack = &SlackChannel{
+			BotToken:     env["SLACK_BOT_TOKEN"],
+			AppToken:     env["SLACK_APP_TOKEN"],
+			BotID:        env["SLACK_BOT_ID"],
+			AllowedUsers: stringSlice(env["SLACK_ALLOWED_USERS"]),
+		}
+	}
+	if env["TELEGRAM_BOT_TOKEN"] != "" || env["TELEGRAM_BOT_ID"] != "" {
+		desc.Channels.Telegram = &TelegramChannel{Token: env["TELEGRAM_BOT_TOKEN"], BotID: env["TELEGRAM_BOT_ID"]}
+	}
+
+	if dir := filepath.Join(root, "skills"); dirExists(dir) {
+		desc.SkillsDir = dir
+	}
+	if dir := filepath.Join(root, "cron"); dirExists(dir) {
+		desc.CronDir = dir
+	}
+	for key := range raw {
+		switch key {
+		case "model", "terminal", "platform_toolsets":
+		default:
+			desc.RawNotes = append(desc.RawNotes, fmt.Sprintf("unrecognized Hermes config key %q was not imported", key))
+		}
+	}
+	return desc, nil
+}
+
+func hermesModelRef(provider, defaultModel, baseURL, apiKey string) ModelRef {
+	provider = strings.TrimSpace(provider)
+	defaultModel = strings.TrimSpace(defaultModel)
+	ref := ModelRef{Provider: provider, Model: defaultModel, BaseURL: strings.TrimSpace(baseURL), APIKey: strings.TrimSpace(apiKey)}
+	if provider == "custom" && strings.Contains(defaultModel, "/") {
+		if parsed, ok := SplitModelRef(defaultModel); ok {
+			ref.Provider = parsed.Provider
+			ref.Model = parsed.Model
+		}
+	}
+	if provider != "" && !strings.Contains(defaultModel, "/") {
+		ref.Model = defaultModel
+	}
+	if provider == "" && strings.Contains(defaultModel, "/") {
+		if parsed, ok := SplitModelRef(defaultModel); ok {
+			ref.Provider = parsed.Provider
+			ref.Model = parsed.Model
+		}
+	}
+	return ref
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/internal/initimport/initimport_test.go
+++ b/internal/initimport/initimport_test.go
@@ -24,9 +24,9 @@ func TestDetectAmbiguousSourceRequiresOverride(t *testing.T) {
 	}
 }
 
-func TestTranslateSlackRoutingFatalUnlessAccepted(t *testing.T) {
+func TestTranslateOpenClawSlackRoutingWritesActionNote(t *testing.T) {
 	src := Descriptor{
-		Kind:      SourceHermes,
+		Kind:      SourceOpenClaw,
 		AgentName: "assistant",
 		Models:    ModelSlots{Primary: ModelRef{Provider: "openrouter", Model: "anthropic/claude-sonnet-4"}},
 		Channels: Channels{Slack: &SlackChannel{
@@ -36,21 +36,19 @@ func TestTranslateSlackRoutingFatalUnlessAccepted(t *testing.T) {
 			AllowedUsers: []string{"U111"},
 		}},
 	}
-	plan, err := Translate(src, TargetOpenClaw, Options{ProjectName: "demo"})
+	plan, err := Translate(src, Options{ProjectName: "demo"})
 	if err != nil {
 		t.Fatalf("unexpected translate error: %v", err)
 	}
-	if !plan.Notes.HasFatal() {
-		t.Fatal("expected Slack routing fatal loss")
-	}
-	if !AcceptLossAllows([]string{"slack-routing"}, plan.Notes.FatalFeatures()) {
-		t.Fatal("expected slack-routing accept token to satisfy fatal loss")
+	migration := renderMigration(plan)
+	if !strings.Contains(migration, "Slack allowed-user routing has no channel://slack surface") {
+		t.Fatalf("expected Slack routing action note, got:\n%s", migration)
 	}
 }
 
 func TestTranslateProxyModelEmitsCllama(t *testing.T) {
 	src := Descriptor{
-		Kind:      SourceHermes,
+		Kind:      SourceOpenClaw,
 		AgentName: "assistant",
 		Models: ModelSlots{Primary: ModelRef{
 			Provider: "openrouter",
@@ -58,7 +56,7 @@ func TestTranslateProxyModelEmitsCllama(t *testing.T) {
 			BaseURL:  "http://cllama:8080/v1",
 		}},
 	}
-	plan, err := Translate(src, TargetHermes, Options{ProjectName: "demo"})
+	plan, err := Translate(src, Options{ProjectName: "demo"})
 	if err != nil {
 		t.Fatalf("unexpected translate error: %v", err)
 	}
@@ -69,7 +67,7 @@ func TestTranslateProxyModelEmitsCllama(t *testing.T) {
 
 func TestTranslateRejectsCllamaNoWithProxySource(t *testing.T) {
 	src := Descriptor{
-		Kind: SourceHermes,
+		Kind: SourceOpenClaw,
 		Models: ModelSlots{Primary: ModelRef{
 			Provider: "openrouter",
 			Model:    "anthropic/claude-sonnet-4",
@@ -77,7 +75,7 @@ func TestTranslateRejectsCllamaNoWithProxySource(t *testing.T) {
 		}},
 	}
 
-	_, err := Translate(src, TargetHermes, Options{ProjectName: "demo", CllamaOverride: "0"})
+	_, err := Translate(src, Options{ProjectName: "demo", CllamaOverride: "0"})
 	if err == nil {
 		t.Fatal("expected --cllama=no/0 to fail with proxy source")
 	}
@@ -86,44 +84,39 @@ func TestTranslateRejectsCllamaNoWithProxySource(t *testing.T) {
 	}
 }
 
-func TestTranslateCronIsMigrationActionNotFatal(t *testing.T) {
+func TestTranslateCronIsMigrationAction(t *testing.T) {
 	src := Descriptor{
 		Kind:    SourceHermes,
 		CronDir: "/tmp/source-cron",
 		Models:  ModelSlots{Primary: ModelRef{Provider: "openrouter", Model: "anthropic/claude-sonnet-4"}},
+		Channels: Channels{Discord: &DiscordChannel{
+			Token: "${DISCORD_BOT_TOKEN}",
+			BotID: "${DISCORD_BOT_ID}",
+		}},
 	}
 
-	plan, err := Translate(src, TargetHermes, Options{ProjectName: "demo"})
+	plan, err := Translate(src, Options{ProjectName: "demo"})
 	if err != nil {
 		t.Fatalf("unexpected translate error: %v", err)
 	}
-	if plan.Notes.HasFatal() {
-		t.Fatalf("cron should not be fatal, got %#v", plan.Notes.FatalLosses)
-	}
 	migration := renderMigration(plan)
-	if strings.Contains(migration, "--accept-loss=cron") {
-		t.Fatalf("cron migration note should not require accept-loss, got:\n%s", migration)
-	}
 	if !strings.Contains(migration, "cron files copied to imported/cron/") {
 		t.Fatalf("expected cron action note, got:\n%s", migration)
 	}
 }
 
-func TestTranslateCustomProviderAddsBestEffortPlaceholder(t *testing.T) {
+func TestTranslateCustomProviderRequiresModelOverride(t *testing.T) {
 	src := Descriptor{
 		Kind:   SourceHermes,
 		Models: ModelSlots{Primary: ModelRef{Provider: "mistral-ai", Model: "large"}},
 	}
 
-	plan, err := Translate(src, TargetHermes, Options{ProjectName: "demo"})
-	if err != nil {
-		t.Fatalf("unexpected translate error: %v", err)
+	_, err := Translate(src, Options{ProjectName: "demo"})
+	if err == nil {
+		t.Fatal("expected custom provider to fail")
 	}
-	if !plan.Notes.HasFatal() || !AcceptLossAllows([]string{"custom-provider"}, plan.Notes.FatalFeatures()) {
-		t.Fatalf("expected custom-provider fatal loss, got %#v", plan.Notes.FatalLosses)
-	}
-	if got := plan.Environment["MISTRAL_AI_API_KEY"]; got != "${MISTRAL_AI_API_KEY}" {
-		t.Fatalf("expected best-effort provider placeholder, got %q", got)
+	if !strings.Contains(err.Error(), "pass --model") {
+		t.Fatalf("expected --model recovery hint, got: %v", err)
 	}
 }
 
@@ -139,7 +132,7 @@ func TestTranslateFallbackModelsEmitClawfileLines(t *testing.T) {
 		},
 	}
 
-	plan, err := Translate(src, TargetOpenClaw, Options{ProjectName: "demo"})
+	plan, err := Translate(src, Options{ProjectName: "demo"})
 	if err != nil {
 		t.Fatalf("unexpected translate error: %v", err)
 	}
@@ -159,6 +152,29 @@ func TestTranslateFallbackModelsEmitClawfileLines(t *testing.T) {
 	migration := renderMigration(plan)
 	if !strings.Contains(migration, "additional source fallback models") || !strings.Contains(migration, "openai/gpt-4.1-mini") {
 		t.Fatalf("expected additional fallback migration note, got:\n%s", migration)
+	}
+}
+
+func TestTranslateUnsupportedFallbackProviderIsNotEmitted(t *testing.T) {
+	src := Descriptor{
+		Kind: SourceOpenClaw,
+		Models: ModelSlots{
+			Primary:  ModelRef{Provider: "openrouter", Model: "anthropic/claude-sonnet-4"},
+			Fallback: []ModelRef{{Provider: "mistral-ai", Model: "large"}},
+		},
+	}
+
+	plan, err := Translate(src, Options{ProjectName: "demo"})
+	if err != nil {
+		t.Fatalf("unexpected translate error: %v", err)
+	}
+	clawfile := renderClawfile(plan)
+	if strings.Contains(clawfile, "MODEL fallback mistral-ai/large") {
+		t.Fatalf("unsupported fallback should not be emitted, got:\n%s", clawfile)
+	}
+	migration := renderMigration(plan)
+	if !strings.Contains(migration, `fallback provider "mistral-ai" is not supported`) {
+		t.Fatalf("expected unsupported fallback migration note, got:\n%s", migration)
 	}
 }
 

--- a/internal/initimport/initimport_test.go
+++ b/internal/initimport/initimport_test.go
@@ -67,6 +67,150 @@ func TestTranslateProxyModelEmitsCllama(t *testing.T) {
 	}
 }
 
+func TestTranslateRejectsCllamaNoWithProxySource(t *testing.T) {
+	src := Descriptor{
+		Kind: SourceHermes,
+		Models: ModelSlots{Primary: ModelRef{
+			Provider: "openrouter",
+			Model:    "anthropic/claude-sonnet-4",
+			BaseURL:  "http://proxy.example/v1",
+		}},
+	}
+
+	_, err := Translate(src, TargetHermes, Options{ProjectName: "demo", CllamaOverride: "0"})
+	if err == nil {
+		t.Fatal("expected --cllama=no/0 to fail with proxy source")
+	}
+	if !strings.Contains(err.Error(), "--cllama=no") {
+		t.Fatalf("expected clear cllama error, got: %v", err)
+	}
+}
+
+func TestTranslateCronIsMigrationActionNotFatal(t *testing.T) {
+	src := Descriptor{
+		Kind:    SourceHermes,
+		CronDir: "/tmp/source-cron",
+		Models:  ModelSlots{Primary: ModelRef{Provider: "openrouter", Model: "anthropic/claude-sonnet-4"}},
+	}
+
+	plan, err := Translate(src, TargetHermes, Options{ProjectName: "demo"})
+	if err != nil {
+		t.Fatalf("unexpected translate error: %v", err)
+	}
+	if plan.Notes.HasFatal() {
+		t.Fatalf("cron should not be fatal, got %#v", plan.Notes.FatalLosses)
+	}
+	migration := renderMigration(plan)
+	if strings.Contains(migration, "--accept-loss=cron") {
+		t.Fatalf("cron migration note should not require accept-loss, got:\n%s", migration)
+	}
+	if !strings.Contains(migration, "cron files copied to imported/cron/") {
+		t.Fatalf("expected cron action note, got:\n%s", migration)
+	}
+}
+
+func TestTranslateCustomProviderAddsBestEffortPlaceholder(t *testing.T) {
+	src := Descriptor{
+		Kind:   SourceHermes,
+		Models: ModelSlots{Primary: ModelRef{Provider: "mistral-ai", Model: "large"}},
+	}
+
+	plan, err := Translate(src, TargetHermes, Options{ProjectName: "demo"})
+	if err != nil {
+		t.Fatalf("unexpected translate error: %v", err)
+	}
+	if !plan.Notes.HasFatal() || !AcceptLossAllows([]string{"custom-provider"}, plan.Notes.FatalFeatures()) {
+		t.Fatalf("expected custom-provider fatal loss, got %#v", plan.Notes.FatalLosses)
+	}
+	if got := plan.Environment["MISTRAL_AI_API_KEY"]; got != "${MISTRAL_AI_API_KEY}" {
+		t.Fatalf("expected best-effort provider placeholder, got %q", got)
+	}
+}
+
+func TestTranslateFallbackModelsEmitClawfileLines(t *testing.T) {
+	src := Descriptor{
+		Kind: SourceOpenClaw,
+		Models: ModelSlots{
+			Primary: ModelRef{Provider: "openrouter", Model: "anthropic/claude-sonnet-4"},
+			Fallback: []ModelRef{
+				{Provider: "anthropic", Model: "claude-haiku-3-5"},
+				{Provider: "openai", Model: "gpt-4.1-mini"},
+			},
+		},
+	}
+
+	plan, err := Translate(src, TargetOpenClaw, Options{ProjectName: "demo"})
+	if err != nil {
+		t.Fatalf("unexpected translate error: %v", err)
+	}
+	clawfile := renderClawfile(plan)
+	if !strings.Contains(clawfile, "MODEL fallback anthropic/claude-haiku-3-5") {
+		t.Fatalf("expected fallback model in Clawfile, got:\n%s", clawfile)
+	}
+	if !strings.Contains(clawfile, "MODEL fallback_2 openai/gpt-4.1-mini") {
+		t.Fatalf("expected second fallback model in Clawfile, got:\n%s", clawfile)
+	}
+	if got := plan.Environment["ANTHROPIC_API_KEY"]; got != "${ANTHROPIC_API_KEY}" {
+		t.Fatalf("expected fallback provider key placeholder, got %q", got)
+	}
+	if got := plan.Environment["OPENAI_API_KEY"]; got != "${OPENAI_API_KEY}" {
+		t.Fatalf("expected second fallback provider key placeholder, got %q", got)
+	}
+}
+
+func TestReadOpenClawDiscordRequireMentionAndSortedGuilds(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "openclaw.json"), `{
+		"channels": {
+			"discord": {
+				"enabled": true,
+				"requireMention": true,
+				"guilds": {
+					"z-guild": {"users": ["9"]},
+					"a-guild": {"requireMention": true, "users": ["1"]}
+				}
+			}
+		}
+	}`)
+
+	desc, err := readOpenClaw(filepath.Join(dir, "openclaw.json"))
+	if err != nil {
+		t.Fatalf("read openclaw: %v", err)
+	}
+	discord := desc.Channels.Discord
+	if discord == nil || !discord.RequireMention {
+		t.Fatalf("expected root requireMention to be read, got %#v", discord)
+	}
+	if len(discord.Guilds) != 2 || discord.Guilds[0].ID != "a-guild" || discord.Guilds[1].ID != "z-guild" {
+		t.Fatalf("expected sorted guilds, got %#v", discord.Guilds)
+	}
+}
+
+func TestReadHermesFoldsEnvIdentityWithSoulAndNotesToolsets(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "config.yaml"), `model:
+  provider: openrouter
+  default: anthropic/claude-sonnet-4
+platform_toolsets:
+  slack: true
+`)
+	mustWrite(t, filepath.Join(dir, "SOUL.md"), "# Soul Identity\n\nSoul body.\n")
+	mustWrite(t, filepath.Join(dir, ".env"), "HERMES_DEFAULT_AGENT_IDENTITY=Env identity.\n")
+
+	desc, err := readHermes(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		t.Fatalf("read hermes: %v", err)
+	}
+	for _, expected := range []string{"Soul body.", "Imported Hermes Default Identity", "Env identity."} {
+		if !strings.Contains(desc.Identity, expected) {
+			t.Fatalf("expected identity to contain %q, got:\n%s", expected, desc.Identity)
+		}
+	}
+	if len(desc.RawNotes) == 0 || !strings.Contains(desc.RawNotes[0], "platform_toolsets") {
+		t.Fatalf("expected platform_toolsets RawNotes entry, got %#v", desc.RawNotes)
+	}
+}
+
 func TestEmitCanonicalLayoutAndCronReferences(t *testing.T) {
 	srcDir := t.TempDir()
 	cronDir := filepath.Join(srcDir, "cron")

--- a/internal/initimport/initimport_test.go
+++ b/internal/initimport/initimport_test.go
@@ -1,0 +1,128 @@
+package initimport
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDetectAmbiguousSourceRequiresOverride(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "openclaw.json"), `{"channels":{}}`)
+	mustWrite(t, filepath.Join(dir, "config.yaml"), "model:\n  provider: openrouter\n  default: anthropic/claude-sonnet-4\n")
+
+	if _, err := Detect(dir, ""); err == nil {
+		t.Fatal("expected ambiguous source to fail")
+	}
+	desc, err := Detect(dir, SourceHermes)
+	if err != nil {
+		t.Fatalf("override should select Hermes: %v", err)
+	}
+	if desc.Kind != SourceHermes {
+		t.Fatalf("expected Hermes descriptor, got %q", desc.Kind)
+	}
+}
+
+func TestTranslateSlackRoutingFatalUnlessAccepted(t *testing.T) {
+	src := Descriptor{
+		Kind:      SourceHermes,
+		AgentName: "assistant",
+		Models:    ModelSlots{Primary: ModelRef{Provider: "openrouter", Model: "anthropic/claude-sonnet-4"}},
+		Channels: Channels{Slack: &SlackChannel{
+			BotToken:     "${SLACK_BOT_TOKEN}",
+			AppToken:     "${SLACK_APP_TOKEN}",
+			BotID:        "${SLACK_BOT_ID}",
+			AllowedUsers: []string{"U111"},
+		}},
+	}
+	plan, err := Translate(src, TargetOpenClaw, Options{ProjectName: "demo"})
+	if err != nil {
+		t.Fatalf("unexpected translate error: %v", err)
+	}
+	if !plan.Notes.HasFatal() {
+		t.Fatal("expected Slack routing fatal loss")
+	}
+	if !AcceptLossAllows([]string{"slack-routing"}, plan.Notes.FatalFeatures()) {
+		t.Fatal("expected slack-routing accept token to satisfy fatal loss")
+	}
+}
+
+func TestTranslateProxyModelEmitsCllama(t *testing.T) {
+	src := Descriptor{
+		Kind:      SourceHermes,
+		AgentName: "assistant",
+		Models: ModelSlots{Primary: ModelRef{
+			Provider: "openrouter",
+			Model:    "anthropic/claude-sonnet-4",
+			BaseURL:  "http://cllama:8080/v1",
+		}},
+	}
+	plan, err := Translate(src, TargetHermes, Options{ProjectName: "demo"})
+	if err != nil {
+		t.Fatalf("unexpected translate error: %v", err)
+	}
+	if !plan.Cllama {
+		t.Fatal("expected proxy source model to emit cllama")
+	}
+}
+
+func TestEmitCanonicalLayoutAndCronReferences(t *testing.T) {
+	srcDir := t.TempDir()
+	cronDir := filepath.Join(srcDir, "cron")
+	if err := os.MkdirAll(cronDir, 0o755); err != nil {
+		t.Fatalf("create cron dir: %v", err)
+	}
+	mustWrite(t, filepath.Join(cronDir, "daily.yaml"), "schedule: '* * * * *'\n")
+	plan := Plan{
+		Source:        Descriptor{Kind: SourceHermes, Config: filepath.Join(srcDir, "config.yaml")},
+		Target:        TargetHermes,
+		ProjectName:   "demo",
+		AgentName:     "assistant",
+		BaseImage:     "hermes-base:test",
+		Model:         ModelRef{Provider: "openrouter", Model: "anthropic/claude-sonnet-4"},
+		Handles:       []HandlePlan{{Platform: "slack", IDEnv: "SLACK_BOT_ID", Username: "assistant"}},
+		Environment:   map[string]string{"SLACK_BOT_TOKEN": "${SLACK_BOT_TOKEN}", "SLACK_APP_TOKEN": "${SLACK_APP_TOKEN}", "SLACK_BOT_ID": "${SLACK_BOT_ID}"},
+		AgentContract: "# Agent Contract\n",
+		CronDir:       cronDir,
+	}
+	dest := t.TempDir()
+	if err := Emit(plan, dest); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	for _, path := range []string{
+		"agents/assistant/Clawfile",
+		"agents/assistant/AGENTS.md",
+		"claw-pod.yml",
+		"MIGRATION.md",
+		"imported/cron/daily.yaml",
+	} {
+		if _, err := os.Stat(filepath.Join(dest, path)); err != nil {
+			t.Fatalf("expected %s: %v", path, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dest, "Clawfile")); !os.IsNotExist(err) {
+		t.Fatalf("expected no legacy root Clawfile, got %v", err)
+	}
+}
+
+func TestEnvBuilderRedactsLiteralSecret(t *testing.T) {
+	env := newEnvBuilder()
+	key := env.addSecret("SLACK_BOT_TOKEN", "xoxb-secret", "slack")
+	if key != "SLACK_BOT_TOKEN" {
+		t.Fatalf("unexpected key %q", key)
+	}
+	if got := env.values["SLACK_BOT_TOKEN"]; got != "${SLACK_BOT_TOKEN}" {
+		t.Fatalf("expected placeholder, got %q", got)
+	}
+	if len(env.secretNotes) == 0 || !strings.Contains(env.secretNotes[0], "literal secret") {
+		t.Fatalf("expected literal secret note, got %#v", env.secretNotes)
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/initimport/initimport_test.go
+++ b/internal/initimport/initimport_test.go
@@ -147,14 +147,18 @@ func TestTranslateFallbackModelsEmitClawfileLines(t *testing.T) {
 	if !strings.Contains(clawfile, "MODEL fallback anthropic/claude-haiku-3-5") {
 		t.Fatalf("expected fallback model in Clawfile, got:\n%s", clawfile)
 	}
-	if !strings.Contains(clawfile, "MODEL fallback_2 openai/gpt-4.1-mini") {
-		t.Fatalf("expected second fallback model in Clawfile, got:\n%s", clawfile)
+	if strings.Contains(clawfile, "fallback_2") {
+		t.Fatalf("expected additional fallbacks to stay out of Clawfile, got:\n%s", clawfile)
 	}
 	if got := plan.Environment["ANTHROPIC_API_KEY"]; got != "${ANTHROPIC_API_KEY}" {
 		t.Fatalf("expected fallback provider key placeholder, got %q", got)
 	}
-	if got := plan.Environment["OPENAI_API_KEY"]; got != "${OPENAI_API_KEY}" {
-		t.Fatalf("expected second fallback provider key placeholder, got %q", got)
+	if _, ok := plan.Environment["OPENAI_API_KEY"]; ok {
+		t.Fatal("did not expect placeholder for additional fallback that current runtimes ignore")
+	}
+	migration := renderMigration(plan)
+	if !strings.Contains(migration, "additional source fallback models") || !strings.Contains(migration, "openai/gpt-4.1-mini") {
+		t.Fatalf("expected additional fallback migration note, got:\n%s", migration)
 	}
 }
 

--- a/internal/initimport/openclaw.go
+++ b/internal/initimport/openclaw.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -105,6 +106,9 @@ func readOpenClawDiscord(channels map[string]any) *DiscordChannel {
 	if dmPolicy, ok := raw["dmPolicy"].(string); ok {
 		d.DMPolicy = strings.TrimSpace(dmPolicy)
 	}
+	if require, ok := raw["requireMention"].(bool); ok {
+		d.RequireMention = require
+	}
 	d.AllowFrom = stringSlice(raw["allowFrom"])
 	if guilds, ok := raw["guilds"].(map[string]any); ok {
 		for id, guildRaw := range guilds {
@@ -121,6 +125,9 @@ func readOpenClawDiscord(channels map[string]any) *DiscordChannel {
 			}
 			d.Guilds = append(d.Guilds, g)
 		}
+		sort.Slice(d.Guilds, func(i, j int) bool {
+			return d.Guilds[i].ID < d.Guilds[j].ID
+		})
 	}
 	return d
 }

--- a/internal/initimport/openclaw.go
+++ b/internal/initimport/openclaw.go
@@ -1,0 +1,178 @@
+package initimport
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func readOpenClaw(configPath string) (Descriptor, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return Descriptor{}, fmt.Errorf("read openclaw config: %w", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return Descriptor{}, fmt.Errorf("parse openclaw.json: %w", err)
+	}
+
+	root := filepath.Dir(configPath)
+	if filepath.Base(root) == "config" {
+		root = filepath.Dir(root)
+	}
+	env, err := readDotEnv(filepath.Join(root, ".env"))
+	if err != nil {
+		return Descriptor{}, fmt.Errorf("read source .env: %w", err)
+	}
+
+	desc := Descriptor{
+		Kind:      SourceOpenClaw,
+		Config:    configPath,
+		Root:      root,
+		AgentName: "assistant",
+		EnvVars:   env,
+	}
+
+	if agents, ok := raw["agents"].(map[string]any); ok {
+		if list, ok := agents["list"].([]any); ok && len(list) > 0 {
+			if first, ok := list[0].(map[string]any); ok {
+				if id, ok := first["id"].(string); ok && strings.TrimSpace(id) != "" {
+					desc.AgentName = normalizeName(id, "assistant")
+				} else if name, ok := first["name"].(string); ok && strings.TrimSpace(name) != "" {
+					desc.AgentName = normalizeName(name, "assistant")
+				}
+				if name, ok := first["name"].(string); ok && strings.TrimSpace(name) != "" {
+					desc.Identity = strings.TrimSpace(name)
+				}
+			}
+		}
+	}
+
+	if primary, ok := nestedString(raw, "agents", "defaults", "model", "primary"); ok {
+		if model, split := SplitModelRef(primary); split {
+			desc.Models.Primary = model
+		} else {
+			desc.Models.Primary = ModelRef{Provider: primary}
+		}
+	}
+	if fallbacks := stringSlice(nestedValue(raw, "agents", "defaults", "model", "fallbacks")); len(fallbacks) > 0 {
+		for _, fallback := range fallbacks {
+			if model, ok := SplitModelRef(fallback); ok {
+				desc.Models.Fallback = append(desc.Models.Fallback, model)
+			}
+		}
+	}
+	if desc.Models.Primary.Provider == "" {
+		desc.Models.Primary = ModelRef{Provider: "openrouter", Model: "anthropic/claude-sonnet-4"}
+	}
+	if providers, ok := nestedMap(raw, "models", "providers"); ok {
+		if providerCfg, ok := providers[desc.Models.Primary.Provider].(map[string]any); ok {
+			if baseURL, ok := providerCfg["baseUrl"].(string); ok && strings.TrimSpace(baseURL) != "" {
+				desc.Models.Primary.BaseURL = strings.TrimSpace(baseURL)
+				desc.Cllama = true
+			}
+			if apiKey, ok := providerCfg["apiKey"].(string); ok {
+				desc.Models.Primary.APIKey = strings.TrimSpace(apiKey)
+			}
+		}
+	}
+
+	channels, _ := raw["channels"].(map[string]any)
+	desc.Channels.Discord = readOpenClawDiscord(channels)
+	desc.Channels.Slack = readOpenClawSlack(channels)
+	desc.Channels.Telegram = readOpenClawTelegram(channels)
+
+	if dir := filepath.Join(root, "skills"); dirExists(dir) {
+		desc.SkillsDir = dir
+	}
+	return desc, nil
+}
+
+func readOpenClawDiscord(channels map[string]any) *DiscordChannel {
+	raw, ok := channels["discord"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	if enabled, ok := raw["enabled"].(bool); ok && !enabled {
+		return nil
+	}
+	d := &DiscordChannel{}
+	if token, ok := raw["token"].(string); ok {
+		d.Token = strings.TrimSpace(token)
+	}
+	if dmPolicy, ok := raw["dmPolicy"].(string); ok {
+		d.DMPolicy = strings.TrimSpace(dmPolicy)
+	}
+	d.AllowFrom = stringSlice(raw["allowFrom"])
+	if guilds, ok := raw["guilds"].(map[string]any); ok {
+		for id, guildRaw := range guilds {
+			guildMap, ok := guildRaw.(map[string]any)
+			if !ok {
+				continue
+			}
+			g := DiscordGuild{ID: id, Users: stringSlice(guildMap["users"])}
+			if require, ok := guildMap["requireMention"].(bool); ok {
+				g.RequireMention = require
+				if require {
+					d.RequireMention = true
+				}
+			}
+			d.Guilds = append(d.Guilds, g)
+		}
+	}
+	return d
+}
+
+func readOpenClawSlack(channels map[string]any) *SlackChannel {
+	raw, ok := channels["slack"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	if enabled, ok := raw["enabled"].(bool); ok && !enabled {
+		return nil
+	}
+	s := &SlackChannel{}
+	if token, ok := raw["token"].(string); ok {
+		s.BotToken = strings.TrimSpace(token)
+	}
+	s.AllowedUsers = append(s.AllowedUsers, stringSlice(raw["allowFrom"])...)
+	s.AllowedUsers = append(s.AllowedUsers, stringSlice(raw["allowedUsers"])...)
+	return s
+}
+
+func readOpenClawTelegram(channels map[string]any) *TelegramChannel {
+	raw, ok := channels["telegram"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	if enabled, ok := raw["enabled"].(bool); ok && !enabled {
+		return nil
+	}
+	t := &TelegramChannel{}
+	if token, ok := raw["token"].(string); ok {
+		t.Token = strings.TrimSpace(token)
+	}
+	return t
+}
+
+func nestedValue(m map[string]any, keys ...string) any {
+	if len(keys) == 0 {
+		return nil
+	}
+	current := m
+	for _, key := range keys[:len(keys)-1] {
+		next, ok := current[key].(map[string]any)
+		if !ok {
+			return nil
+		}
+		current = next
+	}
+	return current[keys[len(keys)-1]]
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}

--- a/internal/initimport/translate.go
+++ b/internal/initimport/translate.go
@@ -7,10 +7,14 @@ import (
 	"github.com/mostlydev/clawdapus/internal/driver/hermes"
 )
 
-func Translate(src Descriptor, target TargetRuntime, opts Options) (Plan, error) {
+func Translate(src Descriptor, opts Options) (Plan, error) {
 	model := src.Models.Primary
 	fallbacks := append([]ModelRef(nil), src.Models.Fallback...)
 	notes := Notes{}
+	target, err := targetForSource(src.Kind)
+	if err != nil {
+		return Plan{}, err
+	}
 	if override := strings.TrimSpace(opts.ModelOverride); override != "" {
 		parsed, ok := SplitModelRef(override)
 		if !ok {
@@ -74,6 +78,9 @@ func Translate(src Descriptor, target TargetRuntime, opts Options) (Plan, error)
 		return Plan{}, err
 	}
 	translateChannels(&plan, &notes, env)
+	if plan.Target == TargetHermes && len(plan.Handles) == 0 {
+		return Plan{}, fmt.Errorf("Hermes import requires at least one supported handle in the source .env (DISCORD_BOT_TOKEN, SLACK_BOT_TOKEN/SLACK_APP_TOKEN, or TELEGRAM_BOT_TOKEN)")
+	}
 	if src.CronDir != "" {
 		notes.Action = append(notes.Action, "cron files copied to imported/cron/ as references; translate them to INVOKE directives")
 	}
@@ -108,13 +115,7 @@ func translateModel(plan *Plan, notes *Notes, env *envBuilder) error {
 	}
 	providerKey := providerEnvKey(model.Provider)
 	if providerKey == "" && model.BaseURL == "" {
-		providerKey = bestEffortProviderEnvKey(model.Provider)
-		env.addSecret(providerKey, model.APIKey, "model API key")
-		notes.Action = append(notes.Action, fmt.Sprintf("custom provider %q is not natively supported; generated best-effort %s placeholder", model.Provider, providerKey))
-		notes.FatalLosses = append(notes.FatalLosses, FatalLoss{
-			Feature: "custom-provider",
-			Reason:  fmt.Sprintf("provider %q is not natively supported; pass --model <provider/model> or --accept-loss=custom-provider", model.Provider),
-		})
+		return fmt.Errorf("source model provider %q is not supported for same-runtime import; pass --model <provider/model> to choose openrouter, anthropic, or openai", model.Provider)
 	} else if providerKey != "" {
 		apiKey := model.APIKey
 		if model.BaseURL != "" {
@@ -123,16 +124,18 @@ func translateModel(plan *Plan, notes *Notes, env *envBuilder) error {
 		env.addSecret(providerKey, apiKey, "model API key")
 	}
 	notes.Applied = append(notes.Applied, fmt.Sprintf("MODEL primary %s", model.String()))
+	keptFallbacks := plan.Fallback[:0]
 	for _, fallback := range plan.Fallback {
 		if key := providerEnvKey(fallback.Provider); key != "" && fallback.BaseURL == "" {
 			env.addSecret(key, fallback.APIKey, "fallback model API key")
 		} else if fallback.Provider != "" && fallback.BaseURL == "" {
-			key := bestEffortProviderEnvKey(fallback.Provider)
-			env.addSecret(key, fallback.APIKey, "fallback model API key")
-			notes.Action = append(notes.Action, fmt.Sprintf("fallback provider %q is not natively supported; generated best-effort %s placeholder", fallback.Provider, key))
+			notes.Action = append(notes.Action, fmt.Sprintf("fallback provider %q is not supported for same-runtime import; the fallback was not emitted", fallback.Provider))
+			continue
 		}
 		notes.Applied = append(notes.Applied, fmt.Sprintf("MODEL fallback %s", fallback.String()))
+		keptFallbacks = append(keptFallbacks, fallback)
 	}
+	plan.Fallback = keptFallbacks
 	if plan.Cllama {
 		notes.Applied = append(notes.Applied, "CLLAMA passthrough")
 	}
@@ -165,7 +168,7 @@ func translateChannels(plan *Plan, notes *Notes, env *envBuilder) {
 				env.addLiteral("DISCORD_REQUIRE_MENTION", "true")
 			}
 			if d.DMPolicy != "" && d.DMPolicy != "pairing" {
-				notes.FatalLosses = append(notes.FatalLosses, FatalLoss{Feature: "discord-routing", Reason: "Discord dmPolicy has no Hermes equivalent; pass --accept-loss=discord-routing to drop it"})
+				notes.Action = append(notes.Action, fmt.Sprintf("Discord dmPolicy %q has no Hermes equivalent and was not preserved", d.DMPolicy))
 			}
 		}
 	}
@@ -183,7 +186,7 @@ func translateChannels(plan *Plan, notes *Notes, env *envBuilder) {
 				env.addLiteral("SLACK_ALLOWED_USERS", strings.Join(s.AllowedUsers, ","))
 				notes.Applied = append(notes.Applied, "SLACK_ALLOWED_USERS preserved")
 			} else {
-				notes.FatalLosses = append(notes.FatalLosses, FatalLoss{Feature: "slack-routing", Reason: "Slack routing has no channel://slack surface in v1; pass --accept-loss=slack-routing to drop it"})
+				notes.Action = append(notes.Action, "Slack allowed-user routing has no channel://slack surface in v1 and was not preserved")
 			}
 		}
 	}
@@ -202,6 +205,17 @@ func baseImageForTarget(target TargetRuntime) string {
 		return hermes.BaseImageTag
 	default:
 		return "openclaw:latest"
+	}
+}
+
+func targetForSource(source SourceKind) (TargetRuntime, error) {
+	switch source {
+	case SourceOpenClaw:
+		return TargetOpenClaw, nil
+	case SourceHermes:
+		return TargetHermes, nil
+	default:
+		return "", fmt.Errorf("unsupported import source %q", source)
 	}
 }
 

--- a/internal/initimport/translate.go
+++ b/internal/initimport/translate.go
@@ -1,0 +1,221 @@
+package initimport
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mostlydev/clawdapus/internal/driver/hermes"
+)
+
+func Translate(src Descriptor, target TargetRuntime, opts Options) (Plan, error) {
+	model := src.Models.Primary
+	if override := strings.TrimSpace(opts.ModelOverride); override != "" {
+		parsed, ok := SplitModelRef(override)
+		if !ok {
+			return Plan{}, fmt.Errorf("--model %q is invalid (expected provider/model)", override)
+		}
+		model = parsed
+	}
+	if model.Provider == "" {
+		model = ModelRef{Provider: "openrouter", Model: "anthropic/claude-sonnet-4"}
+	}
+
+	env := newEnvBuilder()
+	notes := Notes{}
+	for _, note := range src.RawNotes {
+		notes.Action = append(notes.Action, note)
+	}
+
+	projectName := normalizeName(opts.ProjectName, "clawdapus-import")
+	agentName := normalizeName(opts.AgentName, normalizeName(src.AgentName, "assistant"))
+	if strings.TrimSpace(opts.AgentName) == "" && strings.TrimSpace(src.AgentName) != "" {
+		agentName = normalizeName(src.AgentName, "assistant")
+	}
+
+	cllama := src.Cllama || model.BaseURL != "" || isCllamaForced(opts.CllamaOverride)
+	if strings.EqualFold(strings.TrimSpace(opts.CllamaOverride), "no") || strings.EqualFold(strings.TrimSpace(opts.CllamaOverride), "false") {
+		cllama = model.BaseURL != ""
+	}
+
+	plan := Plan{
+		Source:        src,
+		Target:        target,
+		ProjectName:   projectName,
+		AgentName:     agentName,
+		BaseImage:     baseImageForTarget(target),
+		Model:         model,
+		Cllama:        cllama,
+		Environment:   map[string]string{},
+		CllamaEnv:     map[string]string{},
+		AgentContract: defaultImportedContract(src, target),
+		SoulContent:   sourceSoul(src),
+		SkillsDir:     src.SkillsDir,
+		CronDir:       src.CronDir,
+	}
+
+	if err := translateModel(&plan, &notes, env); err != nil {
+		return Plan{}, err
+	}
+	translateChannels(&plan, &notes, env)
+	if src.CronDir != "" {
+		notes.Action = append(notes.Action, fmt.Sprintf("cron files copied to imported/cron/ as references; translate them to INVOKE directives"))
+		notes.FatalLosses = append(notes.FatalLosses, FatalLoss{Feature: "cron", Reason: "Hermes cron files are not active in Clawdapus imports; pass --accept-loss=cron to keep them as references only"})
+	}
+	if src.Identity != "" && src.EnvVars["HERMES_DEFAULT_AGENT_IDENTITY"] != "" {
+		notes.Action = append(notes.Action, "HERMES_DEFAULT_AGENT_IDENTITY was folded into AGENTS.md/SOUL.md, not preserved as raw env")
+	}
+
+	for key, value := range env.values {
+		plan.Environment[key] = value
+	}
+	if plan.Cllama {
+		for key, value := range plan.Environment {
+			if strings.HasSuffix(key, "_API_KEY") || strings.HasSuffix(key, "_TOKEN") {
+				switch key {
+				case "DISCORD_BOT_TOKEN", "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "TELEGRAM_BOT_TOKEN":
+					continue
+				default:
+					plan.CllamaEnv[key] = value
+				}
+			}
+		}
+	}
+	notes.SecretNotes = append(notes.SecretNotes, env.secretNotes...)
+	plan.Notes = notes
+	return plan, nil
+}
+
+func translateModel(plan *Plan, notes *Notes, env *envBuilder) error {
+	model := plan.Model
+	if model.BaseURL != "" {
+		plan.Cllama = true
+		notes.Action = append(notes.Action, fmt.Sprintf("model provider %q had a custom base_url; emitted CLLAMA passthrough and left upstream verification to the operator", model.Provider))
+	}
+	providerKey := providerEnvKey(model.Provider)
+	if providerKey == "" && model.BaseURL == "" {
+		notes.FatalLosses = append(notes.FatalLosses, FatalLoss{
+			Feature: "custom-provider",
+			Reason:  fmt.Sprintf("provider %q is not natively supported; pass --model <provider/model> or --accept-loss=custom-provider", model.Provider),
+		})
+		return nil
+	}
+	if providerKey != "" {
+		apiKey := model.APIKey
+		if model.BaseURL != "" {
+			apiKey = ""
+		}
+		env.addSecret(providerKey, apiKey, "model API key")
+		notes.Applied = append(notes.Applied, fmt.Sprintf("MODEL primary %s", model.String()))
+	}
+	if plan.Cllama {
+		notes.Applied = append(notes.Applied, "CLLAMA passthrough")
+	}
+	return nil
+}
+
+func translateChannels(plan *Plan, notes *Notes, env *envBuilder) {
+	src := plan.Source
+	if src.Channels.Discord != nil {
+		d := src.Channels.Discord
+		env.addSecret("DISCORD_BOT_TOKEN", firstNonEmpty(d.Token, src.EnvVars["DISCORD_BOT_TOKEN"]), "Discord bot token")
+		env.addSecret("DISCORD_BOT_ID", firstNonEmpty(d.BotID, src.EnvVars["DISCORD_BOT_ID"]), "Discord bot id")
+		plan.Handles = append(plan.Handles, HandlePlan{Platform: "discord", IDEnv: "DISCORD_BOT_ID", Username: plan.AgentName, Guilds: d.Guilds})
+		notes.Applied = append(notes.Applied, "HANDLE discord")
+		switch plan.Target {
+		case TargetOpenClaw:
+			if len(d.AllowFrom) > 0 || d.DMPolicy != "" || len(d.Guilds) > 0 {
+				plan.Surfaces = append(plan.Surfaces, SurfacePlan{
+					Platform: "discord",
+					Discord:  &DiscordSurface{DMAllowFrom: d.AllowFrom, DMPolicy: d.DMPolicy, Guilds: d.Guilds},
+				})
+				notes.Applied = append(notes.Applied, "Discord routing mapped to channel://discord")
+			}
+		case TargetHermes:
+			if len(d.AllowFrom) > 0 {
+				env.addLiteral("DISCORD_ALLOWED_USERS", strings.Join(d.AllowFrom, ","))
+				notes.Applied = append(notes.Applied, "DISCORD_ALLOWED_USERS preserved")
+			}
+			if d.RequireMention {
+				env.addLiteral("DISCORD_REQUIRE_MENTION", "true")
+			}
+			if d.DMPolicy != "" && d.DMPolicy != "pairing" {
+				notes.FatalLosses = append(notes.FatalLosses, FatalLoss{Feature: "discord-routing", Reason: "Discord dmPolicy has no Hermes equivalent; pass --accept-loss=discord-routing to drop it"})
+			}
+		}
+	}
+	if src.Channels.Slack != nil {
+		s := src.Channels.Slack
+		env.addSecret("SLACK_BOT_TOKEN", firstNonEmpty(s.BotToken, src.EnvVars["SLACK_BOT_TOKEN"]), "Slack bot token")
+		if plan.Target == TargetHermes {
+			env.addSecret("SLACK_APP_TOKEN", firstNonEmpty(s.AppToken, src.EnvVars["SLACK_APP_TOKEN"]), "Slack app token")
+		}
+		env.addSecret("SLACK_BOT_ID", firstNonEmpty(s.BotID, src.EnvVars["SLACK_BOT_ID"]), "Slack bot id")
+		plan.Handles = append(plan.Handles, HandlePlan{Platform: "slack", IDEnv: "SLACK_BOT_ID", Username: plan.AgentName})
+		notes.Applied = append(notes.Applied, "HANDLE slack")
+		if len(s.AllowedUsers) > 0 {
+			if plan.Target == TargetHermes {
+				env.addLiteral("SLACK_ALLOWED_USERS", strings.Join(s.AllowedUsers, ","))
+				notes.Applied = append(notes.Applied, "SLACK_ALLOWED_USERS preserved")
+			} else {
+				notes.FatalLosses = append(notes.FatalLosses, FatalLoss{Feature: "slack-routing", Reason: "Slack routing has no channel://slack surface in v1; pass --accept-loss=slack-routing to drop it"})
+			}
+		}
+	}
+	if src.Channels.Telegram != nil {
+		t := src.Channels.Telegram
+		env.addSecret("TELEGRAM_BOT_TOKEN", firstNonEmpty(t.Token, src.EnvVars["TELEGRAM_BOT_TOKEN"]), "Telegram bot token")
+		env.addSecret("TELEGRAM_BOT_ID", firstNonEmpty(t.BotID, src.EnvVars["TELEGRAM_BOT_ID"]), "Telegram bot id")
+		plan.Handles = append(plan.Handles, HandlePlan{Platform: "telegram", IDEnv: "TELEGRAM_BOT_ID", Username: plan.AgentName})
+		notes.Applied = append(notes.Applied, "HANDLE telegram")
+	}
+}
+
+func baseImageForTarget(target TargetRuntime) string {
+	switch target {
+	case TargetHermes:
+		return hermes.BaseImageTag
+	default:
+		return "openclaw:latest"
+	}
+}
+
+func isCllamaForced(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "yes", "true", "1", "passthrough":
+		return true
+	default:
+		return false
+	}
+}
+
+func defaultImportedContract(src Descriptor, target TargetRuntime) string {
+	var b strings.Builder
+	b.WriteString("# Agent Contract\n\n")
+	if strings.TrimSpace(src.Identity) != "" {
+		b.WriteString(strings.TrimSpace(src.Identity))
+		b.WriteString("\n\n")
+	}
+	b.WriteString("You are an imported ")
+	b.WriteString(string(target))
+	b.WriteString(" agent managed by Clawdapus. Follow the source identity and the generated migration notes until the operator refines this contract.\n")
+	return b.String()
+}
+
+func sourceSoul(src Descriptor) string {
+	if strings.TrimSpace(src.Identity) == "" {
+		return ""
+	}
+	if strings.Contains(src.Identity, "\n") || strings.HasPrefix(strings.TrimSpace(src.Identity), "#") {
+		return strings.TrimRight(src.Identity, "\n") + "\n"
+	}
+	return "# Imported Identity\n\n" + strings.TrimSpace(src.Identity) + "\n"
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/internal/initimport/translate.go
+++ b/internal/initimport/translate.go
@@ -9,19 +9,27 @@ import (
 
 func Translate(src Descriptor, target TargetRuntime, opts Options) (Plan, error) {
 	model := src.Models.Primary
+	fallbacks := append([]ModelRef(nil), src.Models.Fallback...)
+	notes := Notes{}
 	if override := strings.TrimSpace(opts.ModelOverride); override != "" {
 		parsed, ok := SplitModelRef(override)
 		if !ok {
 			return Plan{}, fmt.Errorf("--model %q is invalid (expected provider/model)", override)
 		}
 		model = parsed
+		if len(fallbacks) > 0 {
+			notes.Action = append(notes.Action, "source fallback models were not preserved because --model override was used")
+			fallbacks = nil
+		}
 	}
 	if model.Provider == "" {
 		model = ModelRef{Provider: "openrouter", Model: "anthropic/claude-sonnet-4"}
 	}
+	if isCllamaDisabled(opts.CllamaOverride) && model.BaseURL != "" {
+		return Plan{}, fmt.Errorf("--cllama=no cannot import source model base_url %q; pass --model <provider/model> to use a native route or omit --cllama=no", model.BaseURL)
+	}
 
 	env := newEnvBuilder()
-	notes := Notes{}
 	for _, note := range src.RawNotes {
 		notes.Action = append(notes.Action, note)
 	}
@@ -33,8 +41,12 @@ func Translate(src Descriptor, target TargetRuntime, opts Options) (Plan, error)
 	}
 
 	cllama := src.Cllama || model.BaseURL != "" || isCllamaForced(opts.CllamaOverride)
-	if strings.EqualFold(strings.TrimSpace(opts.CllamaOverride), "no") || strings.EqualFold(strings.TrimSpace(opts.CllamaOverride), "false") {
-		cllama = model.BaseURL != ""
+	if isCllamaDisabled(opts.CllamaOverride) {
+		cllama = false
+	}
+	baseImage := strings.TrimSpace(opts.BaseImage)
+	if baseImage == "" {
+		baseImage = baseImageForTarget(target)
 	}
 
 	plan := Plan{
@@ -42,8 +54,9 @@ func Translate(src Descriptor, target TargetRuntime, opts Options) (Plan, error)
 		Target:        target,
 		ProjectName:   projectName,
 		AgentName:     agentName,
-		BaseImage:     baseImageForTarget(target),
+		BaseImage:     baseImage,
 		Model:         model,
+		Fallback:      fallbacks,
 		Cllama:        cllama,
 		Environment:   map[string]string{},
 		CllamaEnv:     map[string]string{},
@@ -58,8 +71,7 @@ func Translate(src Descriptor, target TargetRuntime, opts Options) (Plan, error)
 	}
 	translateChannels(&plan, &notes, env)
 	if src.CronDir != "" {
-		notes.Action = append(notes.Action, fmt.Sprintf("cron files copied to imported/cron/ as references; translate them to INVOKE directives"))
-		notes.FatalLosses = append(notes.FatalLosses, FatalLoss{Feature: "cron", Reason: "Hermes cron files are not active in Clawdapus imports; pass --accept-loss=cron to keep them as references only"})
+		notes.Action = append(notes.Action, "cron files copied to imported/cron/ as references; translate them to INVOKE directives")
 	}
 	if src.Identity != "" && src.EnvVars["HERMES_DEFAULT_AGENT_IDENTITY"] != "" {
 		notes.Action = append(notes.Action, "HERMES_DEFAULT_AGENT_IDENTITY was folded into AGENTS.md/SOUL.md, not preserved as raw env")
@@ -88,24 +100,34 @@ func Translate(src Descriptor, target TargetRuntime, opts Options) (Plan, error)
 func translateModel(plan *Plan, notes *Notes, env *envBuilder) error {
 	model := plan.Model
 	if model.BaseURL != "" {
-		plan.Cllama = true
 		notes.Action = append(notes.Action, fmt.Sprintf("model provider %q had a custom base_url; emitted CLLAMA passthrough and left upstream verification to the operator", model.Provider))
 	}
 	providerKey := providerEnvKey(model.Provider)
 	if providerKey == "" && model.BaseURL == "" {
+		providerKey = bestEffortProviderEnvKey(model.Provider)
+		env.addSecret(providerKey, model.APIKey, "model API key")
+		notes.Action = append(notes.Action, fmt.Sprintf("custom provider %q is not natively supported; generated best-effort %s placeholder", model.Provider, providerKey))
 		notes.FatalLosses = append(notes.FatalLosses, FatalLoss{
 			Feature: "custom-provider",
 			Reason:  fmt.Sprintf("provider %q is not natively supported; pass --model <provider/model> or --accept-loss=custom-provider", model.Provider),
 		})
-		return nil
-	}
-	if providerKey != "" {
+	} else if providerKey != "" {
 		apiKey := model.APIKey
 		if model.BaseURL != "" {
 			apiKey = ""
 		}
 		env.addSecret(providerKey, apiKey, "model API key")
-		notes.Applied = append(notes.Applied, fmt.Sprintf("MODEL primary %s", model.String()))
+	}
+	notes.Applied = append(notes.Applied, fmt.Sprintf("MODEL primary %s", model.String()))
+	for i, fallback := range plan.Fallback {
+		if key := providerEnvKey(fallback.Provider); key != "" && fallback.BaseURL == "" {
+			env.addSecret(key, fallback.APIKey, "fallback model API key")
+		} else if fallback.Provider != "" && fallback.BaseURL == "" {
+			key := bestEffortProviderEnvKey(fallback.Provider)
+			env.addSecret(key, fallback.APIKey, "fallback model API key")
+			notes.Action = append(notes.Action, fmt.Sprintf("fallback provider %q is not natively supported; generated best-effort %s placeholder", fallback.Provider, key))
+		}
+		notes.Applied = append(notes.Applied, fmt.Sprintf("MODEL %s %s", fallbackSlot(i), fallback.String()))
 	}
 	if plan.Cllama {
 		notes.Applied = append(notes.Applied, "CLLAMA passthrough")
@@ -179,9 +201,25 @@ func baseImageForTarget(target TargetRuntime) string {
 	}
 }
 
+func fallbackSlot(index int) string {
+	if index == 0 {
+		return "fallback"
+	}
+	return fmt.Sprintf("fallback_%d", index+1)
+}
+
 func isCllamaForced(value string) bool {
 	switch strings.ToLower(strings.TrimSpace(value)) {
 	case "yes", "true", "1", "passthrough":
+		return true
+	default:
+		return false
+	}
+}
+
+func isCllamaDisabled(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "no", "false", "0":
 		return true
 	default:
 		return false

--- a/internal/initimport/translate.go
+++ b/internal/initimport/translate.go
@@ -25,6 +25,10 @@ func Translate(src Descriptor, target TargetRuntime, opts Options) (Plan, error)
 	if model.Provider == "" {
 		model = ModelRef{Provider: "openrouter", Model: "anthropic/claude-sonnet-4"}
 	}
+	if len(fallbacks) > 1 {
+		notes.Action = append(notes.Action, fmt.Sprintf("additional source fallback models are not emitted because current runtimes use only MODEL fallback: %s", strings.Join(modelRefStrings(fallbacks[1:]), ", ")))
+		fallbacks = fallbacks[:1]
+	}
 	if isCllamaDisabled(opts.CllamaOverride) && model.BaseURL != "" {
 		return Plan{}, fmt.Errorf("--cllama=no cannot import source model base_url %q; pass --model <provider/model> to use a native route or omit --cllama=no", model.BaseURL)
 	}
@@ -119,7 +123,7 @@ func translateModel(plan *Plan, notes *Notes, env *envBuilder) error {
 		env.addSecret(providerKey, apiKey, "model API key")
 	}
 	notes.Applied = append(notes.Applied, fmt.Sprintf("MODEL primary %s", model.String()))
-	for i, fallback := range plan.Fallback {
+	for _, fallback := range plan.Fallback {
 		if key := providerEnvKey(fallback.Provider); key != "" && fallback.BaseURL == "" {
 			env.addSecret(key, fallback.APIKey, "fallback model API key")
 		} else if fallback.Provider != "" && fallback.BaseURL == "" {
@@ -127,7 +131,7 @@ func translateModel(plan *Plan, notes *Notes, env *envBuilder) error {
 			env.addSecret(key, fallback.APIKey, "fallback model API key")
 			notes.Action = append(notes.Action, fmt.Sprintf("fallback provider %q is not natively supported; generated best-effort %s placeholder", fallback.Provider, key))
 		}
-		notes.Applied = append(notes.Applied, fmt.Sprintf("MODEL %s %s", fallbackSlot(i), fallback.String()))
+		notes.Applied = append(notes.Applied, fmt.Sprintf("MODEL fallback %s", fallback.String()))
 	}
 	if plan.Cllama {
 		notes.Applied = append(notes.Applied, "CLLAMA passthrough")
@@ -201,13 +205,6 @@ func baseImageForTarget(target TargetRuntime) string {
 	}
 }
 
-func fallbackSlot(index int) string {
-	if index == 0 {
-		return "fallback"
-	}
-	return fmt.Sprintf("fallback_%d", index+1)
-}
-
 func isCllamaForced(value string) bool {
 	switch strings.ToLower(strings.TrimSpace(value)) {
 	case "yes", "true", "1", "passthrough":
@@ -256,4 +253,14 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func modelRefStrings(models []ModelRef) []string {
+	out := make([]string, 0, len(models))
+	for _, model := range models {
+		if ref := strings.TrimSpace(model.String()); ref != "" {
+			out = append(out, ref)
+		}
+	}
+	return out
 }

--- a/internal/initimport/types.go
+++ b/internal/initimport/types.go
@@ -1,9 +1,6 @@
 package initimport
 
-import (
-	"fmt"
-	"strings"
-)
+import "strings"
 
 type SourceKind string
 
@@ -107,7 +104,6 @@ type Options struct {
 	AgentName      string
 	ModelOverride  string
 	CllamaOverride string
-	AcceptLoss     []string
 	BaseImage      string
 }
 
@@ -152,60 +148,5 @@ type DiscordSurface struct {
 type Notes struct {
 	Applied     []string
 	Action      []string
-	FatalLosses []FatalLoss
 	SecretNotes []string
-}
-
-type FatalLoss struct {
-	Feature string
-	Reason  string
-}
-
-func (n Notes) HasFatal() bool {
-	return len(n.FatalLosses) > 0
-}
-
-func (n Notes) FatalFeatures() []string {
-	out := make([]string, 0, len(n.FatalLosses))
-	for _, loss := range n.FatalLosses {
-		out = append(out, loss.Feature)
-	}
-	return uniqueSorted(out)
-}
-
-func ResolveImportTarget(value string, source SourceKind) (TargetRuntime, error) {
-	target := strings.ToLower(strings.TrimSpace(value))
-	if target == "" {
-		target = string(source)
-	}
-	switch target {
-	case string(TargetOpenClaw):
-		return TargetOpenClaw, nil
-	case string(TargetHermes):
-		return TargetHermes, nil
-	default:
-		return "", fmt.Errorf("import target %q not supported yet; use --type openclaw|hermes for --from", target)
-	}
-}
-
-func AcceptLossAllows(accepted []string, features []string) bool {
-	if len(features) == 0 {
-		return true
-	}
-	set := make(map[string]struct{}, len(accepted))
-	for _, token := range accepted {
-		token = strings.ToLower(strings.TrimSpace(token))
-		if token != "" {
-			set[token] = struct{}{}
-		}
-	}
-	if _, ok := set["all"]; ok {
-		return true
-	}
-	for _, feature := range features {
-		if _, ok := set[strings.ToLower(strings.TrimSpace(feature))]; !ok {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/initimport/types.go
+++ b/internal/initimport/types.go
@@ -1,0 +1,209 @@
+package initimport
+
+import (
+	"fmt"
+	"strings"
+)
+
+type SourceKind string
+
+const (
+	SourceOpenClaw SourceKind = "openclaw"
+	SourceHermes   SourceKind = "hermes"
+)
+
+type TargetRuntime string
+
+const (
+	TargetOpenClaw TargetRuntime = "openclaw"
+	TargetHermes   TargetRuntime = "hermes"
+)
+
+type Descriptor struct {
+	Kind      SourceKind
+	Config    string
+	Root      string
+	AgentName string
+	Identity  string
+	Models    ModelSlots
+	Cllama    bool
+	Channels  Channels
+	EnvVars   map[string]string
+	SkillsDir string
+	CronDir   string
+	RawNotes  []string
+}
+
+type Channels struct {
+	Discord  *DiscordChannel
+	Slack    *SlackChannel
+	Telegram *TelegramChannel
+}
+
+type DiscordChannel struct {
+	Token          string
+	BotID          string
+	RequireMention bool
+	AllowFrom      []string
+	DMPolicy       string
+	Guilds         []DiscordGuild
+}
+
+type DiscordGuild struct {
+	ID             string
+	RequireMention bool
+	Users          []string
+}
+
+type SlackChannel struct {
+	BotToken     string
+	AppToken     string
+	BotID        string
+	AllowedUsers []string
+}
+
+type TelegramChannel struct {
+	Token string
+	BotID string
+}
+
+type ModelSlots struct {
+	Primary  ModelRef
+	Fallback []ModelRef
+}
+
+type ModelRef struct {
+	Provider string
+	Model    string
+	BaseURL  string
+	APIKey   string
+}
+
+func (m ModelRef) String() string {
+	provider := strings.TrimSpace(m.Provider)
+	model := strings.TrimSpace(m.Model)
+	if provider == "" {
+		return model
+	}
+	if model == "" {
+		return provider
+	}
+	if strings.HasPrefix(model, provider+"/") {
+		return model
+	}
+	return provider + "/" + model
+}
+
+func SplitModelRef(ref string) (ModelRef, bool) {
+	provider, model, ok := strings.Cut(strings.TrimSpace(ref), "/")
+	if !ok || strings.TrimSpace(provider) == "" || strings.TrimSpace(model) == "" {
+		return ModelRef{}, false
+	}
+	return ModelRef{Provider: strings.TrimSpace(provider), Model: strings.TrimSpace(model)}, true
+}
+
+type Options struct {
+	ProjectName    string
+	AgentName      string
+	ModelOverride  string
+	CllamaOverride string
+	AcceptLoss     []string
+}
+
+type Plan struct {
+	Source        Descriptor
+	Target        TargetRuntime
+	ProjectName   string
+	AgentName     string
+	BaseImage     string
+	Model         ModelRef
+	Cllama        bool
+	Handles       []HandlePlan
+	Environment   map[string]string
+	CllamaEnv     map[string]string
+	Surfaces      []SurfacePlan
+	AgentContract string
+	SoulContent   string
+	SkillsDir     string
+	CronDir       string
+	Notes         Notes
+}
+
+type HandlePlan struct {
+	Platform string
+	IDEnv    string
+	Username string
+	Guilds   []DiscordGuild
+}
+
+type SurfacePlan struct {
+	Platform string
+	Discord  *DiscordSurface
+}
+
+type DiscordSurface struct {
+	DMAllowFrom []string
+	DMPolicy    string
+	Guilds      []DiscordGuild
+}
+
+type Notes struct {
+	Applied     []string
+	Action      []string
+	FatalLosses []FatalLoss
+	SecretNotes []string
+}
+
+type FatalLoss struct {
+	Feature string
+	Reason  string
+}
+
+func (n Notes) HasFatal() bool {
+	return len(n.FatalLosses) > 0
+}
+
+func (n Notes) FatalFeatures() []string {
+	out := make([]string, 0, len(n.FatalLosses))
+	for _, loss := range n.FatalLosses {
+		out = append(out, loss.Feature)
+	}
+	return uniqueSorted(out)
+}
+
+func ResolveImportTarget(value string, source SourceKind) (TargetRuntime, error) {
+	target := strings.ToLower(strings.TrimSpace(value))
+	if target == "" {
+		target = string(source)
+	}
+	switch target {
+	case string(TargetOpenClaw):
+		return TargetOpenClaw, nil
+	case string(TargetHermes):
+		return TargetHermes, nil
+	default:
+		return "", fmt.Errorf("import target %q not supported yet; use --type openclaw|hermes for --from", target)
+	}
+}
+
+func AcceptLossAllows(accepted []string, features []string) bool {
+	if len(features) == 0 {
+		return true
+	}
+	set := make(map[string]struct{}, len(accepted))
+	for _, token := range accepted {
+		token = strings.ToLower(strings.TrimSpace(token))
+		if token != "" {
+			set[token] = struct{}{}
+		}
+	}
+	if _, ok := set["all"]; ok {
+		return true
+	}
+	for _, feature := range features {
+		if _, ok := set[strings.ToLower(strings.TrimSpace(feature))]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/initimport/types.go
+++ b/internal/initimport/types.go
@@ -108,6 +108,7 @@ type Options struct {
 	ModelOverride  string
 	CllamaOverride string
 	AcceptLoss     []string
+	BaseImage      string
 }
 
 type Plan struct {
@@ -117,6 +118,7 @@ type Plan struct {
 	AgentName     string
 	BaseImage     string
 	Model         ModelRef
+	Fallback      []ModelRef
 	Cllama        bool
 	Handles       []HandlePlan
 	Environment   map[string]string

--- a/internal/initimport/util.go
+++ b/internal/initimport/util.go
@@ -119,22 +119,6 @@ func nestedString(m map[string]any, keys ...string) (string, bool) {
 	return strings.TrimSpace(value), ok
 }
 
-func nestedBool(m map[string]any, keys ...string) (bool, bool) {
-	if len(keys) == 0 {
-		return false, false
-	}
-	current := m
-	for _, key := range keys[:len(keys)-1] {
-		next, ok := current[key].(map[string]any)
-		if !ok {
-			return false, false
-		}
-		current = next
-	}
-	value, ok := current[keys[len(keys)-1]].(bool)
-	return value, ok
-}
-
 func readDotEnv(path string) (map[string]string, error) {
 	file, err := os.Open(path)
 	if err != nil {

--- a/internal/initimport/util.go
+++ b/internal/initimport/util.go
@@ -1,0 +1,224 @@
+package initimport
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"unicode"
+)
+
+var validNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
+
+func normalizeName(value, fallback string) string {
+	var b strings.Builder
+	lastDash := false
+	for _, r := range strings.TrimSpace(value) {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			b.WriteRune(unicode.ToLower(r))
+			lastDash = false
+		case r == '_' || r == '-':
+			if !lastDash && b.Len() > 0 {
+				b.WriteRune('-')
+				lastDash = true
+			}
+		default:
+			if !lastDash && b.Len() > 0 {
+				b.WriteRune('-')
+				lastDash = true
+			}
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if out == "" {
+		out = fallback
+	}
+	if !validNamePattern.MatchString(out) {
+		return fallback
+	}
+	return out
+}
+
+func uniqueSorted(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func stringSlice(v any) []string {
+	switch x := v.(type) {
+	case []any:
+		out := make([]string, 0, len(x))
+		for _, item := range x {
+			if s, ok := item.(string); ok && strings.TrimSpace(s) != "" {
+				out = append(out, strings.TrimSpace(s))
+			}
+		}
+		return out
+	case []string:
+		return uniqueSorted(x)
+	case string:
+		if strings.TrimSpace(x) == "" {
+			return nil
+		}
+		parts := strings.Split(x, ",")
+		out := make([]string, 0, len(parts))
+		for _, part := range parts {
+			if strings.TrimSpace(part) != "" {
+				out = append(out, strings.TrimSpace(part))
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func nestedMap(m map[string]any, keys ...string) (map[string]any, bool) {
+	current := m
+	for _, key := range keys {
+		next, ok := current[key].(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current = next
+	}
+	return current, true
+}
+
+func nestedString(m map[string]any, keys ...string) (string, bool) {
+	if len(keys) == 0 {
+		return "", false
+	}
+	current := m
+	for _, key := range keys[:len(keys)-1] {
+		next, ok := current[key].(map[string]any)
+		if !ok {
+			return "", false
+		}
+		current = next
+	}
+	value, ok := current[keys[len(keys)-1]].(string)
+	return strings.TrimSpace(value), ok
+}
+
+func nestedBool(m map[string]any, keys ...string) (bool, bool) {
+	if len(keys) == 0 {
+		return false, false
+	}
+	current := m
+	for _, key := range keys[:len(keys)-1] {
+		next, ok := current[key].(map[string]any)
+		if !ok {
+			return false, false
+		}
+		current = next
+	}
+	value, ok := current[keys[len(keys)-1]].(bool)
+	return value, ok
+}
+
+func readDotEnv(path string) (map[string]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]string{}, nil
+		}
+		return nil, err
+	}
+	defer file.Close()
+
+	out := make(map[string]string)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(strings.TrimPrefix(key, "export "))
+		value = strings.TrimSpace(value)
+		value = strings.Trim(value, `"'`)
+		if key != "" {
+			out[key] = value
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func copyFile(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Close()
+}
+
+func copyDirFiles(srcDir, dstDir string) error {
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		src := filepath.Join(srcDir, entry.Name())
+		dst := filepath.Join(dstDir, entry.Name())
+		if err := copyFile(src, dst, 0o644); err != nil {
+			return fmt.Errorf("copy %s: %w", src, err)
+		}
+	}
+	return nil
+}
+
+func firstMarkdownHeading(data string) string {
+	for _, line := range strings.Split(data, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "#") {
+			return strings.TrimSpace(strings.TrimLeft(line, "#"))
+		}
+	}
+	return ""
+}

--- a/site/guide/cli.md
+++ b/site/guide/cli.md
@@ -332,7 +332,8 @@ When run interactively (no flags), prompts for project name, agent name, claw ty
 
 | Flag | Description |
 |------|-------------|
-| `--from <path>` | Migrate from an existing OpenClaw config directory. |
+| `--from <path>` | Import an existing OpenClaw or Hermes config into the same runtime. |
+| `--source <openclaw\|hermes>` | Source runtime override when `--from` autodetection is ambiguous. |
 | `--project <name>` | Project name (used for `x-claw.pod` and image prefix). |
 | `--agent <name>` | Primary agent name. |
 | `--type <type>` | Claw type (openclaw, hermes, nanoclaw, nanobot, picoclaw, nullclaw, microclaw, generic). |
@@ -350,8 +351,8 @@ claw init my-project
 # Non-interactive with all flags
 claw init --project trading-desk --type openclaw --platform discord
 
-# Migrate from existing OpenClaw setup
-claw init --from ~/existing-openclaw-config
+# Import an existing OpenClaw or Hermes setup into claw management
+claw init --from ~/existing-config
 ```
 
 After scaffolding:


### PR DESCRIPTION
## Summary
- Add `internal/initimport` to detect existing OpenClaw or Hermes sources and emit the canonical `agents/<name>/` scaffold for the same runtime.
- Keep `--from` source autodetection plus `--source` for ambiguous directories, while rejecting `--type` during imports so cross-runtime translation is not implied.
- Preserve supported model/channel/identity inputs, extract secrets into `.env.example`, generate a focused `MIGRATION.md`, and copy Hermes cron files as gitignored references only.
- Remove the cross-runtime translation and `--accept-loss` loss-token machinery; unsupported providers fail with a `--model` recovery hint and unsupported fallbacks are omitted with migration notes.

## Tests
- `go test ./internal/initimport ./cmd/claw`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

Closes #230
