### PR TITLE
#232 phase 1: bounded raw-window channel awareness + retrieval tools + metadata

### DIFF
--- a/cmd/claw-wall/main.go
+++ b/cmd/claw-wall/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -16,10 +17,12 @@ import (
 )
 
 type config struct {
-	Addr         string
-	TokenPairs   string
-	BufferLimit  int
-	PollInterval time.Duration
+	Addr              string
+	TokenPairs        string
+	BufferLimit       int
+	PollInterval      time.Duration
+	ToolToken         string
+	AgentChannelsPath string
 }
 
 func main() {
@@ -49,6 +52,10 @@ func run(args []string) error {
 	if err != nil {
 		return fmt.Errorf("claw-wall: parse CLAW_WALL_TOKENS: %w", err)
 	}
+	agentChannels, err := loadAgentChannels(cfg.AgentChannelsPath)
+	if err != nil {
+		return err
+	}
 
 	store := newConversationStore(cfg.BufferLimit)
 	poller := newDiscordPoller(&http.Client{Timeout: 10 * time.Second}, store, targets, cfg.BufferLimit)
@@ -59,7 +66,7 @@ func run(args []string) error {
 
 	server := &http.Server{
 		Addr:              cfg.Addr,
-		Handler:           newHandler(store),
+		Handler:           newHandler(store, handlerConfig{toolToken: cfg.ToolToken, agentChannels: agentChannels}),
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
@@ -111,11 +118,46 @@ func loadConfig() (config, error) {
 	}
 
 	return config{
-		Addr:         envOr("CLAW_WALL_ADDR", ":8080"),
-		TokenPairs:   tokenPairs,
-		BufferLimit:  bufferLimit,
-		PollInterval: time.Duration(pollSeconds) * time.Second,
+		Addr:              envOr("CLAW_WALL_ADDR", ":8080"),
+		TokenPairs:        tokenPairs,
+		BufferLimit:       bufferLimit,
+		PollInterval:      time.Duration(pollSeconds) * time.Second,
+		ToolToken:         strings.TrimSpace(os.Getenv("CLAW_WALL_TOOL_TOKEN")),
+		AgentChannelsPath: envOr("CLAW_WALL_AGENT_CHANNELS_FILE", "/etc/claw-wall/agent-channels.json"),
 	}, nil
+}
+
+func loadAgentChannels(path string) (map[string]map[string]struct{}, error) {
+	if strings.TrimSpace(os.Getenv("CLAW_WALL_TOOL_TOKEN")) == "" {
+		return nil, nil
+	}
+	// Tool auth is configured once at startup. If an operator adds
+	// CLAW_WALL_TOOL_TOKEN later, claw-wall must be recreated so the matching
+	// allowlist is loaded too; otherwise requests fail closed as unknown_agent.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("claw-wall: read agent channel allowlist: %w", err)
+	}
+	var parsed agentChannelAllowlistFile
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, fmt.Errorf("claw-wall: parse agent channel allowlist: %w", err)
+	}
+	out := make(map[string]map[string]struct{}, len(parsed.Agents))
+	for agentID, channels := range parsed.Agents {
+		agentID = strings.TrimSpace(agentID)
+		if agentID == "" {
+			continue
+		}
+		set := make(map[string]struct{}, len(channels))
+		for _, channelID := range channels {
+			channelID = strings.TrimSpace(channelID)
+			if channelID != "" {
+				set[channelID] = struct{}{}
+			}
+		}
+		out[agentID] = set
+	}
+	return out, nil
 }
 
 func envOr(key, fallback string) string {

--- a/cmd/claw-wall/main_test.go
+++ b/cmd/claw-wall/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -209,7 +210,7 @@ func TestChannelContextHandlerTailModeIsDefault(t *testing.T) {
 	if firstResp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", firstResp.StatusCode)
 	}
-	if !strings.Contains(string(firstBody), "[channel-context] mode=tail") {
+	if !strings.Contains(string(firstBody), "[channel-context] kind=tail mode=tail") {
 		t.Fatalf("expected tail coverage header, got %q", string(firstBody))
 	}
 	if !strings.Contains(string(firstBody), "latest signals") {
@@ -230,6 +231,112 @@ func TestChannelContextHandlerTailModeIsDefault(t *testing.T) {
 	}
 	if string(firstBody) != string(secondBody) {
 		t.Fatalf("expected stable tail response across repeated fetches\nfirst: %q\nsecond: %q", string(firstBody), string(secondBody))
+	}
+}
+
+func TestChannelAwarenessHandlerReturnsRawWindow(t *testing.T) {
+	store := newConversationStore(50)
+	store.merge("chan-1", []wallMessage{
+		{ID: "100", Author: "alice", Content: "older signal", Timestamp: time.Unix(100, 0)},
+		{ID: "101", Author: "bob", Content: "newer signal", Timestamp: time.Unix(101, 0)},
+	})
+
+	server := httptest.NewServer(newHandler(store))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/channel-awareness?channels=chan-1&limit=1&max_chars=4096")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+	text := string(body)
+	if !strings.Contains(text, "[channel-awareness] kind=raw_window") || !strings.Contains(text, "retained=2/since-all") || !strings.Contains(text, "digest=unavailable") {
+		t.Fatalf("expected raw awareness header, got %q", text)
+	}
+	if strings.Contains(text, "older signal") || !strings.Contains(text, "newer signal") {
+		t.Fatalf("expected newest bounded awareness body, got %q", text)
+	}
+}
+
+func TestToolSearchRequiresAuthAndChannelAllowlist(t *testing.T) {
+	store := newConversationStore(50)
+	store.merge("chan-1", []wallMessage{
+		{ID: "100", Author: "alice", Content: "alpha signal", Timestamp: time.Unix(100, 0)},
+	})
+	store.merge("chan-2", []wallMessage{
+		{ID: "200", Author: "bob", Content: "beta signal", Timestamp: time.Unix(200, 0)},
+	})
+
+	server := httptest.NewServer(newHandler(store, handlerConfig{
+		toolToken: "tool-token",
+		agentChannels: map[string]map[string]struct{}{
+			"trader-0": {"chan-1": {}},
+		},
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/search_channel_context", strings.NewReader(`{"channels":["chan-1"],"query":"alpha"}`))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer tool-token")
+	req.Header.Set("X-Claw-ID", "trader-0")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+	var result retrievalResult
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if result.Status != "ok" || len(result.Messages) != 1 || result.Messages[0].ID != "100" {
+		t.Fatalf("unexpected search result: %+v", result)
+	}
+
+	req, err = http.NewRequest(http.MethodPost, server.URL+"/get_channel_messages", strings.NewReader(`{"channels":["chan-2"],"message_ids":["200"]}`))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer tool-token")
+	req.Header.Set("X-Claw-ID", "trader-0")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST forbidden: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 403 for disallowed channel, got %d: %s", resp.StatusCode, string(body))
+	}
+}
+
+func TestGetChannelMessagesSupportsTimestampRange(t *testing.T) {
+	store := newConversationStore(50)
+	store.merge("chan-1", []wallMessage{
+		{ID: "100", Author: "alice", Content: "before", Timestamp: time.Date(2026, 5, 12, 8, 0, 0, 0, time.UTC)},
+		{ID: "101", Author: "bob", Content: "inside", Timestamp: time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC)},
+		{ID: "102", Author: "carol", Content: "after", Timestamp: time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)},
+	})
+
+	result := store.getMessages(getChannelMessagesRequest{
+		Channels: []string{"chan-1"},
+		After:    "2026-05-12T08:30Z",
+		Before:   "2026-05-12T09:30Z",
+	})
+	if result.Status != "ok" || len(result.Messages) != 1 || result.Messages[0].ID != "101" {
+		t.Fatalf("unexpected timestamp-bounded result: %+v", result)
 	}
 }
 
@@ -302,6 +409,46 @@ func TestChannelContextHandlerTailAfterCursor(t *testing.T) {
 	}
 	if !strings.Contains(text, "after=chan-1:100") || !strings.Contains(text, "cursor=chan-1:101") {
 		t.Fatalf("expected after and returned cursor in header, got %q", text)
+	}
+}
+
+func TestChannelContextHeaderByContextKindParam(t *testing.T) {
+	store := newConversationStore(50)
+	store.merge("chan-1", []wallMessage{
+		{ID: "100", Author: "alice", Content: "first", Timestamp: time.Unix(100, 0)},
+		{ID: "101", Author: "bob", Content: "second", Timestamp: time.Unix(101, 0)},
+	})
+
+	server := httptest.NewServer(newHandler(store))
+	defer server.Close()
+
+	cases := []struct {
+		name string
+		kind string
+		want string
+	}{
+		{name: "delta", kind: "delta_tail", want: "[channel-context delta] kind=delta_tail"},
+		{name: "bootstrap", kind: "bootstrap_tail", want: "[channel-context bootstrap] kind=bootstrap_tail reason=epoch_changed"},
+		{name: "tail", kind: "tail", want: "[channel-context] kind=tail"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := http.Get(server.URL + "/channel-context?channels=chan-1&mode=tail&context_kind=" + tc.kind)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer resp.Body.Close()
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("read response: %v", err)
+			}
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+			}
+			if !strings.Contains(string(body), tc.want) {
+				t.Fatalf("expected %q, got %q", tc.want, string(body))
+			}
+		})
 	}
 }
 

--- a/cmd/claw-wall/store.go
+++ b/cmd/claw-wall/store.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"sort"
 	"strconv"
@@ -14,15 +16,16 @@ const (
 	defaultResponseLimit  = 20
 	backgroundContextSize = 10
 	defaultTailLimit      = 40
+	defaultAwarenessLimit = 60
 	defaultTailMaxChars   = 8 * 1024
 )
 
 type wallMessage struct {
-	ID        string
-	ChannelID string
-	Author    string
-	Content   string
-	Timestamp time.Time
+	ID        string    `json:"id"`
+	ChannelID string    `json:"channel_id"`
+	Author    string    `json:"author"`
+	Content   string    `json:"content"`
+	Timestamp time.Time `json:"timestamp"`
 }
 
 type channelBuffer struct {
@@ -57,6 +60,48 @@ type tailResult struct {
 	BufferNewest time.Time
 	Cursor       map[string]string
 	After        map[string]string
+}
+
+type handlerConfig struct {
+	toolToken     string
+	agentChannels map[string]map[string]struct{}
+}
+
+type agentChannelAllowlistFile struct {
+	Version int                 `json:"version"`
+	Agents  map[string][]string `json:"agents"`
+}
+
+type retrievalResult struct {
+	Messages         []wallMessage `json:"messages"`
+	RetainedCoverage coverageInfo  `json:"retained_coverage"`
+	Status           string        `json:"status"`
+	Hint             string        `json:"hint,omitempty"`
+}
+
+type coverageInfo struct {
+	OldestTS   string `json:"oldest_ts,omitempty"`
+	NewestTS   string `json:"newest_ts,omitempty"`
+	BufferSize int    `json:"buffer_size"`
+	oldestTime time.Time
+	newestTime time.Time
+}
+
+type searchChannelContextRequest struct {
+	Channels []string `json:"channels"`
+	Query    string   `json:"query"`
+	Since    string   `json:"since"`
+	Author   string   `json:"author"`
+	Limit    int      `json:"limit"`
+}
+
+type getChannelMessagesRequest struct {
+	Channels   []string `json:"channels"`
+	MessageIDs []string `json:"message_ids"`
+	After      string   `json:"after"`
+	Before     string   `json:"before"`
+	Author     string   `json:"author"`
+	Limit      int      `json:"limit"`
 }
 
 func newConversationStore(limit int) *conversationStore {
@@ -299,7 +344,141 @@ func (s *conversationStore) tail(req tailRequest) tailResult {
 	return result
 }
 
-func newHandler(store *conversationStore) http.Handler {
+func (s *conversationStore) search(req searchChannelContextRequest, now time.Time) retrievalResult {
+	limit := req.Limit
+	if limit <= 0 {
+		limit = defaultResponseLimit
+	}
+	if limit > s.limit {
+		limit = s.limit
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	var windowStart time.Time
+	if strings.TrimSpace(req.Since) != "" {
+		if d, err := time.ParseDuration(strings.TrimSpace(req.Since)); err == nil && d > 0 {
+			windowStart = now.Add(-d)
+		}
+	}
+	query := strings.ToLower(strings.TrimSpace(req.Query))
+	author := strings.ToLower(strings.TrimSpace(req.Author))
+	result := s.scan(req.Channels, func(msg wallMessage) bool {
+		if !windowStart.IsZero() && !msg.Timestamp.IsZero() && msg.Timestamp.Before(windowStart) {
+			return false
+		}
+		if author != "" && !strings.Contains(strings.ToLower(msg.Author), author) {
+			return false
+		}
+		if query != "" && !strings.Contains(strings.ToLower(msg.Content), query) {
+			return false
+		}
+		return true
+	}, limit)
+	if result.Status == "empty" && !windowStart.IsZero() && !result.RetainedCoverage.oldestTime.IsZero() && windowStart.Before(result.RetainedCoverage.oldestTime) {
+		result.Status = "not_in_buffer"
+		result.Hint = "Requested window extends before buffer's oldest_ts. Operator can widen CLAW_WALL_LIMIT or rely on v2 digest once available."
+	}
+	return result
+}
+
+func (s *conversationStore) getMessages(req getChannelMessagesRequest) retrievalResult {
+	limit := req.Limit
+	if limit <= 0 {
+		limit = defaultResponseLimit
+	}
+	if limit > s.limit {
+		limit = s.limit
+	}
+	wanted := make(map[string]struct{}, len(req.MessageIDs))
+	for _, id := range req.MessageIDs {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			wanted[id] = struct{}{}
+		}
+	}
+	author := strings.ToLower(strings.TrimSpace(req.Author))
+	result := s.scan(req.Channels, func(msg wallMessage) bool {
+		if len(wanted) > 0 {
+			if _, ok := wanted[msg.ID]; !ok {
+				return false
+			}
+		}
+		if after := strings.TrimSpace(req.After); after != "" && !messageAfterBoundary(msg, after) {
+			return false
+		}
+		if before := strings.TrimSpace(req.Before); before != "" && !messageBeforeBoundary(msg, before) {
+			return false
+		}
+		if author != "" && !strings.Contains(strings.ToLower(msg.Author), author) {
+			return false
+		}
+		return true
+	}, limit)
+	if len(wanted) > 0 && len(result.Messages) < len(wanted) {
+		result.Status = "not_in_buffer"
+		result.Hint = "One or more requested message_ids are not retained in claw-wall's current buffer."
+	}
+	return result
+}
+
+func (s *conversationStore) scan(channelIDs []string, match func(wallMessage) bool, limit int) retrievalResult {
+	channelIDs = normalizeChannelIDs(channelIDs)
+	if limit <= 0 {
+		limit = defaultResponseLimit
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	candidates := make([]wallMessage, 0)
+	var bufferOldest, bufferNewest time.Time
+	bufferSize := 0
+	for _, channelID := range channelIDs {
+		state := s.channels[channelID]
+		if state == nil {
+			continue
+		}
+		bufferSize += len(state.messages)
+		for _, msg := range state.messages {
+			if !msg.Timestamp.IsZero() {
+				if bufferOldest.IsZero() || msg.Timestamp.Before(bufferOldest) {
+					bufferOldest = msg.Timestamp
+				}
+				if bufferNewest.IsZero() || msg.Timestamp.After(bufferNewest) {
+					bufferNewest = msg.Timestamp
+				}
+			}
+			if match == nil || match(msg) {
+				candidates = append(candidates, msg)
+			}
+		}
+	}
+	sortWallMessages(candidates)
+	if len(candidates) > limit {
+		candidates = candidates[len(candidates)-limit:]
+	}
+	status := "ok"
+	if len(candidates) == 0 {
+		status = "empty"
+	}
+	return retrievalResult{
+		Messages: candidates,
+		RetainedCoverage: coverageInfo{
+			OldestTS:   formatOptionalHeaderTimestamp(bufferOldest),
+			NewestTS:   formatOptionalHeaderTimestamp(bufferNewest),
+			BufferSize: bufferSize,
+			oldestTime: bufferOldest,
+			newestTime: bufferNewest,
+		},
+		Status: status,
+	}
+}
+
+func newHandler(store *conversationStore, cfgs ...handlerConfig) http.Handler {
+	cfg := handlerConfig{}
+	if len(cfgs) > 0 {
+		cfg = cfgs[0]
+	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -381,9 +560,131 @@ func newHandler(store *conversationStore) http.Handler {
 			MaxChars:   maxChars,
 			Now:        time.Now(),
 		})
-		_, _ = w.Write([]byte(formatTailContext(result, since)))
+		kind := contextKindFromRequest(r, result)
+		_, _ = w.Write([]byte(formatTailContext(result, since, kind)))
+	})
+	mux.HandleFunc("/channel-awareness", func(w http.ResponseWriter, r *http.Request) {
+		rawChannels := strings.TrimSpace(r.URL.Query().Get("channels"))
+		if rawChannels == "" {
+			http.Error(w, "channels is required", http.StatusBadRequest)
+			return
+		}
+		channelIDs := strings.Split(rawChannels, ",")
+		limit := defaultAwarenessLimit
+		if rawLimit := strings.TrimSpace(r.URL.Query().Get("limit")); rawLimit != "" {
+			parsed, err := strconv.Atoi(rawLimit)
+			if err != nil || parsed < 1 {
+				http.Error(w, "limit must be a positive integer", http.StatusBadRequest)
+				return
+			}
+			limit = parsed
+		}
+		since, err := parseDurationQuery(r.URL.Query().Get("since"), r.URL.Query().Get("window"))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		maxChars := defaultTailMaxChars
+		if rawMaxChars := strings.TrimSpace(r.URL.Query().Get("max_chars")); rawMaxChars != "" {
+			parsed, err := strconv.Atoi(rawMaxChars)
+			if err != nil || parsed < 1 {
+				http.Error(w, "max_chars must be a positive integer", http.StatusBadRequest)
+				return
+			}
+			maxChars = parsed
+		}
+		result := store.tail(tailRequest{
+			ChannelIDs: channelIDs,
+			Since:      since,
+			Limit:      limit,
+			MaxChars:   maxChars,
+			Now:        time.Now(),
+		})
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = w.Write([]byte(formatChannelAwareness(result, since)))
+	})
+	mux.HandleFunc("/search_channel_context", func(w http.ResponseWriter, r *http.Request) {
+		if !authorizeToolRequest(w, r, cfg) {
+			return
+		}
+		var req searchChannelContextRequest
+		if !decodeJSONRequest(w, r, &req) {
+			return
+		}
+		if disallowed := firstDisallowedToolChannel(req.Channels, r.Header.Get("X-Claw-ID"), cfg.agentChannels); disallowed != "" {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "channel_not_allowed", "agent": r.Header.Get("X-Claw-ID"), "channel": disallowed})
+			return
+		}
+		writeJSON(w, http.StatusOK, store.search(req, time.Now()))
+	})
+	mux.HandleFunc("/get_channel_messages", func(w http.ResponseWriter, r *http.Request) {
+		if !authorizeToolRequest(w, r, cfg) {
+			return
+		}
+		var req getChannelMessagesRequest
+		if !decodeJSONRequest(w, r, &req) {
+			return
+		}
+		if disallowed := firstDisallowedToolChannel(req.Channels, r.Header.Get("X-Claw-ID"), cfg.agentChannels); disallowed != "" {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "channel_not_allowed", "agent": r.Header.Get("X-Claw-ID"), "channel": disallowed})
+			return
+		}
+		writeJSON(w, http.StatusOK, store.getMessages(req))
 	})
 	return mux
+}
+
+func authorizeToolRequest(w http.ResponseWriter, r *http.Request, cfg handlerConfig) bool {
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
+		return false
+	}
+	auth := strings.TrimSpace(r.Header.Get("Authorization"))
+	want := "Bearer " + strings.TrimSpace(cfg.toolToken)
+	if cfg.toolToken == "" || auth != want {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthenticated"})
+		return false
+	}
+	agentID := strings.TrimSpace(r.Header.Get("X-Claw-ID"))
+	if agentID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing_agent_id"})
+		return false
+	}
+	if _, ok := cfg.agentChannels[agentID]; !ok {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "unknown_agent"})
+		return false
+	}
+	return true
+}
+
+func firstDisallowedToolChannel(channels []string, agentID string, allowlists map[string]map[string]struct{}) string {
+	allowed := allowlists[strings.TrimSpace(agentID)]
+	for _, channelID := range normalizeChannelIDs(channels) {
+		if _, ok := allowed[channelID]; !ok {
+			return channelID
+		}
+	}
+	return ""
+}
+
+func decodeJSONRequest(w http.ResponseWriter, r *http.Request, out any) bool {
+	defer r.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "read_failed"})
+		return false
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid_json"})
+		return false
+	}
+	return true
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
 }
 
 func formatWallMessages(messages []wallMessage) string {
@@ -401,9 +702,29 @@ func formatWallMessage(msg wallMessage) string {
 	return fmt.Sprintf("[%s] %s: %s", formatWallTimestamp(msg.Timestamp), msg.Author, msg.Content)
 }
 
-func formatTailContext(result tailResult, since time.Duration) string {
+func contextKindFromRequest(r *http.Request, result tailResult) string {
+	kind := strings.TrimSpace(r.URL.Query().Get("context_kind"))
+	switch kind {
+	case "delta_tail", "bootstrap_tail", "tail":
+		return kind
+	}
+	if len(result.After) > 0 {
+		return "delta_tail"
+	}
+	return "tail"
+}
+
+func formatTailContext(result tailResult, since time.Duration, kind string) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "[channel-context] mode=tail since=%s channels=%s messages=%d available=%d omitted=%d",
+	switch kind {
+	case "delta_tail":
+		fmt.Fprintf(&b, "[channel-context delta] kind=delta_tail")
+	case "bootstrap_tail":
+		fmt.Fprintf(&b, "[channel-context bootstrap] kind=bootstrap_tail reason=epoch_changed")
+	default:
+		fmt.Fprintf(&b, "[channel-context] kind=tail")
+	}
+	fmt.Fprintf(&b, " mode=tail since=%s channels=%s messages=%d available=%d omitted=%d",
 		formatDurationForHeader(since), strings.Join(result.ChannelIDs, ","), len(result.Messages), result.Available, result.Omitted)
 	if result.CapReason != "" {
 		fmt.Fprintf(&b, " cap=%s", result.CapReason)
@@ -413,6 +734,35 @@ func formatTailContext(result tailResult, since time.Duration) string {
 	}
 	if len(result.Cursor) > 0 {
 		fmt.Fprintf(&b, " cursor=%s", formatCursorMap(result.Cursor))
+	}
+	fmt.Fprintf(&b, " range=%s buffer_range=%s",
+		formatTimeRange(messageRange(result.Messages)),
+		formatTimeRange(result.BufferOldest, result.BufferNewest))
+	b.WriteString("\n")
+	if result.Omitted > 0 {
+		fmt.Fprintf(&b, "[omitted %d older retained messages due to %s; newest retained messages follow]\n",
+			result.Omitted, result.CapReason)
+	}
+	if len(result.Messages) > 0 {
+		b.WriteByte('\n')
+		b.WriteString(formatWallMessages(result.Messages))
+	}
+	return b.String()
+}
+
+func formatChannelAwareness(result tailResult, since time.Duration) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "[channel-awareness] kind=raw_window since=%s channels=%s messages=%d available=%d omitted=%d retained=%d/since-%s digest=unavailable",
+		formatDurationForHeader(since),
+		strings.Join(result.ChannelIDs, ","),
+		len(result.Messages),
+		result.Available,
+		result.Omitted,
+		result.Available,
+		formatDurationForHeader(since),
+	)
+	if result.CapReason != "" {
+		fmt.Fprintf(&b, " cap=%s", result.CapReason)
 	}
 	fmt.Fprintf(&b, " range=%s buffer_range=%s",
 		formatTimeRange(messageRange(result.Messages)),
@@ -540,6 +890,41 @@ func formatHeaderTimestamp(ts time.Time) string {
 		return "unknown-time"
 	}
 	return ts.UTC().Format("2006-01-02T15:04Z")
+}
+
+func formatOptionalHeaderTimestamp(ts time.Time) string {
+	if ts.IsZero() {
+		return ""
+	}
+	return formatHeaderTimestamp(ts)
+}
+
+func messageAfterBoundary(msg wallMessage, raw string) bool {
+	if boundary, ok := parseMessageBoundaryTime(raw); ok {
+		return !msg.Timestamp.IsZero() && msg.Timestamp.After(boundary)
+	}
+	return compareSnowflakes(msg.ID, raw) > 0
+}
+
+func messageBeforeBoundary(msg wallMessage, raw string) bool {
+	if boundary, ok := parseMessageBoundaryTime(raw); ok {
+		return !msg.Timestamp.IsZero() && msg.Timestamp.Before(boundary)
+	}
+	return compareSnowflakes(msg.ID, raw) < 0
+}
+
+func parseMessageBoundaryTime(raw string) (time.Time, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02T15:04Z", "2006-01-02 15:04"} {
+		ts, err := time.Parse(layout, raw)
+		if err == nil {
+			return ts, true
+		}
+	}
+	return time.Time{}, false
 }
 
 func formatWallTimestamp(ts time.Time) string {

--- a/cmd/claw/audit.go
+++ b/cmd/claw/audit.go
@@ -188,7 +188,7 @@ func formatModelUsage(models map[string]int) string {
 func init() {
 	auditCmd.Flags().StringVar(&auditSince, "since", "", "Only include events since this duration or RFC3339 timestamp")
 	auditCmd.Flags().StringVar(&auditClaw, "claw", "", "Only include events for one claw_id")
-	auditCmd.Flags().StringVar(&auditType, "type", "", "Only include one event type (for example request, response, error, intervention, feed_fetch, provider_pool, tool_call)")
+	auditCmd.Flags().StringVar(&auditType, "type", "", "Only include one event type (for example request, response, error, intervention, feed_fetch, channel_context_op, provider_pool, tool_call)")
 	auditCmd.Flags().BoolVar(&auditJSON, "json", false, "Emit machine-readable JSON")
 	rootCmd.AddCommand(auditCmd)
 }

--- a/cmd/claw/compose_up.go
+++ b/cmd/claw/compose_up.go
@@ -4,11 +4,13 @@ import (
 	"bufio"
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -40,19 +42,23 @@ var composeUpDiscoverTools bool
 var runtimePlaceholderPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
 
 const (
-	conversationWallServiceName  = "claw-wall"
-	conversationWallFeedName     = "channel-context"
-	conversationWallFeedTTL      = 30
-	conversationWallFeedSince    = "24h"
-	conversationWallFeedLimit    = 40
-	conversationWallFeedMaxChars = 8 * 1024
-	conversationWallBufferLimit  = 500
-	conversationWallPollInterval = "30"
-	conversationWallInternalPort = "8080"
-	conversationWallDockerfile   = "dockerfiles/claw-wall/Dockerfile"
-	clawInternalNetworkName      = "claw-internal"
-	historyReplayAuthService     = "cllama-history"
-	historyReplayBaseURL         = "http://cllama:8080/history"
+	conversationWallServiceName    = "claw-wall"
+	conversationWallFeedName       = "channel-context"
+	conversationWallAwarenessName  = "channel-awareness"
+	conversationWallFeedTTL        = 30
+	conversationWallFeedSince      = "24h"
+	conversationWallFeedLimit      = 40
+	conversationWallAwarenessLimit = 60
+	conversationWallFeedMaxChars   = 8 * 1024
+	conversationWallBufferLimit    = 500
+	conversationWallPollInterval   = "30"
+	conversationWallInternalPort   = "8080"
+	conversationWallDockerfile     = "dockerfiles/claw-wall/Dockerfile"
+	conversationWallToolTokenEnv   = "CLAW_WALL_TOOL_TOKEN"
+	conversationWallAllowlistPath  = "/etc/claw-wall/agent-channels.json"
+	clawInternalNetworkName        = "claw-internal"
+	historyReplayAuthService       = "cllama-history"
+	historyReplayBaseURL           = "http://cllama:8080/history"
 )
 
 var (
@@ -433,6 +439,10 @@ func runComposeUp(podFile string) (err error) {
 	if err != nil {
 		return err
 	}
+	conversationWallAuth, conversationWallAllowlists, err := prepareConversationWallRuntime(runtimeDir, p, resolvedClaws)
+	if err != nil {
+		return err
+	}
 	for _, rc := range resolvedClaws {
 		if rc == nil {
 			continue
@@ -548,6 +558,7 @@ func runComposeUp(podFile string) (err error) {
 					ordinalAuth := mergeServiceAuthEntries(
 						lookupServiceAuth(clawAPIAuth, ordinalName),
 						lookupServiceAuth(historyReplayAuth, ordinalName),
+						lookupServiceAuth(conversationWallAuth, ordinalName),
 					)
 					feeds, err := buildFeedManifestEntries(p, serviceDescriptors, runtimeEnv, name, ordinalName, ordinalAuth)
 					if err != nil {
@@ -563,13 +574,14 @@ func runComposeUp(podFile string) (err error) {
 					}
 					md := augmentClawdapusMD(shared.GenerateClawdapusMD(&ordinalRC, p.Name), tools, memory)
 					contextInputs = append(contextInputs, cllama.AgentContextInput{
-						AgentID:     ordinalName,
-						AgentsMD:    string(agentContent),
-						ClawdapusMD: md,
-						Feeds:       feeds,
-						Tools:       tools,
-						Memory:      memory,
-						ServiceAuth: ordinalAuth,
+						AgentID:          ordinalName,
+						AgentsMD:         string(agentContent),
+						ClawdapusMD:      md,
+						Feeds:            feeds,
+						Tools:            tools,
+						Memory:           memory,
+						ServiceAuth:      ordinalAuth,
+						ChannelAllowlist: conversationWallAllowlists[ordinalName],
 						Metadata: cllama.InjectCompiledModelPolicy(map[string]any{
 							"service":  name,
 							"ordinal":  i,
@@ -586,6 +598,7 @@ func runComposeUp(podFile string) (err error) {
 			svcAuth := mergeServiceAuthEntries(
 				lookupServiceAuth(clawAPIAuth, name),
 				lookupServiceAuth(historyReplayAuth, name),
+				lookupServiceAuth(conversationWallAuth, name),
 			)
 			feeds, err := buildFeedManifestEntries(p, serviceDescriptors, runtimeEnv, name, name, svcAuth)
 			if err != nil {
@@ -601,13 +614,14 @@ func runComposeUp(podFile string) (err error) {
 			}
 			md := augmentClawdapusMD(shared.GenerateClawdapusMD(rc, p.Name), tools, memory)
 			contextInputs = append(contextInputs, cllama.AgentContextInput{
-				AgentID:     name,
-				AgentsMD:    string(agentContent),
-				ClawdapusMD: md,
-				Feeds:       feeds,
-				Tools:       tools,
-				Memory:      memory,
-				ServiceAuth: svcAuth,
+				AgentID:          name,
+				AgentsMD:         string(agentContent),
+				ClawdapusMD:      md,
+				Feeds:            feeds,
+				Tools:            tools,
+				Memory:           memory,
+				ServiceAuth:      svcAuth,
+				ChannelAllowlist: conversationWallAllowlists[name],
 				Metadata: cllama.InjectCompiledModelPolicy(map[string]any{
 					"service":  name,
 					"pod":      p.Name,
@@ -1783,7 +1797,10 @@ func injectConversationWall(p *pod.Pod, resolvedClaws map[string]*driver.Resolve
 			continue
 		}
 		settings := conversationWallChannelContext(p, svc)
+		awarenessSettings := conversationWallChannelAwarenessContext()
+		svc.Claw.Feeds = appendConversationWallAwarenessFeed(svc.Claw.Feeds, channelIDs, awarenessSettings)
 		svc.Claw.Feeds = appendConversationWallFeed(svc.Claw.Feeds, channelIDs, settings)
+		svc.Claw.Tools = appendConversationWallToolPolicy(svc.Claw.Tools)
 	}
 
 	p.Services[conversationWallServiceName] = &pod.Service{
@@ -1866,6 +1883,14 @@ func conversationWallChannelContext(p *pod.Pod, svc *pod.Service) conversationWa
 	return settings
 }
 
+func conversationWallChannelAwarenessContext() conversationWallContextSettings {
+	return conversationWallContextSettings{
+		Since:    conversationWallFeedSince,
+		Limit:    conversationWallAwarenessLimit,
+		MaxChars: conversationWallFeedMaxChars,
+	}
+}
+
 func applyConversationWallChannelContext(settings conversationWallContextSettings, cfg *pod.ChannelContextConfig) conversationWallContextSettings {
 	if cfg == nil {
 		return settings
@@ -1917,6 +1942,57 @@ func appendConversationWallFeed(feeds []pod.FeedEntry, channelIDs []string, sett
 		Source: conversationWallServiceName,
 		Path:   path,
 		TTL:    conversationWallFeedTTL,
+	})
+}
+
+func appendConversationWallAwarenessFeed(feeds []pod.FeedEntry, channelIDs []string, settings conversationWallContextSettings) []pod.FeedEntry {
+	path := fmt.Sprintf(
+		"/channel-awareness?channels=%s&since=%s&limit=%d&max_chars=%d&context_kind=raw_window",
+		strings.Join(channelIDs, ","),
+		settings.Since,
+		settings.Limit,
+		settings.MaxChars,
+	)
+	for _, feed := range feeds {
+		if feed.Name == conversationWallAwarenessName && feed.Source == conversationWallServiceName && feed.Path == path {
+			return feeds
+		}
+	}
+	return append(feeds, pod.FeedEntry{
+		Name:   conversationWallAwarenessName,
+		Source: conversationWallServiceName,
+		Path:   path,
+		TTL:    conversationWallFeedTTL,
+	})
+}
+
+func appendConversationWallToolPolicy(tools []pod.ToolPolicyEntry) []pod.ToolPolicyEntry {
+	required := []string{"search_channel_context", "get_channel_messages"}
+	for _, policy := range tools {
+		if policy.Service != conversationWallServiceName {
+			continue
+		}
+		if len(policy.Allow) == 1 && policy.Allow[0] == "all" {
+			return tools
+		}
+		seen := make(map[string]struct{}, len(policy.Allow))
+		for _, item := range policy.Allow {
+			seen[item] = struct{}{}
+		}
+		covered := true
+		for _, name := range required {
+			if _, ok := seen[name]; !ok {
+				covered = false
+				break
+			}
+		}
+		if covered {
+			return tools
+		}
+	}
+	return append(tools, pod.ToolPolicyEntry{
+		Service: conversationWallServiceName,
+		Allow:   required,
 	})
 }
 
@@ -2151,6 +2227,96 @@ func prepareClawAPIRuntime(runtimeDir string, p *pod.Pod, resolvedClaws map[stri
 	return serviceAuth, nil
 }
 
+type conversationWallAllowlistFile struct {
+	Version int                 `json:"version"`
+	Agents  map[string][]string `json:"agents"`
+}
+
+func prepareConversationWallRuntime(runtimeDir string, p *pod.Pod, resolvedClaws map[string]*driver.ResolvedClaw) (map[string]cllama.ServiceAuthEntry, map[string][]string, error) {
+	if p == nil {
+		return nil, nil, nil
+	}
+	wallSvc := p.Services[conversationWallServiceName]
+	if wallSvc == nil {
+		return nil, nil, nil
+	}
+
+	allowlists := conversationWallAgentAllowlists(p, resolvedClaws)
+	if len(allowlists) == 0 {
+		return nil, nil, nil
+	}
+
+	manifest := conversationWallAllowlistFile{
+		Version: 1,
+		Agents:  allowlists,
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal claw-wall channel allowlist: %w", err)
+	}
+	data = append(data, '\n')
+	hostPath := filepath.Join(runtimeDir, "claw-wall-agent-channels.json")
+	if err := writeRuntimeFile(hostPath, data, 0644); err != nil {
+		return nil, nil, fmt.Errorf("write claw-wall channel allowlist: %w", err)
+	}
+
+	token := cllama.GenerateToken(conversationWallServiceName)
+	if wallSvc.Environment == nil {
+		wallSvc.Environment = make(map[string]string)
+	}
+	wallSvc.Environment[conversationWallToolTokenEnv] = token
+	sum := sha256.Sum256(data)
+	wallSvc.Environment["CLAW_WALL_AGENT_CHANNELS_SHA"] = hex.EncodeToString(sum[:])
+	if wallSvc.Compose == nil {
+		wallSvc.Compose = make(map[string]interface{})
+	}
+	volumes, err := appendComposeString(wallSvc.Compose["volumes"], fmt.Sprintf("%s:%s:ro", hostPath, conversationWallAllowlistPath))
+	if err != nil {
+		return nil, nil, fmt.Errorf("claw-wall volumes: %w", err)
+	}
+	wallSvc.Compose["volumes"] = volumes
+
+	serviceAuth := make(map[string]cllama.ServiceAuthEntry, len(allowlists))
+	for agentID := range allowlists {
+		serviceAuth[agentID] = cllama.ServiceAuthEntry{
+			Service:   conversationWallServiceName,
+			AuthType:  "bearer",
+			Token:     token,
+			Principal: agentID,
+		}
+	}
+	return serviceAuth, allowlists, nil
+}
+
+func conversationWallAgentAllowlists(p *pod.Pod, resolvedClaws map[string]*driver.ResolvedClaw) map[string][]string {
+	allowlists := make(map[string][]string)
+	if p == nil {
+		return allowlists
+	}
+	for _, name := range sortedResolvedClawNames(resolvedClaws) {
+		rc := resolvedClaws[name]
+		if rc == nil || len(rc.Cllama) == 0 {
+			continue
+		}
+		svc := p.Services[name]
+		if svc == nil || svc.Claw == nil {
+			continue
+		}
+		channelIDs := discordHandleChannelIDs(svc.Claw.Handles)
+		if len(channelIDs) == 0 {
+			continue
+		}
+		count := 1
+		if rc.Count > 0 {
+			count = rc.Count
+		}
+		for _, agentID := range expandedServiceNames(name, count) {
+			allowlists[agentID] = append([]string(nil), channelIDs...)
+		}
+	}
+	return allowlists
+}
+
 func writeClawAPIPrincipalStore(runtimeDir, hostPath string, store clawapi.Store) error {
 	principalsDir := filepath.Dir(hostPath)
 	if err := os.MkdirAll(principalsDir, 0700); err != nil {
@@ -2280,6 +2446,33 @@ func ensureServiceOnNetwork(svc *pod.Service, network string) error {
 	}
 	svc.Compose["networks"] = networks
 	return nil
+}
+
+func appendComposeString(base interface{}, value string) (interface{}, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return base, nil
+	}
+	switch current := base.(type) {
+	case nil:
+		return []string{value}, nil
+	case []string:
+		for _, item := range current {
+			if item == value {
+				return current, nil
+			}
+		}
+		return append(current, value), nil
+	case []interface{}:
+		for _, item := range current {
+			if s, ok := item.(string); ok && s == value {
+				return current, nil
+			}
+		}
+		return append(current, value), nil
+	default:
+		return nil, fmt.Errorf("expected list, got %T", base)
+	}
 }
 
 func appendComposeNetwork(base interface{}, network string) (interface{}, error) {
@@ -3566,6 +3759,11 @@ func resolveServiceMetadata(podDir string, p *pod.Pod, serviceName string, svc *
 		descriptors[serviceName] = descriptor
 		return "", nil, descriptor, nil
 	}
+	if serviceName == conversationWallServiceName && p != nil && p.Services[conversationWallServiceName] != nil {
+		descriptor := builtinClawWallDescriptor()
+		descriptors[serviceName] = descriptor
+		return strings.TrimSpace(svc.Image), infos[serviceName], descriptor, nil
+	}
 
 	if descriptorPath := explicitDescribeFile(podDir, svc); descriptorPath != "" {
 		descriptor, err := loadDescriptorFromFile(descriptorPath)
@@ -3889,6 +4087,9 @@ func collectServiceDescriptors(podDir string, p *pod.Pod, imageRefs map[string]s
 	if p.ClawAPI != nil {
 		descriptors["claw-api"] = builtinClawAPIDescriptor()
 	}
+	if p.Services[conversationWallServiceName] != nil {
+		descriptors[conversationWallServiceName] = builtinClawWallDescriptor()
+	}
 
 	serviceNames := make([]string, 0, len(p.Services))
 	for name := range p.Services {
@@ -4030,6 +4231,86 @@ func builtinClawAPIDescriptor() *describe.ServiceDescriptor {
 		Auth: &describe.AuthDescriptor{
 			Type: "bearer",
 			Env:  "CLAW_API_TOKEN",
+		},
+	}
+}
+
+func builtinClawWallDescriptor() *describe.ServiceDescriptor {
+	return &describe.ServiceDescriptor{
+		Version:     2,
+		Description: "Conversation wall channel context, awareness, and retrieval for Discord-backed surfaces.",
+		Auth: &describe.AuthDescriptor{
+			Type: "bearer",
+			Env:  conversationWallToolTokenEnv,
+		},
+		Tools: []describe.ToolDescriptor{
+			{
+				Name:        "search_channel_context",
+				Description: "Search this agent's recent channel buffer for messages matching a query.",
+				InputSchema: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"channels": map[string]interface{}{
+							"type":  "array",
+							"items": map[string]interface{}{"type": "string"},
+						},
+						"query": map[string]interface{}{
+							"type": "string",
+						},
+						"since": map[string]interface{}{
+							"type":    "string",
+							"default": "24h",
+						},
+						"author": map[string]interface{}{
+							"type": "string",
+						},
+						"limit": map[string]interface{}{
+							"type":    "integer",
+							"default": 20,
+						},
+					},
+					"required": []interface{}{"channels", "query"},
+				},
+				HTTP: &describe.ToolHTTP{
+					Method: http.MethodPost,
+					Path:   "/search_channel_context",
+				},
+			},
+			{
+				Name:        "get_channel_messages",
+				Description: "Fetch exact channel messages by message ID, ID range, or author/time window.",
+				InputSchema: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"channels": map[string]interface{}{
+							"type":  "array",
+							"items": map[string]interface{}{"type": "string"},
+						},
+						"message_ids": map[string]interface{}{
+							"type":  "array",
+							"items": map[string]interface{}{"type": "string"},
+						},
+						"after": map[string]interface{}{
+							"type": "string",
+						},
+						"before": map[string]interface{}{
+							"type": "string",
+						},
+						"author": map[string]interface{}{
+							"type": "string",
+						},
+						"limit": map[string]interface{}{
+							"type":    "integer",
+							"default": 20,
+						},
+					},
+					"required": []interface{}{"channels"},
+				},
+				HTTP: &describe.ToolHTTP{
+					Method: http.MethodPost,
+					Path:   "/get_channel_messages",
+				},
+			},
 		},
 	}
 }

--- a/cmd/claw/compose_up_test.go
+++ b/cmd/claw/compose_up_test.go
@@ -3852,6 +3852,17 @@ func testConversationWallService(token string, channelIDs ...string) *pod.Servic
 	}
 }
 
+func testFeedByName(t *testing.T, feeds []pod.FeedEntry, name string) pod.FeedEntry {
+	t.Helper()
+	for _, feed := range feeds {
+		if feed.Name == name {
+			return feed
+		}
+	}
+	t.Fatalf("expected feed %q, got %+v", name, feeds)
+	return pod.FeedEntry{}
+}
+
 func TestInjectConversationWallAddsServiceAndFeed(t *testing.T) {
 	t.Setenv("CLAW_WALL_POLL_INTERVAL", "")
 
@@ -3896,14 +3907,26 @@ func TestInjectConversationWallAddsServiceAndFeed(t *testing.T) {
 	}
 
 	traderFeeds := p.Services["trader"].Claw.Feeds
-	if len(traderFeeds) != 1 {
-		t.Fatalf("expected one injected wall feed, got %+v", traderFeeds)
+	if len(traderFeeds) != 2 {
+		t.Fatalf("expected awareness and cursor wall feeds, got %+v", traderFeeds)
 	}
-	if traderFeeds[0].Source != conversationWallServiceName {
-		t.Fatalf("expected claw-wall feed source, got %+v", traderFeeds[0])
+	awarenessFeed := testFeedByName(t, traderFeeds, conversationWallAwarenessName)
+	if awarenessFeed.Source != conversationWallServiceName {
+		t.Fatalf("expected claw-wall awareness source, got %+v", awarenessFeed)
 	}
-	if traderFeeds[0].Path != "/channel-context?consumer={claw_id}&channels=chan-1,chan-2&mode=tail&since=24h&limit=40&max_chars=8192" {
-		t.Fatalf("unexpected wall feed path: %q", traderFeeds[0].Path)
+	if awarenessFeed.Path != "/channel-awareness?channels=chan-1,chan-2&since=24h&limit=60&max_chars=8192&context_kind=raw_window" {
+		t.Fatalf("unexpected awareness feed path: %q", awarenessFeed.Path)
+	}
+	contextFeed := testFeedByName(t, traderFeeds, conversationWallFeedName)
+	if contextFeed.Source != conversationWallServiceName {
+		t.Fatalf("expected claw-wall context source, got %+v", contextFeed)
+	}
+	if contextFeed.Path != "/channel-context?consumer={claw_id}&channels=chan-1,chan-2&mode=tail&since=24h&limit=40&max_chars=8192" {
+		t.Fatalf("unexpected wall feed path: %q", contextFeed.Path)
+	}
+	traderTools := p.Services["trader"].Claw.Tools
+	if len(traderTools) != 1 || traderTools[0].Service != conversationWallServiceName || !slices.Equal(traderTools[0].Allow, []string{"search_channel_context", "get_channel_messages"}) {
+		t.Fatalf("expected claw-wall retrieval tool policy, got %+v", traderTools)
 	}
 	if len(p.Services["observer"].Claw.Feeds) != 0 {
 		t.Fatalf("expected no wall feed for non-cllama service, got %+v", p.Services["observer"].Claw.Feeds)
@@ -3945,24 +3968,169 @@ func TestInjectConversationWallHonorsChannelContextConfig(t *testing.T) {
 	}
 
 	traderFeeds := p.Services["trader"].Claw.Feeds
-	if len(traderFeeds) != 1 {
+	if len(traderFeeds) != 2 {
 		t.Fatalf("expected trader feed, got %+v", traderFeeds)
 	}
-	if traderFeeds[0].Path != "/channel-context?consumer={claw_id}&channels=chan-1&mode=tail&since=6h&limit=25&max_chars=4096" {
-		t.Fatalf("unexpected trader feed path: %q", traderFeeds[0].Path)
+	traderAwareness := testFeedByName(t, traderFeeds, conversationWallAwarenessName)
+	if traderAwareness.Path != "/channel-awareness?channels=chan-1&since=24h&limit=60&max_chars=8192&context_kind=raw_window" {
+		t.Fatalf("unexpected trader awareness path: %q", traderAwareness.Path)
+	}
+	traderContext := testFeedByName(t, traderFeeds, conversationWallFeedName)
+	if traderContext.Path != "/channel-context?consumer={claw_id}&channels=chan-1&mode=tail&since=6h&limit=25&max_chars=4096" {
+		t.Fatalf("unexpected trader feed path: %q", traderContext.Path)
 	}
 
 	scoutFeeds := p.Services["scout"].Claw.Feeds
-	if len(scoutFeeds) != 1 {
+	if len(scoutFeeds) != 2 {
 		t.Fatalf("expected scout feed, got %+v", scoutFeeds)
 	}
-	if scoutFeeds[0].Path != "/channel-context?consumer={claw_id}&channels=chan-1&mode=tail&since=30m&limit=8&max_chars=1024" {
-		t.Fatalf("unexpected scout feed path: %q", scoutFeeds[0].Path)
+	scoutAwareness := testFeedByName(t, scoutFeeds, conversationWallAwarenessName)
+	if scoutAwareness.Path != "/channel-awareness?channels=chan-1&since=24h&limit=60&max_chars=8192&context_kind=raw_window" {
+		t.Fatalf("unexpected scout awareness path: %q", scoutAwareness.Path)
+	}
+	scoutContext := testFeedByName(t, scoutFeeds, conversationWallFeedName)
+	if scoutContext.Path != "/channel-context?consumer={claw_id}&channels=chan-1&mode=tail&since=30m&limit=8&max_chars=1024" {
+		t.Fatalf("unexpected scout feed path: %q", scoutContext.Path)
 	}
 
 	wall := p.Services[conversationWallServiceName]
 	if wall.Environment["CLAW_WALL_LIMIT"] != "700" {
 		t.Fatalf("expected wall buffer to use max service buffer, got %q", wall.Environment["CLAW_WALL_LIMIT"])
+	}
+}
+
+func TestPrepareConversationWallRuntimeWritesAllowlistAndServiceAuth(t *testing.T) {
+	runtimeDir := t.TempDir()
+	p := &pod.Pod{
+		Services: map[string]*pod.Service{
+			conversationWallServiceName: {
+				Image:       resolveConversationWallImageRef(),
+				Environment: map[string]string{},
+			},
+			"trader": testConversationWallService("${TRADER_DISCORD_BOT_TOKEN}", "chan-2", "chan-1"),
+		},
+	}
+	resolvedClaws := map[string]*driver.ResolvedClaw{
+		"trader": {ServiceName: "trader", Cllama: []string{"passthrough"}, Count: 2},
+	}
+
+	auth, allowlists, err := prepareConversationWallRuntime(runtimeDir, p, resolvedClaws)
+	if err != nil {
+		t.Fatalf("prepareConversationWallRuntime: %v", err)
+	}
+	if !slices.Equal(allowlists["trader-0"], []string{"chan-1", "chan-2"}) || !slices.Equal(allowlists["trader-1"], []string{"chan-1", "chan-2"}) {
+		t.Fatalf("unexpected allowlists: %+v", allowlists)
+	}
+	if auth["trader-0"].Service != conversationWallServiceName || auth["trader-0"].Token == "" || auth["trader-1"].Token != auth["trader-0"].Token {
+		t.Fatalf("unexpected service auth: %+v", auth)
+	}
+
+	wall := p.Services[conversationWallServiceName]
+	if wall.Environment[conversationWallToolTokenEnv] != auth["trader-0"].Token {
+		t.Fatalf("expected wall tool token to match service auth")
+	}
+	if wall.Environment["CLAW_WALL_AGENT_CHANNELS_SHA"] == "" {
+		t.Fatal("expected allowlist sha env")
+	}
+	volumes, ok := wall.Compose["volumes"].([]string)
+	if !ok || len(volumes) != 1 || !strings.HasSuffix(volumes[0], ":"+conversationWallAllowlistPath+":ro") {
+		t.Fatalf("unexpected claw-wall volumes: %#v", wall.Compose["volumes"])
+	}
+
+	raw, err := os.ReadFile(filepath.Join(runtimeDir, "claw-wall-agent-channels.json"))
+	if err != nil {
+		t.Fatalf("read allowlist: %v", err)
+	}
+	var manifest conversationWallAllowlistFile
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		t.Fatalf("parse allowlist: %v", err)
+	}
+	if manifest.Version != 1 || !slices.Equal(manifest.Agents["trader-0"], []string{"chan-1", "chan-2"}) {
+		t.Fatalf("unexpected allowlist manifest: %+v", manifest)
+	}
+}
+
+func TestComposeMaterializesAutoRegisteredToolsForChannelConsumers(t *testing.T) {
+	p := &pod.Pod{
+		Services: map[string]*pod.Service{
+			"observer": testConversationWallService("${OBSERVER_DISCORD_BOT_TOKEN}", "chan-2"),
+			"trader":   testConversationWallService("${TRADER_DISCORD_BOT_TOKEN}", "chan-1"),
+		},
+	}
+	resolvedClaws := map[string]*driver.ResolvedClaw{
+		"observer": {ServiceName: "observer"},
+		"trader":   {ServiceName: "trader", Cllama: []string{"passthrough"}},
+	}
+	if err := injectConversationWall(p, resolvedClaws); err != nil {
+		t.Fatalf("injectConversationWall: %v", err)
+	}
+
+	descriptors := map[string]*describe.ServiceDescriptor{
+		conversationWallServiceName: builtinClawWallDescriptor(),
+	}
+	registry, err := describe.BuildToolRegistry(descriptors)
+	if err != nil {
+		t.Fatalf("BuildToolRegistry: %v", err)
+	}
+	resolvedTools, err := resolveToolSubscriptions(p, registry)
+	if err != nil {
+		t.Fatalf("resolveToolSubscriptions: %v", err)
+	}
+	if len(resolvedTools["observer"]) != 0 {
+		t.Fatalf("expected no observer tools, got %+v", resolvedTools["observer"])
+	}
+	if len(resolvedTools["trader"]) != 2 {
+		t.Fatalf("expected two trader tools, got %+v", resolvedTools["trader"])
+	}
+}
+
+func TestToolsJSONCarriesClawWallBearerWithoutLeakingEnv(t *testing.T) {
+	p := &pod.Pod{
+		Services: map[string]*pod.Service{
+			"trader": testConversationWallService("${TRADER_DISCORD_BOT_TOKEN}", "chan-1"),
+		},
+	}
+	resolvedClaws := map[string]*driver.ResolvedClaw{
+		"trader": {ServiceName: "trader", Cllama: []string{"passthrough"}},
+	}
+	if err := injectConversationWall(p, resolvedClaws); err != nil {
+		t.Fatalf("injectConversationWall: %v", err)
+	}
+	auth, _, err := prepareConversationWallRuntime(t.TempDir(), p, resolvedClaws)
+	if err != nil {
+		t.Fatalf("prepareConversationWallRuntime: %v", err)
+	}
+	descriptors := map[string]*describe.ServiceDescriptor{
+		conversationWallServiceName: builtinClawWallDescriptor(),
+	}
+	registry, err := describe.BuildToolRegistry(descriptors)
+	if err != nil {
+		t.Fatalf("BuildToolRegistry: %v", err)
+	}
+	resolvedTools, err := resolveToolSubscriptions(p, registry)
+	if err != nil {
+		t.Fatalf("resolveToolSubscriptions: %v", err)
+	}
+	tools, err := buildToolManifestEntries(p, descriptors, nil, "trader", resolvedTools["trader"], lookupServiceAuth(auth, "trader"))
+	if err != nil {
+		t.Fatalf("buildToolManifestEntries: %v", err)
+	}
+	if len(tools) != 2 {
+		t.Fatalf("expected two tool manifest entries, got %+v", tools)
+	}
+	for _, tool := range tools {
+		if tool.Execution.Service != conversationWallServiceName || tool.Execution.BaseURL != "http://claw-wall:8080" {
+			t.Fatalf("unexpected claw-wall execution metadata: %+v", tool)
+		}
+		if tool.Execution.Auth == nil || tool.Execution.Auth.Type != "bearer" || tool.Execution.Auth.Token == "" {
+			t.Fatalf("expected projected bearer auth in tools.json entry: %+v", tool)
+		}
+		if tool.Execution.Auth.Token != p.Services[conversationWallServiceName].Environment[conversationWallToolTokenEnv] {
+			t.Fatalf("expected tools.json token to match claw-wall service token")
+		}
+	}
+	if _, leaked := p.Services["trader"].Environment[conversationWallToolTokenEnv]; leaked {
+		t.Fatalf("consumer env leaked %s", conversationWallToolTokenEnv)
 	}
 }
 

--- a/docs/plans/2026-05-12-issue-232-channel-24h-awareness.md
+++ b/docs/plans/2026-05-12-issue-232-channel-24h-awareness.md
@@ -5,6 +5,7 @@
 **Revision history:**
 - 2026-05-12 r1 — initial draft.
 - 2026-05-12 r2 — codex (`codex:27f8b72e`) r1 adversarial pass; folded in: (1) header rewrite now targets the real after-bound tail path (kind discriminator keyed on `after=` presence, not on `mode=delta` — which is no longer the default per #201); (2) explicit tool ACL/auto-subscription via compose-materialized per-agent channel allowlist; (3) v2 producer model clarified — `claw-channel-memory` emits the channel-awareness wire surface and may use #164 internals, but channel events do **not** flow through ADR-021's `/recall` in any phase; (4) v1 default flipped from opt-in to default-on with smaller per-Discord-channel caps, and #232 explicitly stays open through v2 since v1 is not acceptance-complete; (5) feed ordering enforced via compose-emitted manifest order with regression test; (6) retrieval out-of-buffer semantics spelled out (structured `not_in_buffer` response with retained-coverage range).
+- 2026-05-12 r3 — codex r2 adversarial pass; folded in: (a) auth model rewritten — claw-wall does **not** validate bearer auth on `/channel-context`; feeds remain generated-URL-only on the compose network; tools are strictly cllama-mediated with cllama validating agent identity + per-agent channel allowlist before forwarding to claw-wall (claw-wall enforces defense-in-depth via a service token + `X-Claw-ID` header); (b) tool auto-registration spelled out — compose-up emits a synthetic `claw.describe` v2 descriptor on the auto-injected claw-wall service that routes through the existing extraction path; (c) #220 epoch-bootstrap path gets its own `kind=bootstrap_tail` via a cllama-passed `context_kind=` URL hint; (d) ACL allowlist switched from env-var to a mounted JSON config file (`claw-wall-agent-channels.json`); claw-wall recreates on config change, no hot reload in v1; (e) `channel_context_op` telemetry spec'd explicitly for both feed and tool paths; (f) stale text scrubbed (§4.1 caps, §6 ">120 messages" wording, §7.5 spike vs integration, §4.1 "mode=delta header rewrite" residue).
 
 **Issue:** https://github.com/mostlydev/clawdapus/issues/232
 
@@ -50,13 +51,14 @@ The v1 channel-awareness block is **not** rebranded as "the 24h fix". The plan e
 ### 4.1 New feed: `channel-awareness` (v1, producer = claw-wall)
 
 ```
-GET /channel-awareness?channels=<csv>&since=24h&limit=120&max_chars=12288
+GET /channel-awareness?channels=<csv>&since=24h&limit=60&max_chars=8192&context_kind=raw_window
 ```
 
 - **No cursor**. No `consumer=` param. No `mode=delta` path. This feed exists precisely to be cursor-independent.
 - Same channel-authorization model as `channel-context` (caller is upstream-restricted to surface-derived channels), PLUS the per-agent ACL of §4.2.1 (the same allowlist guards both feed and tool paths).
 - Reuses `consumeTail` semantics from #201 (newest-first walk, dual cap, sort ASC for output) but rebranded.
 - v1 defaults (r2): `since=24h`, `limit=60`, `max_chars=8192` (8KB, aligned with cllama's `MaxFeedResponseBytes` so we don't double-truncate). Operator-tunable via `x-claw.context.channel-awareness` (parallel of #201's `x-claw.context.channel`).
+- Generated URL example: `/channel-awareness?channels=14645…,14647…&since=24h&limit=60&max_chars=8192&context_kind=raw_window`.
 - Header line is explicit about layer kind, exactly so the model cannot conflate it with a delta:
 
 ```
@@ -65,7 +67,7 @@ GET /channel-awareness?channels=<csv>&since=24h&limit=120&max_chars=12288
 
 `digest=unavailable` in v1 documents the known gap. In v2 the same feed emits `digest=ready` and a digest section is appended below the raw window.
 
-`channel-context` (the existing delta feed) keeps its `mode=tail` and `mode=delta` headers from #201 verbatim — but #232 lands a **header rewrite** on the `mode=delta` path so it stops claiming `[channel-context]` and instead reads `[channel-context delta] kind=delta`. See §4.4.
+`channel-context` (the existing delta feed) keeps its `mode=tail` request shape from #201 verbatim. #232 lands a **header rewrite** keyed on cllama's per-fetch `context_kind=` URL hint (or, as a fallback, the presence of `after=`). See §4.4 for the full kind matrix including the `#220` epoch-bootstrap path.
 
 ### 4.2 New tools: retrieval (v1, producer = claw-wall, ADR-020 managed)
 
@@ -93,33 +95,71 @@ tools:
     http: { path: /get_channel_messages }
 ```
 
-Both are **mediated** by cllama (ADR-020) so policy/telemetry/auth flow through the standard plane.
+Both are **mediated** by cllama (ADR-020). Mediation is what makes the auth model work — see §4.2.1.
 
-#### 4.2.1 Per-agent channel ACL (codex r1 must-fix)
+#### 4.2.1 Auth and per-agent channel ACL (codex r1+r2 must-fix)
 
-Today's `claw-wall` (`cmd/claw-wall/store.go`, `newHandler`) accepts `channels=` from any caller — auto-generated feed URLs are safe only because compose-up writes surface-derived channel IDs into the URL. Model-supplied tool arguments are **not** safe by construction: an agent could call `search_channel_context(channels=["<other-channel-id>"])` and read a room it has no surface to.
+**Current state (must not be misrepresented):** `claw-wall` today does **not** validate bearer auth on `/channel-context`. Auto-generated feed URLs are safe only because (a) `claw-wall` is reachable only on the compose Docker network, and (b) compose-up writes surface-derived channel IDs into the URL, so the request itself names exactly what the agent legitimately has access to. There is no token check.
 
-Compose-up materializes a per-agent allowlist at `claw up` time and writes it into the `claw-wall` service config alongside `CLAW_WALL_TOKENS`:
+**v1 contract:**
 
+| Endpoint | Caller | Auth on claw-wall | Channel ACL site |
+|----------|--------|-------------------|------------------|
+| `/channel-context` (delta feed) | cllama fetcher with generated URL | none (network-scoped trust) | URL is single-writer compose-emitted |
+| `/channel-awareness` (raw window feed) | cllama fetcher with generated URL | none (network-scoped trust) | URL is single-writer compose-emitted |
+| `/search_channel_context` (tool) | cllama-mediated, agent on model side | service token (Bearer) + `X-Claw-ID` header (the validated agent) | cllama enforces; claw-wall re-checks (defense-in-depth) |
+| `/get_channel_messages` (tool) | cllama-mediated, agent on model side | service token (Bearer) + `X-Claw-ID` header | cllama enforces; claw-wall re-checks |
+
+The model never speaks to claw-wall directly. Tool calls go: model → cllama validates agent bearer (existing per-agent token from ADR-015 / claw-api auth pattern) → cllama checks per-agent channel allowlist → cllama forwards to claw-wall with the claw-wall service token + `X-Claw-ID: <agentID>` → claw-wall validates service token, re-checks `X-Claw-ID` against its mounted allowlist, runs the query.
+
+**Where the allowlist lives:** compose-up materializes a single JSON config at `claw up` time (codex r2: prefer file over env var) and mounts it read-only into `claw-wall`:
+
+```json
+// claw-wall-agent-channels.json (mounted at /etc/claw-wall/agent-channels.json)
+{
+  "version": 1,
+  "agents": {
+    "boulton-0": ["1464509330731696213", "1464796137893662843"],
+    "logan-0":   ["1464509330731696213"]
+  }
+}
 ```
-CLAW_WALL_AGENT_CHANNELS=<agentID>:<chA>,<chB>;<agentID2>:<chC>,...
-```
 
-`agentID` is the bearer-authenticated principal (already validated by claw-wall for the feed path; same path used for tool path). The allowlist is exactly the surface-derived channel set used to materialize that agent's `channel-context` and `channel-awareness` feed URLs — i.e., what the agent already legitimately has access to.
+The same allowlist is also projected into each agent's cllama context dir (`channels-allowlist.json`) so cllama can pre-check before forwarding. Two-lock model: cllama is the primary gate (correctness), claw-wall is the defense-in-depth (containment if cllama is bypassed or misconfigured).
 
-Tool request handler:
-1. Authenticate caller → `agentID` (existing Bearer validation; tools share auth with feeds).
-2. Parse requested `channels[]`.
-3. Reject any channel not in `allowlist[agentID]` with HTTP 403 and a structured `{"error": "channel_not_allowed", "agent": "...", "channel": "..."}` body. cllama surfaces this as a tool-call error to the model with a short hint ("This agent has no surface to channel X; ask the operator to add it.").
-4. Pass through to store with the validated channel set.
+**No hot reload in v1** (codex r2): claw-wall reads the file at startup. `claw up` recreates the claw-wall container when the generated config changes (compose detects the file-mount diff). Operators who add a channel surface mid-life must `claw up` to re-materialize.
 
-The same allowlist guards both new tool endpoints and is checked once per request.
+**claw-wall service token:** compose-up generates a per-pod service token at `claw up` time (same pattern as the `claw-api` token from #44/`x-claw.master`). The token is mounted into cllama's per-agent context as part of the tool's auth descriptor (existing ADR-020 path) and into claw-wall's env as `CLAW_WALL_TOOL_TOKEN`. claw-wall validates incoming tool requests have `Authorization: Bearer <CLAW_WALL_TOOL_TOKEN>`; without it, 401.
 
-#### 4.2.2 Auto-subscription
+**Tool request handler order:**
+1. Validate `Authorization` header against `CLAW_WALL_TOOL_TOKEN`. Miss → 401 `{"error":"unauthenticated"}`.
+2. Read `X-Claw-ID: <agentID>` header. Miss → 400 `{"error":"missing_agent_id"}`.
+3. Confirm `agentID` exists in `agents` map of the mounted JSON. Miss → 403 `{"error":"unknown_agent"}`.
+4. Parse requested `channels[]` from body.
+5. Reject any channel not in `agents[agentID]` → 403 `{"error":"channel_not_allowed", "agent":"...", "channel":"..."}`.
+6. Pass to store with validated channel set.
 
-Both tools are auto-registered for any service whose `x-claw` consumes channel surfaces (i.e., the same condition that auto-injects `claw-wall`). No separate pod knob. Rationale: if the agent has channel surfaces declared, it already needs the tools to recover from cursor/buffer-bound gaps. Forcing operators to opt-in twice (channel surface + retrieval tool) is friction without value.
+cllama surfaces the 403 case to the model with a short hint ("This agent has no surface to channel X; ask the operator to add it.").
 
-#### 4.2.3 Out-of-buffer semantics (codex r1 must-fix)
+#### 4.2.2 Tool auto-registration (codex r2 must-fix)
+
+Auto-injected `claw-wall` is not a user-declared `x-claw` provider, so the existing descriptor extraction path needs an explicit hook. The mechanism:
+
+1. compose-up generates the `claw-wall` service as today (including image, env, healthcheck).
+2. compose-up additionally writes a **synthetic `claw.describe` v2 descriptor** to the runtime artifact dir (`.claw-runtime/describe/claw-wall.json`) declaring the two tool entries with their HTTP paths and `auth: {type: bearer, env: CLAW_WALL_TOOL_TOKEN}`.
+3. compose-up adds a label to the claw-wall service: `claw.describe.path=/etc/claw-wall/describe.json`, and bind-mounts the synthetic descriptor file at that path. This routes auto-injected claw-wall through the existing `internal/describe/` extraction code path without a new code branch — the descriptor extractor reads from image labels OR from the filesystem-fallback path that already exists for build-context descriptors.
+4. The normal compile pipeline (`internal/describe/registry.go`) projects the two tool entries into the `tools.json` of each agent whose `x-claw` consumes a channel surface (the same auto-subscription trigger that injects `claw-wall` itself).
+5. Per-agent `tools.json` gets the standard ADR-020 mediated tool entry shape, with `http.base_url=http://claw-wall:8080`, `http.path=/search_channel_context` (or `/get_channel_messages`), and `auth.token=<service-token-value>`.
+
+This means **no new code in the describe extractor or tool-manifest compiler** — we use the existing label + filesystem-fallback path, and the new code is confined to compose-up (synthetic descriptor emission) and claw-wall (the two new HTTP handlers + auth).
+
+Regression test (§7.3 `TestComposeMaterializesAutoRegisteredToolsForChannelConsumers`): a pod with two agents — one consuming a Discord channel surface, one not — produces `tools.json` for the first agent containing both `search_channel_context` and `get_channel_messages` entries with the correct base URL and bearer token; the second agent's `tools.json` contains neither.
+
+#### 4.2.3 Auto-subscription trigger
+
+Tools are auto-registered for any service whose `x-claw` consumes channel surfaces (i.e., the same condition that auto-injects `claw-wall`). No separate pod knob. Rationale: if the agent has channel surfaces declared, it already needs the tools to recover from cursor/buffer-bound gaps. Forcing operators to opt-in twice (channel surface + retrieval tool) is friction without value.
+
+#### 4.2.4 Out-of-buffer semantics (codex r1 must-fix)
 
 claw-wall can only search/return messages currently in its in-process ring buffer (size from `CLAW_WALL_LIMIT`, default 50, configurable up to operator-set ceiling). When a query falls outside that window — either by `since` reach or by `message_ids` referring to evicted ids — the response is structured:
 
@@ -165,29 +205,65 @@ cllama's `fetchFeeds` / `FormatAllFeeds` (`cllama/internal/feeds/inject.go`) ite
 
 Every channel-flavored block carries an explicit `kind=` field in its header. The implicit assumption "channel-context = full room" is the bug we are killing.
 
-**Important (codex r1 must-fix):** the discriminator is keyed on the **presence of an `after=` cursor in the fetch URL**, not on the legacy `mode=delta` query param. Since #201, the default `channel-context` fetch uses `mode=tail`, and cllama injects `after=` from its cursor ledger when one exists (see `cllama/internal/proxy/channel_context_feed.go::prepareChannelContextFeed`). The r1 plan's "rewrite mode=delta header" missed this — the real steady-state delta path is `mode=tail` with an `after=` injection, and that is the path the model actually sees and misreads.
+**Discriminator (codex r1+r2 must-fix):** the kind is **passed explicitly by cllama via a `context_kind=` URL query param**, not inferred from `after=` presence alone. r2 made the case: claw-wall cannot distinguish "first/cold tail" from "#220 epoch-bootstrap tail" from the URL alone — both arrive without `after=`, but the meanings differ (the bootstrap case means cllama *intentionally* suppressed a stored cursor due to an epoch change). cllama owns that distinction in `channelContextPrepareDecision` (`Bootstrapped`, `AppliedAfter`), so cllama stamps the URL accordingly.
 
-| Source URL pattern | Block kind | Header prefix | Notes |
-|--------------------|------------|---------------|-------|
-| `channel-context` with `after=` (steady-state, post-cursor) | `delta_tail` | `[channel-context delta] kind=delta_tail cursor=<ch>:<id>,...` | the headline rewrite; today emits `[channel-context]` with no kind |
-| `channel-context` without `after=` (epoch bootstrap, first turn, empty cursor map) | `tail` | `[channel-context] kind=tail` | one-shot bootstrap or legacy; the cllama-side decision struct (`channelContextPrepareDecision.AppliedAfter == false`) is the trigger |
-| `channel-awareness` (always uncursored) | `raw_window` | `[channel-awareness] kind=raw_window since=...` | v1 default |
-| `channel-awareness` v2 composite | `raw_window` + `digest` sections | `[channel-awareness] kind=raw_window+digest since=... digest_source_count=...` | v2 only; v1 emits `digest=unavailable` instead |
-| Tool response | `tool_call` | `[channel-tool] kind=tool_call name=... status=...` | retrieval tool output |
+cllama-side mapping (`cllama/internal/proxy/channel_context_feed.go::prepareChannelContextFeed`):
 
-The header rewrite is generated in claw-wall's response formatter (it already produces the `[channel-context] mode=tail …` line per #201 §4.3). claw-wall doesn't know whether cllama is injecting `after=` against it; but the `mode=tail`-with-`after=` URL parameter is visible to claw-wall on the request, so it can switch the header based on that signal directly. v2 of #204's `coverage_partial=true` annotation is preserved verbatim.
+| Decision state | Appended URL param |
+|----------------|--------------------|
+| `AppliedAfter == true` | `context_kind=delta_tail` (also keeps `after=`) |
+| `Bootstrapped == true` (epoch change suppressed cursor) | `context_kind=bootstrap_tail` |
+| neither (first turn, empty cursor, legacy) | `context_kind=tail` |
+
+For the new `channel-awareness` feed, compose-up writes `context_kind=raw_window` directly into the URL (no cllama logic needed; awareness is always raw_window in v1).
+
+claw-wall's response formatter reads `context_kind` and emits the corresponding header line. If the param is missing (older cllama against newer claw-wall), claw-wall falls back to `delta_tail` if `after=` is present, `tail` otherwise. The fallback is intentional for back-compat but never used by current cllama.
+
+| `context_kind` | Block kind | Header line |
+|----------------|------------|-------------|
+| `delta_tail` | `delta_tail` | `[channel-context delta] kind=delta_tail cursor=<ch>:<id>,...` |
+| `bootstrap_tail` | `bootstrap_tail` | `[channel-context bootstrap] kind=bootstrap_tail reason=epoch_changed` |
+| `tail` | `tail` | `[channel-context] kind=tail` |
+| `raw_window` | `raw_window` | `[channel-awareness] kind=raw_window since=...` |
+| `raw_window+digest` (v2) | composite | `[channel-awareness] kind=raw_window+digest since=... digest_source_count=...` |
+| (tool response) | `tool_call` | `[channel-tool] kind=tool_call name=... status=...` |
+
+v2 of #204's `coverage_partial=true` annotation is preserved verbatim across all kinds.
 
 **Back-compat note:** model prompts that contained the old `[channel-context]` header for delta will now see `[channel-context delta] kind=delta_tail` once v1 ships. This is the intended behavior — the old prefix was the bug. No tool/agent code parses this header; only the model reads it.
 
 ### 4.5 Telemetry (part 4 of contract)
 
-New normalized event kind: `channel_context_op` with fields `{kind, channels[], retained, returned, omitted, latency_ms, source, status}`. Emitted for:
-- every channel-awareness fetch (kind=raw_window)
-- every channel-context fetch — kind=delta_tail if `after=` was present, kind=tail otherwise — normalizes the existing claw-wall log line through cllama
-- every retrieval tool call (kind=tool_call) with `status` from §4.2.3 (`ok` / `empty` / `not_in_buffer`)
-- v2 digest production (kind=digest_built) and consumption (kind=digest)
+New normalized event kind: `channel_context_op` emitted on the cllama side (which already has the agent/pod identity and request context). It is **not** an existing event renamed — the audit/session-history paths today use distinct `feed_fetch` and `memory_op` events; tool calls flow through tool-trace normalization. r2 raised the concern that "fold into existing tool_call_result" assumed an event that doesn't exist. v1 lands `channel_context_op` as a new normalized record alongside `feed_fetch` and `memory_op`.
 
-`claw audit` surfaces this alongside `memory_op` and `feed_fetch`.
+Schema (cllama records, claw-api surfaces):
+
+```json
+{
+  "type": "channel_context_op",
+  "agent_id": "boulton-0",
+  "pod": "tiverton-house",
+  "kind": "raw_window | delta_tail | bootstrap_tail | tail | tool_call | digest_built | digest",
+  "channels": ["1464…", "1464…"],
+  "retained": 60,           // messages in claw-wall's window that matched
+  "returned": 47,           // after caps
+  "omitted": 13,            // retained - returned
+  "latency_ms": 24,
+  "source": "claw-wall",    // or "claw-channel-memory" in v2
+  "status": "ok | empty | not_in_buffer | error",
+  "tool_name": "search_channel_context"  // present only for kind=tool_call
+}
+```
+
+Emission sites:
+- every `channel-awareness` fetch → `kind=raw_window`
+- every `channel-context` fetch → `kind` mirrors the cllama-side `context_kind=` decision (`delta_tail` / `bootstrap_tail` / `tail`), so the audit view shows exactly which path served each turn
+- every retrieval tool call → `kind=tool_call`, `status` reflects the §4.2.4 enum, `tool_name` is the called tool
+- v2: digest production → `kind=digest_built`; digest injection → `kind=digest`
+
+The retrieval `status` is also embedded in the session-history tool-trace record (per r2: agents/audits that look at session history can see "the tool was called, it returned not_in_buffer" without re-correlating two streams). The cllama tool-trace shim writes `status` into the existing trace JSON alongside the request/response pair.
+
+`claw audit` surfaces `channel_context_op` alongside `memory_op` and `feed_fetch`.
 
 ## 5. Compose-up wiring
 
@@ -208,13 +284,19 @@ x-claw:
 
 Service-level overrides via the same pod-defaults pattern (`x-claw.context.channel-awareness` on individual services). There is **no** `enabled` knob — see §8; the feed is emitted automatically when the service consumes any channel surface, matching the auto-injection of `claw-wall` itself.
 
-`appendConversationWallFeed` (in `cmd/claw/compose_up.go`) gains a sibling `appendConversationWallAwarenessFeed` that emits `/channel-awareness?channels=...&since=...&limit=...&max_chars=...` whenever the service has any consumed channel IDs. Tool registration uses the existing claw-wall descriptor extraction path. A second emission writes `CLAW_WALL_AGENT_CHANNELS` into the auto-injected `claw-wall` service env, per §4.2.1.
+`appendConversationWallFeed` (in `cmd/claw/compose_up.go`) gains a sibling `appendConversationWallAwarenessFeed` that emits `/channel-awareness?channels=...&since=...&limit=...&max_chars=...&context_kind=raw_window` whenever the service has any consumed channel IDs. Three additional emissions:
+
+1. The synthetic `claw.describe` v2 descriptor at `.claw-runtime/describe/claw-wall.json` declaring the two retrieval tools (per §4.2.2). The claw-wall service gets a `claw.describe.path` label and a bind-mount for that file.
+2. The per-agent channel allowlist at `.claw-runtime/claw-wall-agent-channels.json` (per §4.2.1). Bind-mounted into claw-wall at `/etc/claw-wall/agent-channels.json`.
+3. The per-agent allowlist is also projected into each agent's cllama context dir as `channels-allowlist.json` so cllama can pre-check before forwarding tool calls.
+
+claw-wall reloads neither file at runtime in v1: a generated-config change triggers compose recreate-on-diff (Docker compose hashes mounted file content), so `claw up` after any pod edit gives claw-wall the fresh allowlist. No SIGHUP path needed.
 
 ## 6. Stopgap discipline (codex challenge #2)
 
 This plan **must not** ship as "the 24h fix" without phase 2. The framing in the PR body, the release note, and the on-call runbook reads:
 
-> v1 of #232 ships bounded raw-window awareness, retrieval tools, and metadata. **Busy rooms (>120 messages in 24h) will exceed the v1 dual cap.** When that happens, the agent will see the most recent N messages plus retrieved older ones on demand; full 24h compaction is delivered in v2 once #164's salience-memory adapter lands. The `digest=unavailable` header line documents this in-prompt so the model can decide whether to call retrieval.
+> v1 of #232 ships bounded raw-window awareness, retrieval tools, and metadata. **Busy rooms — >60 messages OR >8KB of message content in 24h — will exceed the v1 dual cap.** When that happens, the agent will see the most recent N messages plus retrieved older ones on demand; full 24h compaction is delivered in v2 once #164's salience-memory adapter lands. The `digest=unavailable` header line documents this in-prompt so the model can decide whether to call retrieval.
 
 The acceptance criterion in the issue body — "later Boulton turn still includes Logan's CMCSA read in the 24h awareness layer without requiring the human to restate it" — is **partially satisfied** in v1: Logan's read is reachable via retrieval (and likely also visible in the raw 24h window for a not-too-busy floor), but not guaranteed-injected. v2 closes the gap.
 
@@ -226,10 +308,17 @@ The acceptance criterion in the issue body — "later Boulton turn still include
 - `TestChannelAwarenessHandlerDualCap` — 200-message buffer, `limit=50&max_chars=…` → returns newest 50 sorted ASC, header shows `retained=50/...`.
 - `TestChannelAwarenessHandlerColdStart` — buffer holds 10 minutes worth → header reads `retained=N/buffer range=...` honest about coverage.
 - `TestChannelAwarenessHandlerDoesNotMutateCursor` — interleave with `channel-context` delta consumer; awareness fetch leaves delta cursor untouched.
-- `TestChannelContextHeaderRewriteByAfterPresence` — same handler, two requests: one with `after=…` query param emits `[channel-context delta] kind=delta_tail`; one without emits `[channel-context] kind=tail`. (codex r1 must-fix)
-- `TestPerAgentChannelACLAllowsListed` — `CLAW_WALL_AGENT_CHANNELS=A:ch1,ch2` + Bearer for A; tool request for `channels=[ch1]` → 200 with messages.
-- `TestPerAgentChannelACLRejectsUnlisted` — same env; tool request for `channels=[ch3]` → 403 with `{"error":"channel_not_allowed",...}`.
-- `TestRetrievalToolNotInBufferStatus` — buffer has 10min; tool query with `since=12h` returns `status=not_in_buffer` + `retained_coverage` shape per §4.2.3.
+- `TestChannelContextHeaderByContextKindParam` — three requests on the same handler with `context_kind=delta_tail` / `bootstrap_tail` / `tail` produce the three distinct header lines from §4.4. (codex r2 must-fix)
+- `TestChannelContextHeaderFallbackInfersFromAfter` — when `context_kind=` is missing, presence of `after=` yields `delta_tail`, absence yields `tail`. Back-compat for older cllama.
+- **Tool auth tests (codex r2 must-fix):**
+  - `TestToolRequestRejectsMissingBearer` — no Authorization header → 401.
+  - `TestToolRequestRejectsWrongServiceToken` — Bearer present but wrong value → 401.
+  - `TestToolRequestRejectsMissingClawID` — Bearer ok, no `X-Claw-ID` → 400.
+  - `TestToolRequestRejectsUnknownAgent` — Bearer ok, `X-Claw-ID` not in mounted allowlist → 403.
+  - `TestToolRequestRejectsDisallowedChannel` — Bearer ok, agent known, requested channel not in agent's allowlist → 403 with `{"error":"channel_not_allowed", ...}`.
+  - `TestToolRequestAcceptsAllowedAgentAndChannel` — full happy path → 200.
+- `TestToolRequestLoadsAllowlistFromMountedFile` — claw-wall reads `/etc/claw-wall/agent-channels.json` at startup; a malformed file produces a startup failure (fail-closed).
+- `TestRetrievalToolNotInBufferStatus` — buffer has 10min; tool query with `since=12h` returns `status=not_in_buffer` + `retained_coverage` shape per §4.2.4.
 - `TestRetrievalToolEmptyVsNotInBuffer` — distinguishes `status=empty` (in-buffer, no match) from `status=not_in_buffer` (out-of-buffer).
 - `TestGetChannelMessagesByIDRange` — fetch by id range returns exact messages, ordered, each carrying its snowflake id.
 
@@ -237,27 +326,45 @@ The acceptance criterion in the issue body — "later Boulton turn still include
 
 - `TestChannelAwarenessFeedIsFetchedWithoutCursor` — register a `channel-awareness` feed entry; assert URL has no `after=` and `X-Claw-Consumer-Session-Epoch` is **not** consulted for it (orthogonal to #220's epoch).
 - `TestChannelAwarenessAndDeltaCoExist` — pod wires both feeds; both blocks appear in the late-context section, in the §4.3 order, with their respective `kind=` headers.
-- `TestChannelContextHeaderRewriteFlowsThroughCllama` — claw-wall returns `[channel-context delta] kind=delta_tail` for an `after=`-bound fetch; cllama formats it into the late context without further mutation. (codex r1 must-fix)
-- `TestChannelContextOpTelemetryNormalized` — fetch each kind, assert `audit.go`-style normalized records for `kind=raw_window`, `kind=delta_tail`, `kind=tail`, `kind=tool_call`.
+- **`context_kind=` stamping tests (codex r2 must-fix):**
+  - `TestPrepareChannelContextStampsDeltaTail` — `AppliedAfter == true` → URL gains `context_kind=delta_tail`.
+  - `TestPrepareChannelContextStampsBootstrapTail` — `Bootstrapped == true` (epoch mismatch) → URL gains `context_kind=bootstrap_tail` and **no** `after=`.
+  - `TestPrepareChannelContextStampsTail` — neither (first turn, empty cursor) → URL gains `context_kind=tail`.
+- `TestChannelContextHeaderFlowsThroughCllama` — claw-wall returns `[channel-context delta] kind=delta_tail`; cllama formats into late context without mutation.
+- `TestToolMediationChecksChannelAllowlist` — cllama loads per-agent `channels-allowlist.json`; mediated tool call with disallowed channel is rejected by cllama before forwarding (returns a tool error to the model with hint per §4.2.1).
+- `TestToolMediationForwardsValidatedRequest` — happy path: cllama forwards with `Authorization: Bearer <CLAW_WALL_TOOL_TOKEN>` and `X-Claw-ID: <agent>`; mocked claw-wall sees both headers.
+- `TestChannelContextOpTelemetryNormalized` — fetch each kind, assert `audit.go`-style normalized records for `kind=raw_window`, `kind=delta_tail`, `kind=bootstrap_tail`, `kind=tail`, `kind=tool_call` with `status`.
 
 ### 7.3 compose_up (`cmd/claw/`)
 
 - `TestAppendChannelAwarenessFeedHonorsPodConfig` — pod-level `x-claw.context.channel-awareness` overrides flow into generated URL.
-- `TestChannelAwarenessFeedDefaultOnWithChannelSurface` — service consumes a Discord channel surface; pod has no explicit `channel-awareness` block; feed entry IS emitted with default `since=24h&limit=60&max_chars=8192`. (codex r1, default-on)
+- `TestChannelAwarenessFeedDefaultOnWithChannelSurface` — service consumes a Discord channel surface; pod has no explicit `channel-awareness` block; feed entry IS emitted with default `since=24h&limit=60&max_chars=8192&context_kind=raw_window`. (codex r1, default-on)
 - `TestChannelAwarenessFeedAbsentWithoutChannelSurface` — service has no channel surface; no awareness feed entry emitted.
 - `TestConversationWallFeedsEmittedInAwarenessBeforeDeltaOrder` — manifest-order regression: when both feeds are emitted, awareness appears before delta in the materialized `feeds.json`. (codex r1 must-fix §4.3.1)
-- `TestComposeMaterializesAgentChannelAllowlist` — when claw-wall is auto-injected, the service env contains `CLAW_WALL_AGENT_CHANNELS=<agentID>:<chA>,<chB>;...` reflecting each consuming agent's surface-derived channel set. (codex r1 must-fix §4.2.1)
-- `TestChannelAwarenessToolsRegisteredFromDescriptor` — claw-wall descriptor extraction picks up the two tool entries; tools auto-subscribe to any service with a channel surface (§4.2.2).
+- `TestComposeMaterializesAgentChannelAllowlistJSON` — when claw-wall is auto-injected, the runtime dir contains `claw-wall-agent-channels.json` with the per-agent allowlist, bind-mounted at `/etc/claw-wall/agent-channels.json`. (codex r2 must-fix §4.2.1)
+- `TestComposeProjectsAllowlistIntoCllamaContext` — each consuming agent's cllama context dir contains `channels-allowlist.json` mirroring the same surface-derived channels.
+- `TestComposeEmitsSyntheticClawWallDescriptor` — `.claw-runtime/describe/claw-wall.json` exists with the two tool entries; the claw-wall service has a `claw.describe.path` label pointing at the bind-mounted descriptor. (codex r2 must-fix §4.2.2)
+- `TestComposeMaterializesAutoRegisteredToolsForChannelConsumers` — pod with two agents (one channel-consuming, one not); the channel-consuming agent's `tools.json` contains both `search_channel_context` and `get_channel_messages` with `http.base_url=http://claw-wall:8080` and the service token in `auth.token`; the non-consumer's `tools.json` contains neither.
+- `TestComposeEmitsClawWallToolTokenEnv` — auto-injected claw-wall service env contains `CLAW_WALL_TOOL_TOKEN=<generated>`; the same value appears in the consuming agent's `tools.json` auth descriptor.
 
 ### 7.4 Pod parser (`internal/pod/`)
 
 - `TestParseChannelAwarenessConfig` — accepts `since` / `limit` / `max_chars`; rejects negatives; rejects unparseable durations. No `enabled` field (default-on).
 - `TestPodDefaultsChannelAwareness` — service-level overrides pod defaults using the standard pattern.
 
-### 7.5 Integration / spike
+### 7.5 Integration (no spike)
 
-- Extend `TestSpikeRollCall` (or a sibling spike) so that the rollcall pod's `channel-awareness` feed body contains a header-line `kind=raw_window` and matches the retained-coverage shape. The spike already exercises real LLM calls through cllama; this just asserts the new feed flows end-to-end.
-- A targeted fixture test reproduces the Tiverton case: pre-seed `claw-wall` buffer with messages spanning the cursor, run a turn that advances cursor past Logan's hypothetical CMCSA message, then run a second turn with a human-mention prompt and assert the `channel-awareness` block contains Logan's message even though the `channel-context` delta does not.
+Codex r1+r2: plain integration tests against a faked claw-wall are sufficient; spike-tag inflates CI cost and requires real provider credentials this scenario does not need.
+
+- `TestChannelAwarenessEndToEndAgainstFakeClawWall` (in `cmd/claw/` or `cllama/internal/proxy/`) — a real cllama instance fronting a faked claw-wall (httptest server). Pod wires both `channel-context` and `channel-awareness` feeds. Assert the cllama-produced upstream request contains both header lines (`kind=delta_tail` from delta, `kind=raw_window` from awareness) in the late-context block in the §4.3 order.
+- `TestTivertonReproductionFixture` (in `cmd/claw/` or as a fixture-driven harness test) — the issue-body scenario, fully reproducible without external services:
+  1. Pre-seed the fake claw-wall buffer with messages spanning a 24h window, including a "Logan CMCSA read" at T-2h.
+  2. Run cllama turn #1 with a routine prompt; the `channel-context` delta advances the cursor past Logan's message.
+  3. Run cllama turn #2 with a human-mention prompt ("wanna pick up CMCSA on Logan's read?").
+  4. Assert the upstream request for turn #2 contains the Logan message in the `[channel-awareness] kind=raw_window` block, even though the `[channel-context delta] kind=delta_tail` block has only post-cursor traffic.
+  5. Assert the per-agent allowlist enforcement: the same turn issuing a `search_channel_context(channels=["<other-channel>"])` tool call is rejected by cllama before forwarding.
+
+`TestSpikeRollCall` is **not** extended; it remains the live-Docker validation for cllama proxy enforcement and stays scoped to existing concerns.
 
 ## 8. Default behavior and ramp (revised r2)
 
@@ -311,23 +418,55 @@ The PR body explicitly says:
    - **Codex r1:** plain integration, fake claw-wall, no spike-tag.
    - **r2 resolution:** confirmed — §7.5 targeted reproduction is a normal integration test.
 
-## 10b. Open questions for codex r2 review
+## 10b. r2 open questions — codex answers and r3 resolution
 
-1. **Compose CLAW_WALL_AGENT_CHANNELS env shape.** §4.2.1 specifies `<agentID>:<chA>,<chB>;<agentID2>:...` as a single env var. Alternative: a separate small JSON file mounted into claw-wall (e.g., `claw-wall-agent-channels.json`) like the cllama memory.json pattern. Env-var keeps wiring simple but is shell-fragile for large pods; JSON is more idiomatic but adds a mount. Lean env-var for v1 because the value is small and pure ASCII.
-2. **Tool error rendering.** §4.2.3 specifies `status=not_in_buffer` with a `hint` field. Should cllama's tool-call telemetry record `status` separately from `error_class`, or fold it into the existing `tool_call_result` event? Lean separate so audits can filter "the model retrieved nothing" cases without parsing free-text hints.
-3. **digest=unavailable signaling.** v1 header always carries `digest=unavailable`. Should the model see this once at the top of `channel-awareness` or repeated in `channel-context delta` blocks too? Lean once (in awareness only) — repeating it in delta would invite the model to assume delta is the entire room when digest is unavailable, which is the original bug.
-4. **`claw-channel-memory` service naming and image location.** v2 introduces a new service. Live under `examples/channel-memory/` like `examples/reference-memory/`, or directly as `cmd/claw-channel-memory/` + published image? Lean `examples/` for v2 initial wave (operator-visible but not yet a published infra image), promote later. Matches #164's `examples/salience-memory/` pattern.
+1. **CLAW_WALL_AGENT_CHANNELS env shape.** r2 leaned env-var.
+   - **Codex r2:** prefer JSON config file mounted into claw-wall (less fragile, future reload/diagnostic friendly). No hot reload needed; `claw up` recreates claw-wall on config change.
+   - **r3 resolution:** switched to `claw-wall-agent-channels.json` bind-mounted at `/etc/claw-wall/agent-channels.json` (§4.2.1, §5). Also projected into cllama context as `channels-allowlist.json` for cllama-side pre-check.
 
-## 11. Build sequence (assuming codex r2 sign-off)
+2. **Tool error rendering.** r2 wanted `status` separate from generic tool_call_result.
+   - **Codex r2:** there is no existing `tool_call_result` event. Don't assume. Add explicit `channel_context_op` normalization for feed/tool ops; embed retrieval status in session-history tool-trace as structured data.
+   - **r3 resolution:** §4.5 rewritten — `channel_context_op` is a new normalized event alongside `feed_fetch`/`memory_op`; tool calls also write `status` into the session-history tool-trace record so audit reconstruction is single-stream.
 
-1. **claw-wall** — `channel-awareness` endpoint reusing `consumeTail`; per-agent channel ACL (§4.2.1) parsing `CLAW_WALL_AGENT_CHANNELS`; new tool handlers (`search_channel_context`, `get_channel_messages`) with `not_in_buffer` semantics (§4.2.3); descriptor declares tools. Tests in §7.1.
-2. **compose_up wiring** — `appendConversationWallAwarenessFeed`; pod parser for `x-claw.context.channel-awareness`; ACL allowlist materialization writes `CLAW_WALL_AGENT_CHANNELS` into the `claw-wall` service env; manifest-order discipline emits awareness before delta. Tests in §7.3, §7.4.
-3. **Header rewrite (claw-wall side)** — `channel-context` response formatter switches on `after=` presence to emit `[channel-context delta] kind=delta_tail` vs `[channel-context] kind=tail`. Tests in §7.1.
-4. **cllama feed plumbing** — feed name registry already supports per-feed configuration; the new feed flows through with `kind=raw_window` metadata parsing. Tests in §7.2.
-5. **Telemetry normalization** — `channel_context_op` event kind, `claw audit` rendering; `tool_call_result` status fold-in (or new field per §10b.2).
-6. **Docs sweep** — `docs/CLLAMA_SPEC.md`, ADR (likely new ADR-025 once codex agrees), `skills/clawdapus/SKILL.md` mirror.
-7. **Integration test** — Tiverton-reproduction fixture (§7.5).
-8. **PR body** explicitly labels phase 1 vs phase 2 per §6; does **not** close #232.
+3. **`digest=unavailable` signaling.** r2 leaned "once in awareness only".
+   - **Codex r2:** confirmed — once in `channel-awareness` header only; repeating in delta blocks would invite the bug we're killing.
+   - **r3 resolution:** header tables in §4.4 only carry `digest=unavailable` on the `raw_window` line. Delta/bootstrap/tail headers say nothing about digest.
+
+4. **`claw-channel-memory` service location.** r2 leaned `examples/`.
+   - **Codex r2:** start under `examples/channel-memory/` (or #164-aligned path); avoid published infra image and release pinning in phase 1.
+   - **r3 resolution:** §3 v2 row, §11 build sequence, and §12 non-goals all say `examples/channel-memory/`. No `release_manifest.go` entry; no ghcr.io publication in phase 1.
+
+## 10c. Open questions for codex r3 review
+
+1. **`context_kind=` URL hint vs request header.** §4.4 uses a URL query param (`context_kind=delta_tail` etc.) because it's the lowest-friction change at compose-up/cllama and survives cache-keys naturally. Alternative: an `X-Claw-Context-Kind` request header. Header is cleaner if the value should never affect upstream caching; query param is cleaner if claw-wall ever wants to log per-kind hit ratios via existing access-log infrastructure. Lean query param.
+2. **Defense-in-depth allowlist on feed paths.** §4.2.1 says feeds remain unauthenticated-on-compose-net. claw-wall could *additionally* check that `channels=` matches the agent's allowlist if it received `X-Claw-ID` on feed requests too — but feed requests don't carry `X-Claw-ID` today. Adding it would tighten the model but require cllama to send the header (small change). Lean "leave feeds as today" because the single-writer compose-URL invariant is already enforced; revisit if/when claw-wall ever gains a non-compose ingress.
+3. **`claw.describe.path` label semantics.** §4.2.2 uses this label to point at a bind-mounted descriptor file. Is the existing descriptor extractor (`internal/describe/registry.go`) actually wired for label-based path indirection, or does it only consume `claw.describe` as the JSON inline? If the latter, the alternative is to embed the descriptor JSON directly in the label value. Lean inline JSON to avoid filesystem indirection for a small descriptor.
+
+## 11. Build sequence (assuming codex r3 sign-off)
+
+1. **claw-wall** —
+   - `channel-awareness` endpoint reusing `consumeTail`.
+   - Mounted allowlist loader (`/etc/claw-wall/agent-channels.json`), fail-closed on parse error.
+   - Tool handlers `search_channel_context`, `get_channel_messages` with the §4.2.1 auth order (Bearer service token + `X-Claw-ID` + allowlist check) and §4.2.4 `not_in_buffer` semantics.
+   - Header rewrite keyed on `context_kind=` URL param (with `after=` fallback) per §4.4.
+   - Tests in §7.1.
+2. **compose_up wiring** —
+   - `appendConversationWallAwarenessFeed` emits awareness URL **before** the existing delta feed (manifest order).
+   - Pod parser for `x-claw.context.channel-awareness`.
+   - Per-agent allowlist materialization → `.claw-runtime/claw-wall-agent-channels.json`, bind-mounted into claw-wall + projected into cllama context as `channels-allowlist.json`.
+   - Generated `CLAW_WALL_TOOL_TOKEN` env on claw-wall; same value flowed into per-agent `tools.json` auth descriptor.
+   - Synthetic `claw.describe` v2 descriptor for claw-wall written to `.claw-runtime/describe/claw-wall.json`, with `claw.describe.path` label or inline JSON (§10c.3 pending).
+   - Tests in §7.3, §7.4.
+3. **cllama side** —
+   - `prepareChannelContextFeed` stamps `context_kind=` into the URL based on `channelContextPrepareDecision`.
+   - cllama tool-mediation enforces per-agent channel allowlist before forwarding (loads `channels-allowlist.json` from context).
+   - cllama tool mediator forwards `Authorization: Bearer <CLAW_WALL_TOOL_TOKEN>` + `X-Claw-ID` to claw-wall.
+   - Late-context injection unchanged (manifest order does the work).
+   - Tests in §7.2.
+4. **Telemetry normalization** — `channel_context_op` event kind, schema per §4.5, `claw audit` rendering; session-history tool-trace records `status`.
+5. **Docs sweep** — `docs/CLLAMA_SPEC.md`, new ADR-025 once codex agrees, `skills/clawdapus/SKILL.md` mirror.
+6. **Integration test** — Tiverton-reproduction fixture (§7.5), plain integration, no spike-tag.
+7. **PR body** explicitly labels phase 1 vs phase 2 per §6; does **not** close #232.
 
 ## 12. Non-goals for this PR (clean cut-line)
 

--- a/docs/plans/2026-05-12-issue-232-channel-24h-awareness.md
+++ b/docs/plans/2026-05-12-issue-232-channel-24h-awareness.md
@@ -1,562 +1,230 @@
-# Issue 232 — Bounded 24h channel awareness independent of cursors and restarts
-
-**Author (draft):** claude (`claude:dbaba2df`) on branch `issue-232-channel-24h-awareness` — for adversarial review by codex before any implementation.
-
-**Revision history:**
-- 2026-05-12 r1 — initial draft.
-- 2026-05-12 r2 — codex (`codex:27f8b72e`) r1 adversarial pass; folded in: (1) header rewrite now targets the real after-bound tail path (kind discriminator keyed on `after=` presence, not on `mode=delta` — which is no longer the default per #201); (2) explicit tool ACL/auto-subscription via compose-materialized per-agent channel allowlist; (3) v2 producer model clarified — `claw-channel-memory` emits the channel-awareness wire surface and may use #164 internals, but channel events do **not** flow through ADR-021's `/recall` in any phase; (4) v1 default flipped from opt-in to default-on with smaller per-Discord-channel caps, and #232 explicitly stays open through v2 since v1 is not acceptance-complete; (5) feed ordering enforced via compose-emitted manifest order with regression test; (6) retrieval out-of-buffer semantics spelled out (structured `not_in_buffer` response with retained-coverage range).
-- 2026-05-12 r3 — codex r2 adversarial pass; folded in: (a) auth model rewritten — claw-wall does **not** validate bearer auth on `/channel-context`; feeds remain generated-URL-only on the compose network; tools are strictly cllama-mediated with cllama validating agent identity + per-agent channel allowlist before forwarding to claw-wall (claw-wall enforces defense-in-depth via a service token + `X-Claw-ID` header); (b) tool auto-registration spelled out — compose-up emits a synthetic `claw.describe` v2 descriptor on the auto-injected claw-wall service that routes through the existing extraction path; (c) #220 epoch-bootstrap path gets its own `kind=bootstrap_tail` via a cllama-passed `context_kind=` URL hint; (d) ACL allowlist switched from env-var to a mounted JSON config file (`claw-wall-agent-channels.json`); claw-wall recreates on config change, no hot reload in v1; (e) `channel_context_op` telemetry spec'd explicitly for both feed and tool paths; (f) stale text scrubbed (§4.1 caps, §6 ">120 messages" wording, §7.5 spike vs integration, §4.1 "mode=delta header rewrite" residue).
-- 2026-05-12 r4 — codex r3 adversarial pass; folded in: (i) descriptor mechanism switched to **built-in compiler-owned descriptor** (`builtinClawWallDescriptor()`, sibling of `builtinClawAPIDescriptor()`) because `internal/inspect.ParseLabels` only knows `claw.describe` and treats the value as a build-context file path — neither inline JSON nor runtime bind-mount works at compile time; (ii) tool auto-subscription mechanism corrected — `injectConversationWall` appends a synthetic `tools: [{service: claw-wall, allow: [search_channel_context, get_channel_messages]}]` policy to each channel-consuming service **before** `resolveToolSubscriptions`, since that resolver only scans consumer `svc.Claw.Tools` and does not walk provider descriptors; (iii) allowlist file-content change triggers compose recreate via a sha256-hash env (`CLAW_WALL_AGENT_CHANNELS_SHA=<hash>`) on the claw-wall service — Docker Compose hashes service config, not bind-mounted file contents, so the file alone would not recreate the container; (iv) tool bearer-token projection corrected — token flows through `serviceAuth` map (`map[agentID]ServiceAuthEntry{Service:"claw-wall", AuthType:"bearer", Token:...}`) that `resolveManifestAuth` already consumes, NOT through `CLAW_WALL_TOOL_TOKEN` env on the agent container; (v) §4.1 "same allowlist guards both feed and tool paths" claim deleted — feeds stay generated-URL-only/network-scoped; (vi) §10 traceability note that r3 supersedes r2's after=-presence keying with explicit `context_kind=` stamping.
+# Issue 232 - Bounded channel awareness independent of cursors and restarts
 
 **Issue:** https://github.com/mostlydev/clawdapus/issues/232
 
-**Predecessors:**
-- #201 (channel-context tail mode, v0.13.7) — flipped delta→tail as default, dual cap.
-- #204 (cursored append-only context deltas) — late-context placement, no first-system mutation.
-- #220 (channel-cursor session epoch, v0.14.7) — restart bootstrap via `X-Claw-Consumer-Session-Epoch`.
+This design converged through the PR #236 review loop. The durable outcome is
+kept here; the full review history lives in the PR conversation.
 
-**Sibling:** #164 (salience-memory adapter) — owns LLM-derived compaction. This plan does **not** duplicate that work; v2 of #232 consumes #164's adapter.
+## Problem
 
-## 1. Problem (one paragraph)
+#220 fixed cursor bootstrap after consumer restarts. #201 fixed tail-vs-delta
+semantics. The remaining failure mode is within an active session: an agent's
+cursor can legitimately advance past a same-day room message, then a later human
+prompt refers to that older message and the agent lacks enough room awareness to
+answer.
 
-#220 fixed *across-restart* cursor bootstrap. #201 fixed tail vs delta semantics. The remaining failure mode is *within an active session*: the agent's cursor legitimately advances past a same-day floor message, then a human prompt refers to that older message, and the agent answers "I don't see it in the last 24h" because its prompt only contains the post-cursor delta. The live Tiverton incident (May 11, 2026, boulton on `#trading-floor`) is the canonical case: Logan posted a CMCSA read at 07:47 ET, boulton's cursor advanced normally, and at 09:50 ET the operator asked "wanna pick up CMCSA on Logan's read?" — boulton's prompt contained only the immediate ping thread because the cursor was already past Logan's message.
+The Tiverton May 11, 2026 CMCSA incident is the canonical case: Logan posted a
+substantive CMCSA read, Boulton's cursor advanced, and a later prompt asked
+Boulton to act on Logan's read. The prompt only contained the post-cursor tail.
 
-This is not a cursor bug. It is a missing *awareness layer*: cursorized delta is the right product for live continuity but the wrong product for "what does this agent know about the last 24h of the room?".
+This is not a cursor bug. Cursorized delta remains the right live-continuity
+feed. The missing layer is bounded room awareness: what the agent should know
+about recent shared channel context even after cursors move.
 
-## 2. Contract (the four parts from issue #232 comment r2)
+## Contract
 
-The operator's acceptance contract has four parts. They are not independently dispensable; they compose into "guaranteed bounded 24h awareness":
+The product contract has four parts:
 
-1. **Raw recent window** — exact messages for immediate continuity, bounded.
-2. **Rolling 24h digest** — LLM-derived, source-backed compaction of older same-day material, regenerated under buffer churn and after restart.
-3. **Retrieval path** — explicit fetch of exact source messages by author/ticker/time/id, so a digest can cite without restating.
-4. **Provider-visible metadata** — every channel-context block in the prompt declares whether it is `delta` / `raw_window` / `digest`, with retained-coverage so the model never claims "I don't see the last 24h" when only a delta was injected.
+1. **Raw recent window:** exact recent messages for immediate continuity.
+2. **Rolling digest:** a compact, source-backed 24h summary for older material.
+3. **Retrieval path:** exact source lookup by channel, time, id, author, or query.
+4. **Provider-visible metadata:** prompt blocks must say whether context is a
+   delta, raw window, digest, bootstrap tail, or tool result.
 
-## 3. Phasing
+Phase 1 ships parts 1, 3, and 4. Part 2 is phase 2 and remains tracked by #232
+plus the #164 salience-memory work.
 
-The plan splits along a hard dependency: part (2) needs a memory-grade producer, and the closest fit is #164's salience-memory adapter. v1 ships parts (1), (3), (4) and an explicit stopgap label on (2). v2 retires the stopgap once #164 lands.
+## Phasing
 
-| Part | v1 producer | v2 producer | Wire surface in both phases |
-|------|-------------|-------------|------------------------------|
-| (1) Raw recent window | `claw-wall` (new `channel-awareness` endpoint, uncursored, dual-capped) | unchanged | feed: `channel-awareness` |
-| (2) Rolling 24h digest | **stopgap: omitted** with explicit metadata label `digest=unavailable`; busy rooms rely on retrieval | `claw-channel-memory` service (new) — subscribes to claw-wall events, builds rolling digest (may use #164 salience-memory internals as a library, but channel events do **not** transit ADR-021 `/recall`); emits the **same** `channel-awareness` wire surface with `digest=ready` and an appended digest section | feed: `channel-awareness` (composite block, same name) |
-| (3) Retrieval path | `claw-wall` exposes managed tools (ADR-020) `search_channel_context` and `get_channel_messages`, gated by per-agent channel allowlist (see §4.2) | `claw-channel-memory` may offer richer retrieval (e.g., digest-cited source pull); v1 tools remain | `tools[]` |
-| (4) Metadata | header-line discipline keyed on `after=` presence (see §4.4), new `channel_context_op` telemetry distinguishing `delta_tail` / `raw_window` / `digest` / `tool_call` | unchanged | feed header + telemetry |
+| Part | Phase 1 | Phase 2 | Wire surface |
+| ---- | ------- | ------- | ------------ |
+| Raw recent window | `claw-wall` emits an uncursored bounded raw window | unchanged | `channel-awareness` feed |
+| Rolling digest | omitted, header says `digest=unavailable` | `claw-channel-memory` emits digest-backed awareness | same `channel-awareness` feed |
+| Retrieval | `claw-wall` managed tools with per-agent channel ACL | may gain richer source lookup | `tools[]` |
+| Metadata | feed and tool headers plus audit events | unchanged | prompt text + `channel_context_op` |
 
-The v1 channel-awareness block is **not** rebranded as "the 24h fix". The plan explicitly labels it as bounded raw-window + retrieval; full 24h coverage under busy-room load is only guaranteed once digest lands. **#232 itself stays open through v2** (codex r1) — v1 ships a meaningful improvement but is not acceptance-complete against the issue body's r2 contract.
+Channel events do not flow through ADR-021 `/recall` in either phase. The phase
+2 producer may reuse #164 salience-memory primitives as a library, but channel
+awareness remains its own room-shaped producer and wire surface.
 
-**Architectural invariant (codex r1):** in no phase do channel events flow through ADR-021's per-agent `/recall`. `/recall` payload is `messages[]`/`system`/metadata — agent/session shaped, not room-shaped. Channel awareness is its own producer/consumer pair with its own wire surface. #164's salience-memory adapter may be used as an internal library by `claw-channel-memory` (sharing LLM prompts, dedupe heuristics, etc.) but the two adapters do not share the recall/retain wire endpoints.
+## Phase 1 Awareness Feed
 
-## 4. Wire surfaces
+`claw-wall` exposes:
 
-### 4.1 New feed: `channel-awareness` (v1, producer = claw-wall)
-
-```
+```http
 GET /channel-awareness?channels=<csv>&since=24h&limit=60&max_chars=8192&context_kind=raw_window
 ```
 
-- **No cursor**. No `consumer=` param. No `mode=delta` path. This feed exists precisely to be cursor-independent.
-- Same channel-authorization model as `channel-context`: caller is upstream-restricted to surface-derived channels, baked into the generated URL by compose-up. The feed path is **not** bearer-authenticated and does **not** consult the per-agent allowlist file — single-writer compose URLs on the compose network are the trust boundary (codex r3.4). The per-agent allowlist of §4.2.1 guards the **tool path only**, where channels are model-supplied.
-- Reuses `consumeTail` semantics from #201 (newest-first walk, dual cap, sort ASC for output) but rebranded.
-- v1 defaults (r2): `since=24h`, `limit=60`, `max_chars=8192` (8KB, aligned with cllama's `MaxFeedResponseBytes` so we don't double-truncate). Operator-tunable via `x-claw.context.channel-awareness` (parallel of #201's `x-claw.context.channel`).
-- Generated URL example: `/channel-awareness?channels=14645…,14647…&since=24h&limit=60&max_chars=8192&context_kind=raw_window`.
-- Header line is explicit about layer kind, exactly so the model cannot conflate it with a delta:
+Properties:
 
+- No cursor, no `consumer=`, no delta mode.
+- Emitted automatically for services that consume Discord channel surfaces.
+- No new pod YAML key. Phase-1 defaults are internal and fixed:
+  `since=24h`, `limit=60`, `max_chars=8192`.
+- The feed is network-scoped like existing `channel-context`: compose writes the
+  surface-derived channels into the generated URL and cllama fetches it on the
+  internal network.
+
+Example prompt header:
+
+```text
+[channel-awareness] kind=raw_window since=24h messages=42 channels=14645... retained=42/since-24h digest=unavailable
 ```
-[channel-awareness] kind=raw_window since=24h messages=87 range=2026-05-11T05:42Z..2026-05-12T05:42Z channels=14645…,14647… retained=87/since-24h digest=unavailable
-```
 
-`digest=unavailable` in v1 documents the known gap. In v2 the same feed emits `digest=ready` and a digest section is appended below the raw window.
+`digest=unavailable` is intentional in phase 1. It tells the model and operator
+that busy rooms still need retrieval until phase 2 lands the digest producer.
 
-`channel-context` (the existing delta feed) keeps its `mode=tail` request shape from #201 verbatim. #232 lands a **header rewrite** keyed on cllama's per-fetch `context_kind=` URL hint (or, as a fallback, the presence of `after=`). See §4.4 for the full kind matrix including the `#220` epoch-bootstrap path.
+## Existing Delta Feed
 
-### 4.2 New tools: retrieval (v1, producer = claw-wall, ADR-020 managed)
+`channel-context` remains the cursorized live-continuity feed. Its existing
+`x-claw.context.channel` config from #201 stays in place for tail/delta behavior
+and buffer sizing.
 
-`claw.describe` v2 on the `claw-wall` image declares two managed tools:
+#232 does not add a sibling `x-claw.context.channel-awareness` knob. The raw
+awareness defaults are not operator-tunable in phase 1. If real pods prove those
+defaults wrong, phase 2 can add a single justified policy surface.
+
+## Retrieval Tools
+
+The auto-injected `claw-wall` service has a compiler-owned built-in descriptor
+with two managed tools:
+
+- `search_channel_context`
+- `get_channel_messages`
+
+`injectConversationWall` appends a synthetic tool policy to every service that
+consumes Discord channel surfaces:
 
 ```yaml
-tools:
-  - name: search_channel_context
-    description: "Search recent channel buffer (up to retained-coverage window) for messages matching a query."
-    params:
-      channels: { type: array, items: string, required: true }
-      query: { type: string, required: true }
-      since: { type: string, default: "24h" }
-      author: { type: string, required: false }
-      limit: { type: integer, default: 20 }
-    http: { path: /search_channel_context }
-  - name: get_channel_messages
-    description: "Fetch exact channel messages by ID range, or by author+time window."
-    params:
-      channels: { type: array, items: string, required: true }
-      message_ids: { type: array, items: string, required: false }
-      after: { type: string, required: false }    # snowflake id or ISO ts
-      before: { type: string, required: false }
-      limit: { type: integer, default: 20 }
-    http: { path: /get_channel_messages }
-```
-
-Both are **mediated** by cllama (ADR-020). Mediation is what makes the auth model work — see §4.2.1.
-
-#### 4.2.1 Auth and per-agent channel ACL (codex r1+r2 must-fix)
-
-**Current state (must not be misrepresented):** `claw-wall` today does **not** validate bearer auth on `/channel-context`. Auto-generated feed URLs are safe only because (a) `claw-wall` is reachable only on the compose Docker network, and (b) compose-up writes surface-derived channel IDs into the URL, so the request itself names exactly what the agent legitimately has access to. There is no token check.
-
-**v1 contract:**
-
-| Endpoint | Caller | Auth on claw-wall | Channel ACL site |
-|----------|--------|-------------------|------------------|
-| `/channel-context` (delta feed) | cllama fetcher with generated URL | none (network-scoped trust) | URL is single-writer compose-emitted |
-| `/channel-awareness` (raw window feed) | cllama fetcher with generated URL | none (network-scoped trust) | URL is single-writer compose-emitted |
-| `/search_channel_context` (tool) | cllama-mediated, agent on model side | service token (Bearer) + `X-Claw-ID` header (the validated agent) | cllama enforces; claw-wall re-checks (defense-in-depth) |
-| `/get_channel_messages` (tool) | cllama-mediated, agent on model side | service token (Bearer) + `X-Claw-ID` header | cllama enforces; claw-wall re-checks |
-
-The model never speaks to claw-wall directly. Tool calls go: model → cllama validates agent bearer (existing per-agent token from ADR-015 / claw-api auth pattern) → cllama checks per-agent channel allowlist → cllama forwards to claw-wall with the claw-wall service token + `X-Claw-ID: <agentID>` → claw-wall validates service token, re-checks `X-Claw-ID` against its mounted allowlist, runs the query.
-
-**Where the allowlist lives:** compose-up materializes a single JSON config at `claw up` time (codex r2: prefer file over env var) and mounts it read-only into `claw-wall`:
-
-```json
-// .claw-runtime/claw-wall-agent-channels.json (bind-mounted at /etc/claw-wall/agent-channels.json)
-{
-  "version": 1,
-  "agents": {
-    "boulton-0": ["1464509330731696213", "1464796137893662843"],
-    "logan-0":   ["1464509330731696213"]
-  }
-}
-```
-
-The same allowlist is also projected into each agent's cllama context dir (`channels-allowlist.json`) so cllama can pre-check before forwarding. Two-lock model: cllama is the primary gate (correctness, applied before any forwarding), claw-wall is the defense-in-depth (containment if cllama is bypassed or misconfigured).
-
-**Compose recreates claw-wall when the allowlist content changes (codex r3.3).** Docker Compose's service-config hash sees the bind-mount path, not the file contents — so a file-only edit would not recreate the container. To force a recreate when the allowlist changes:
-
-- compose-up computes `sha256` of the marshalled JSON and sets `CLAW_WALL_AGENT_CHANNELS_SHA=<hash>` on the auto-injected claw-wall service.
-- The env value is part of the service config, so Docker Compose detects the diff and recreates the container on `claw up`.
-- claw-wall reads the file at startup; no hot reload. The sha env is purely for compose-diff detection, not consulted by claw-wall itself.
-
-Test (§7.3): `TestComposeBumpsAllowlistShaOnAllowlistChange` — change a channel surface, re-run compose generation, assert the env hash changes.
-
-**claw-wall service token (codex r3.5):** compose-up generates a per-pod service token at `claw up` time (same pattern as the `claw-api` token from #44/`x-claw.master`). The token is set on the claw-wall service as `CLAW_WALL_TOOL_TOKEN` (server side only) and is projected per-consumer-agent through the existing `serviceAuth` map that `resolveManifestAuth` already consumes:
-
-```go
-// prepareConversationWallToolRuntime (new) returns one of these per channel-consuming agent
-ServiceAuthEntry{
-    Service:  "claw-wall",
-    AuthType: "bearer",
-    Token:    <generated-per-pod-token>,
-}
-```
-
-These entries are merged with the existing claw-api/history auth entries **before** `buildToolManifestEntries`, so `tools.json` gets the bearer token without adding `CLAW_WALL_TOOL_TOKEN` as an env on the consumer's container. Test (§7.3): `TestToolsJSONCarriesClawWallBearerWithoutLeakingEnv` — consumer's `tools.json` has the token, consumer container env does **not** contain `CLAW_WALL_TOOL_TOKEN`.
-
-claw-wall validates incoming tool requests have `Authorization: Bearer <CLAW_WALL_TOOL_TOKEN>`; without it, 401.
-
-**Tool request handler order:**
-1. Validate `Authorization` header against `CLAW_WALL_TOOL_TOKEN`. Miss → 401 `{"error":"unauthenticated"}`.
-2. Read `X-Claw-ID: <agentID>` header. Miss → 400 `{"error":"missing_agent_id"}`.
-3. Confirm `agentID` exists in `agents` map of the mounted JSON. Miss → 403 `{"error":"unknown_agent"}`.
-4. Parse requested `channels[]` from body.
-5. Reject any channel not in `agents[agentID]` → 403 `{"error":"channel_not_allowed", "agent":"...", "channel":"..."}`.
-6. Pass to store with validated channel set.
-
-cllama surfaces the 403 case to the model with a short hint ("This agent has no surface to channel X; ask the operator to add it.").
-
-#### 4.2.2 Tool auto-registration via built-in descriptor (codex r2+r3 must-fix)
-
-Auto-injected `claw-wall` is not a user-declared `x-claw` provider, and (per r3.1) `internal/inspect.ParseLabels` only recognizes `claw.describe` whose value is a build-context file path — it does not consume `claw.describe.path` and does not consume inline JSON. Bind-mounted runtime files are also not visible to the compile-time descriptor extractor. The clean fix is a **compiler-owned built-in descriptor**, sibling of the existing `builtinClawAPIDescriptor()` used for the auto-injected `claw-api` service:
-
-```go
-// internal/describe/builtins.go (new sibling)
-func builtinClawWallDescriptor() ServiceDescriptor {
-    return ServiceDescriptor{
-        Version: 2,
-        Service: "claw-wall",
-        Tools: []ToolSpec{
-            {
-                Name: "search_channel_context",
-                HTTP: &ToolHTTPSpec{BaseURL: "http://claw-wall:8080", Path: "/search_channel_context"},
-                Auth: &ToolAuthSpec{Type: "bearer", Service: "claw-wall"},
-                Params: /* per §4.2 spec */,
-            },
-            {
-                Name: "get_channel_messages",
-                HTTP: &ToolHTTPSpec{BaseURL: "http://claw-wall:8080", Path: "/get_channel_messages"},
-                Auth: &ToolAuthSpec{Type: "bearer", Service: "claw-wall"},
-                Params: /* per §4.2 spec */,
-            },
-        },
-    }
-}
-```
-
-Register it in `collectServiceDescriptors` / `resolveServiceMetadata` whenever the auto-injected claw-wall service is present (same condition that fires `injectConversationWall`).
-
-#### 4.2.3 Synthetic tool-subscription policy (codex r3.2 must-fix)
-
-Provider-descriptor presence alone does not subscribe consumers. `resolveToolSubscriptions` only scans consumer `svc.Claw.Tools` and matches against registered providers — it does not walk providers and attach to consumers.
-
-`injectConversationWall` therefore appends a synthetic tool-subscription policy to each channel-consuming service **before** `resolveToolSubscriptions` runs:
-
-```yaml
-# appended in-memory to each channel-consuming service's x-claw.tools
 tools:
   - service: claw-wall
     allow: [search_channel_context, get_channel_messages]
 ```
 
-This keeps the existing registry-validation and `buildToolManifestEntries` code paths load-bearing — no new tool-resolution code branch. The synthetic policy is conditional: only services whose surfaces consume Discord channels get it, matching the §4.2.4 auto-subscription trigger.
+This is generated in memory before normal tool resolution. Operators do not add
+this policy by hand.
 
-Regression tests (§7.3):
-- `TestInjectConversationWallAddsToolPolicyToChannelConsumers` — a pod with two services (one channel-consuming, one not) results in the channel-consumer's in-memory `x-claw.tools` containing `{service: claw-wall, allow: [...]}` after `injectConversationWall`; the non-consumer's is unchanged.
-- `TestComposeMaterializesAutoRegisteredToolsForChannelConsumers` — end-to-end: the same setup produces `tools.json` for the channel-consumer with both tool entries; the non-consumer's `tools.json` has neither.
+## Tool Auth And Channel ACL
 
-#### 4.2.4 Auto-subscription trigger condition
+Feed URLs are generated by compose and network-scoped. Retrieval tools are
+different because the model supplies request channels, so they need explicit ACL
+checks.
 
-Tools are auto-registered for any service whose `x-claw` consumes channel surfaces (i.e., the same condition that auto-injects `claw-wall`). No separate pod knob. Rationale: if the agent has channel surfaces declared, it already needs the tools to recover from cursor/buffer-bound gaps. Forcing operators to opt-in twice (channel surface + retrieval tool) is friction without value.
+Tool path:
 
-#### 4.2.5 Out-of-buffer semantics (codex r1 must-fix)
+1. The model calls a cllama-managed tool.
+2. cllama validates the agent and checks its generated channel allowlist.
+3. cllama forwards to claw-wall with `Authorization: Bearer <service-token>` and
+   `X-Claw-ID: <agent-id>`.
+4. claw-wall validates the service token and re-checks the same per-agent
+   allowlist before searching its buffer.
 
-claw-wall can only search/return messages currently in its in-process ring buffer (size from `CLAW_WALL_LIMIT`, default 50, configurable up to operator-set ceiling). When a query falls outside that window — either by `since` reach or by `message_ids` referring to evicted ids — the response is structured:
-
-```json
-{
-  "messages": [],
-  "retained_coverage": {
-    "oldest_ts": "2026-05-12T01:14Z",
-    "newest_ts": "2026-05-12T05:42Z",
-    "buffer_size": 500
-  },
-  "status": "not_in_buffer",
-  "hint": "Requested window extends before buffer's oldest_ts. Operator can widen CLAW_WALL_LIMIT or rely on v2 digest once available."
-}
-```
-
-`status: "ok"` for normal hits, `"empty"` for in-buffer-but-no-match, `"not_in_buffer"` for the eviction case. cllama renders this as a tool response with header `[channel-tool] kind=tool_call name=... status=not_in_buffer retained_coverage=...` so the model can see explicitly that the gap is buffer-bound, not absence-of-message.
-
-Tool responses include the same `kind=tool_call source=claw-wall channels=…` metadata header as the feed, so the model treats tool output and feed injection symmetrically. Every returned message carries its Discord snowflake `id` so the model can chain `search_channel_context` → `get_channel_messages` deterministically.
-
-### 4.3 Late-context placement and feed ordering (per #204)
-
-The `channel-awareness` block is appended to the late runtime-context system message (OpenAI) or final user content block (Anthropic), alongside the existing `channel-context` delta block and the memory recall block.
-
-Order inside the late block (deterministic for cache-friendliness):
-
-1. memory recall (existing, from ADR-021)
-2. `channel-awareness` (new — broadest layer, anchors the model in the last 24h)
-3. `channel-context` delta (existing, narrowest layer, fresh post-cursor)
-4. current time line (existing)
-
-Rationale: digest/awareness first sets the model's frame of "what the room knows"; delta then signals "what's new since you last looked"; time anchors the moment. Reversing this lets a stale-but-large window dominate fresh signal.
-
-#### 4.3.1 Manifest-order enforcement (codex r1 must-fix)
-
-cllama's `fetchFeeds` / `FormatAllFeeds` (`cllama/internal/feeds/inject.go`) iterate the feed manifest in order. There is no sort step today. The r1 plan said "order inside the late block" without saying who enforces it; codex flagged this. v1 enforces ordering at the **compose-up emission** side:
-
-- `appendConversationWallAwarenessFeed` emits the awareness entry **before** `appendConversationWallFeed` emits the delta entry, both immediately after any memory recall slot.
-- Regression test `TestConversationWallFeedsEmittedInAwarenessBeforeDeltaOrder` asserts the manifest order matches the §4.3 list.
-- A cllama-side deterministic sort for channel-flavored feeds is **deferred** (would require feed-name introspection in `inject.go`). Manifest-order discipline is sufficient because compose-up is the single writer.
-
-### 4.4 Header discipline (part 4 of contract)
-
-Every channel-flavored block carries an explicit `kind=` field in its header. The implicit assumption "channel-context = full room" is the bug we are killing.
-
-**Discriminator (codex r1+r2 must-fix):** the kind is **passed explicitly by cllama via a `context_kind=` URL query param**, not inferred from `after=` presence alone. r2 made the case: claw-wall cannot distinguish "first/cold tail" from "#220 epoch-bootstrap tail" from the URL alone — both arrive without `after=`, but the meanings differ (the bootstrap case means cllama *intentionally* suppressed a stored cursor due to an epoch change). cllama owns that distinction in `channelContextPrepareDecision` (`Bootstrapped`, `AppliedAfter`), so cllama stamps the URL accordingly.
-
-cllama-side mapping (`cllama/internal/proxy/channel_context_feed.go::prepareChannelContextFeed`):
-
-| Decision state | Appended URL param |
-|----------------|--------------------|
-| `AppliedAfter == true` | `context_kind=delta_tail` (also keeps `after=`) |
-| `Bootstrapped == true` (epoch change suppressed cursor) | `context_kind=bootstrap_tail` |
-| neither (first turn, empty cursor, legacy) | `context_kind=tail` |
-
-For the new `channel-awareness` feed, compose-up writes `context_kind=raw_window` directly into the URL (no cllama logic needed; awareness is always raw_window in v1).
-
-claw-wall's response formatter reads `context_kind` and emits the corresponding header line. If the param is missing (older cllama against newer claw-wall), claw-wall falls back to `delta_tail` if `after=` is present, `tail` otherwise. The fallback is intentional for back-compat but never used by current cllama.
-
-| `context_kind` | Block kind | Header line |
-|----------------|------------|-------------|
-| `delta_tail` | `delta_tail` | `[channel-context delta] kind=delta_tail cursor=<ch>:<id>,...` |
-| `bootstrap_tail` | `bootstrap_tail` | `[channel-context bootstrap] kind=bootstrap_tail reason=epoch_changed` |
-| `tail` | `tail` | `[channel-context] kind=tail` |
-| `raw_window` | `raw_window` | `[channel-awareness] kind=raw_window since=...` |
-| `raw_window+digest` (v2) | composite | `[channel-awareness] kind=raw_window+digest since=... digest_source_count=...` |
-| (tool response) | `tool_call` | `[channel-tool] kind=tool_call name=... status=...` |
-
-v2 of #204's `coverage_partial=true` annotation is preserved verbatim across all kinds.
-
-**Back-compat note:** model prompts that contained the old `[channel-context]` header for delta will now see `[channel-context delta] kind=delta_tail` once v1 ships. This is the intended behavior — the old prefix was the bug. No tool/agent code parses this header; only the model reads it.
-
-### 4.5 Telemetry (part 4 of contract)
-
-New normalized event kind: `channel_context_op` emitted on the cllama side (which already has the agent/pod identity and request context). It is **not** an existing event renamed — the audit/session-history paths today use distinct `feed_fetch` and `memory_op` events; tool calls flow through tool-trace normalization. r2 raised the concern that "fold into existing tool_call_result" assumed an event that doesn't exist. v1 lands `channel_context_op` as a new normalized record alongside `feed_fetch` and `memory_op`.
-
-Schema (cllama records, claw-api surfaces):
+The allowlist is generated by `claw up` from Discord channel surfaces:
 
 ```json
 {
-  "type": "channel_context_op",
-  "agent_id": "boulton-0",
-  "pod": "tiverton-house",
-  "kind": "raw_window | delta_tail | bootstrap_tail | tail | tool_call | digest_built | digest",
-  "channels": ["1464…", "1464…"],
-  "retained": 60,           // messages in claw-wall's window that matched
-  "returned": 47,           // after caps
-  "omitted": 13,            // retained - returned
-  "latency_ms": 24,
-  "source": "claw-wall",    // or "claw-channel-memory" in v2
-  "status": "ok | empty | not_in_buffer | error",
-  "tool_name": "search_channel_context"  // present only for kind=tool_call
+  "version": 1,
+  "agents": {
+    "boulton-0": ["1464509330731696213"],
+    "logan-0": ["1464509330731696213"]
+  }
 }
 ```
 
-Emission sites:
-- every `channel-awareness` fetch → `kind=raw_window`
-- every `channel-context` fetch → `kind` mirrors the cllama-side `context_kind=` decision (`delta_tail` / `bootstrap_tail` / `tail`), so the audit view shows exactly which path served each turn
-- every retrieval tool call → `kind=tool_call`, `status` reflects the §4.2.5 enum, `tool_name` is the called tool
-- v2: digest production → `kind=digest_built`; digest injection → `kind=digest`
+It is mounted into claw-wall read-only and also projected into each agent's
+cllama context as `channels-allowlist.json`. A sha256 of the file is placed in
+`CLAW_WALL_AGENT_CHANNELS_SHA` so Docker Compose recreates claw-wall when the
+generated allowlist changes.
 
-The retrieval `status` is also embedded in the session-history tool-trace record (per r2: agents/audits that look at session history can see "the tool was called, it returned not_in_buffer" without re-correlating two streams). The cllama tool-trace shim writes `status` into the existing trace JSON alongside the request/response pair.
+This two-lock model is internal runtime plumbing, not operator config. It is the
+security boundary for model-supplied retrieval requests.
 
-`claw audit` surfaces `channel_context_op` alongside `memory_op` and `feed_fetch`.
+## Prompt Placement And Ordering
 
-## 5. Compose-up wiring
+Channel awareness is late runtime context, not first-system prompt text. The
+intended order inside the late context block is:
 
-Pod-level config extends #201's `x-claw.context.channel` with a sibling block:
+1. memory recall
+2. `channel-awareness`
+3. `channel-context`
+4. current runtime time
 
-```yaml
-x-claw:
-  context:
-    channel:                    # existing delta feed (from #201)
-      since: 24h
-      limit: 40
-      max_chars: 8192
-    channel-awareness:          # NEW — defaults applied automatically; pod block only needed for overrides
-      since: 24h
-      limit: 60                 # default (r2: tightened from 120)
-      max_chars: 8192           # default (r2: tightened from 12288)
-```
+Compose emits the awareness feed before the delta feed so cllama preserves this
+order when it fetches and formats feeds.
 
-Service-level overrides via the same pod-defaults pattern (`x-claw.context.channel-awareness` on individual services). There is **no** `enabled` knob — see §8; the feed is emitted automatically when the service consumes any channel surface, matching the auto-injection of `claw-wall` itself.
+## Context Kinds
 
-`appendConversationWallFeed` (in `cmd/claw/compose_up.go`) gains a sibling `appendConversationWallAwarenessFeed` that emits `/channel-awareness?channels=...&since=...&limit=...&max_chars=...&context_kind=raw_window` whenever the service has any consumed channel IDs. Plus the following compose-time work (codex r3 refinements):
+Every model-visible channel block carries an explicit kind:
 
-1. **Built-in descriptor registration (§4.2.2):** `collectServiceDescriptors` registers `builtinClawWallDescriptor()` when the auto-injected claw-wall service is present. No bind-mount, no `claw.describe.path` label, no synthetic descriptor file on disk — the descriptor is compiler-owned, sibling of `builtinClawAPIDescriptor()`.
-2. **Synthetic tool-subscription policy (§4.2.3):** before `resolveToolSubscriptions`, `injectConversationWall` appends `tools: [{service: claw-wall, allow: [search_channel_context, get_channel_messages]}]` in-memory to each channel-consuming service's `x-claw`. The normal resolver then materializes those into the consumer's `tools.json`.
-3. **Per-agent allowlist file (§4.2.1):** materialized at `.claw-runtime/claw-wall-agent-channels.json`, bind-mounted into claw-wall at `/etc/claw-wall/agent-channels.json`. Also projected into each consuming agent's cllama context as `channels-allowlist.json` (cllama-side primary gate).
-4. **Allowlist sha env (§4.2.1, codex r3.3):** the sha256 of the marshalled allowlist JSON is set as `CLAW_WALL_AGENT_CHANNELS_SHA=<hash>` on the claw-wall service. This is what makes Docker Compose recreate the container when allowlist contents change; without it, the bind-mount path alone would be considered stable.
-5. **Tool bearer projection via `serviceAuth` (§4.2.1, codex r3.5):** `prepareConversationWallToolRuntime` emits a `ServiceAuthEntry{Service: "claw-wall", AuthType: "bearer", Token: <generated>}` per channel-consuming agent. These flow into the existing `serviceAuth` map consumed by `resolveManifestAuth`, so per-agent `tools.json` gets the bearer token **without** the consumer container's env carrying `CLAW_WALL_TOOL_TOKEN`. Only the claw-wall service env has it.
+| Kind | Surface | Meaning |
+| ---- | ------- | ------- |
+| `raw_window` | `channel-awareness` | uncursored recent room window |
+| `tail` | `channel-context` | initial or steady tail without cursor delta |
+| `delta_tail` | `channel-context` | messages after the committed cursor |
+| `bootstrap_tail` | `channel-context` | restart/session-epoch bootstrap |
+| `tool_call` | retrieval tools | exact lookup result or structured miss |
+| `raw_window+digest` | phase 2 | raw recent window plus rolling digest |
 
-claw-wall reloads neither file at runtime in v1; the sha-env mechanism above ensures `claw up` after any pod edit produces a fresh claw-wall container with the fresh allowlist.
+cllama stamps `context_kind=` on `channel-context` fetches. claw-wall uses that
+hint for the header, with a fallback based on `after=` for older cllama builds.
 
-## 6. Stopgap discipline (codex challenge #2)
+## Retrieval Misses
 
-This plan **must not** ship as "the 24h fix" without phase 2. The framing in the PR body, the release note, and the on-call runbook reads:
+claw-wall searches only its retained in-process buffer in phase 1. If the request
+falls outside the buffer, the tool returns structured `status=not_in_buffer`
+metadata with retained coverage instead of pretending the message does not
+exist.
 
-> v1 of #232 ships bounded raw-window awareness, retrieval tools, and metadata. **Busy rooms — >60 messages OR >8KB of message content in 24h — will exceed the v1 dual cap.** When that happens, the agent will see the most recent N messages plus retrieved older ones on demand; full 24h compaction is delivered in v2 once #164's salience-memory adapter lands. The `digest=unavailable` header line documents this in-prompt so the model can decide whether to call retrieval.
+Normal statuses:
 
-The acceptance criterion in the issue body — "later Boulton turn still includes Logan's CMCSA read in the 24h awareness layer without requiring the human to restate it" — is **partially satisfied** in v1: Logan's read is reachable via retrieval (and likely also visible in the raw 24h window for a not-too-busy floor), but not guaranteed-injected. v2 closes the gap.
+- `ok`: messages returned
+- `empty`: searched retained buffer, no match
+- `not_in_buffer`: requested window or id is older than retained coverage
 
-## 7. Tests
+cllama preserves tool result JSON in traces and prepends a short model-visible
+`[channel-tool]` metadata line.
 
-### 7.1 claw-wall (`cmd/claw-wall/`)
+## Telemetry
 
-- `TestChannelAwarenessHandlerReturnsRawWindow` — `since=24h`, no cursor write, header reads `kind=raw_window`, `digest=unavailable` in v1.
-- `TestChannelAwarenessHandlerDualCap` — 200-message buffer, `limit=50&max_chars=…` → returns newest 50 sorted ASC, header shows `retained=50/...`.
-- `TestChannelAwarenessHandlerColdStart` — buffer holds 10 minutes worth → header reads `retained=N/buffer range=...` honest about coverage.
-- `TestChannelAwarenessHandlerDoesNotMutateCursor` — interleave with `channel-context` delta consumer; awareness fetch leaves delta cursor untouched.
-- `TestChannelContextHeaderByContextKindParam` — three requests on the same handler with `context_kind=delta_tail` / `bootstrap_tail` / `tail` produce the three distinct header lines from §4.4. (codex r2 must-fix)
-- `TestChannelContextHeaderFallbackInfersFromAfter` — when `context_kind=` is missing, presence of `after=` yields `delta_tail`, absence yields `tail`. Back-compat for older cllama.
-- **Tool auth tests (codex r2 must-fix):**
-  - `TestToolRequestRejectsMissingBearer` — no Authorization header → 401.
-  - `TestToolRequestRejectsWrongServiceToken` — Bearer present but wrong value → 401.
-  - `TestToolRequestRejectsMissingClawID` — Bearer ok, no `X-Claw-ID` → 400.
-  - `TestToolRequestRejectsUnknownAgent` — Bearer ok, `X-Claw-ID` not in mounted allowlist → 403.
-  - `TestToolRequestRejectsDisallowedChannel` — Bearer ok, agent known, requested channel not in agent's allowlist → 403 with `{"error":"channel_not_allowed", ...}`.
-  - `TestToolRequestAcceptsAllowedAgentAndChannel` — full happy path → 200.
-- `TestToolRequestLoadsAllowlistFromMountedFile` — claw-wall reads `/etc/claw-wall/agent-channels.json` at startup; a malformed file produces a startup failure (fail-closed).
-- `TestRetrievalToolNotInBufferStatus` — buffer has 10min; tool query with `since=12h` returns `status=not_in_buffer` + `retained_coverage` shape per §4.2.5.
-- `TestRetrievalToolEmptyVsNotInBuffer` — distinguishes `status=empty` (in-buffer, no match) from `status=not_in_buffer` (out-of-buffer).
-- `TestGetChannelMessagesByIDRange` — fetch by id range returns exact messages, ordered, each carrying its snowflake id.
+cllama emits `channel_context_op` events for awareness fetches, delta fetches,
+bootstrap/tail fetches, and retrieval tool calls. Normalized fields include:
 
-### 7.2 cllama (`cllama/internal/proxy/`)
+- `kind`
+- `channels`
+- `source`
+- `tool_name`
+- `status`
+- `returned`
+- `retained`
+- `omitted`
 
-- `TestChannelAwarenessFeedIsFetchedWithoutCursor` — register a `channel-awareness` feed entry; assert URL has no `after=` and `X-Claw-Consumer-Session-Epoch` is **not** consulted for it (orthogonal to #220's epoch).
-- `TestChannelAwarenessAndDeltaCoExist` — pod wires both feeds; both blocks appear in the late-context section, in the §4.3 order, with their respective `kind=` headers.
-- **`context_kind=` stamping tests (codex r2 must-fix):**
-  - `TestPrepareChannelContextStampsDeltaTail` — `AppliedAfter == true` → URL gains `context_kind=delta_tail`.
-  - `TestPrepareChannelContextStampsBootstrapTail` — `Bootstrapped == true` (epoch mismatch) → URL gains `context_kind=bootstrap_tail` and **no** `after=`.
-  - `TestPrepareChannelContextStampsTail` — neither (first turn, empty cursor) → URL gains `context_kind=tail`.
-- `TestChannelContextHeaderFlowsThroughCllama` — claw-wall returns `[channel-context delta] kind=delta_tail`; cllama formats into late context without mutation.
-- `TestToolMediationChecksChannelAllowlist` — cllama loads per-agent `channels-allowlist.json`; mediated tool call with disallowed channel is rejected by cllama before forwarding (returns a tool error to the model with hint per §4.2.1).
-- `TestToolMediationForwardsValidatedRequest` — happy path: cllama forwards with `Authorization: Bearer <CLAW_WALL_TOOL_TOKEN>` and `X-Claw-ID: <agent>`; mocked claw-wall sees both headers.
-- `TestChannelContextOpTelemetryNormalized` — fetch each kind, assert `audit.go`-style normalized records for `kind=raw_window`, `kind=delta_tail`, `kind=bootstrap_tail`, `kind=tail`, `kind=tool_call` with `status`.
+`claw audit` summarizes channel context operations alongside memory and feed
+operations.
 
-### 7.3 compose_up (`cmd/claw/`)
+## What Phase 1 Ships
 
-- `TestAppendChannelAwarenessFeedHonorsPodConfig` — pod-level `x-claw.context.channel-awareness` overrides flow into generated URL.
-- `TestChannelAwarenessFeedDefaultOnWithChannelSurface` — service consumes a Discord channel surface; pod has no explicit `channel-awareness` block; feed entry IS emitted with default `since=24h&limit=60&max_chars=8192&context_kind=raw_window`. (codex r1, default-on)
-- `TestChannelAwarenessFeedAbsentWithoutChannelSurface` — service has no channel surface; no awareness feed entry emitted.
-- `TestConversationWallFeedsEmittedInAwarenessBeforeDeltaOrder` — manifest-order regression: when both feeds are emitted, awareness appears before delta in the materialized `feeds.json`. (codex r1 must-fix §4.3.1)
-- `TestComposeMaterializesAgentChannelAllowlistJSON` — when claw-wall is auto-injected, the runtime dir contains `claw-wall-agent-channels.json` with the per-agent allowlist, bind-mounted at `/etc/claw-wall/agent-channels.json`. (codex r2 must-fix §4.2.1)
-- `TestComposeProjectsAllowlistIntoCllamaContext` — each consuming agent's cllama context dir contains `channels-allowlist.json` mirroring the same surface-derived channels.
-- `TestComposeBumpsAllowlistShaOnAllowlistChange` — changing a channel surface in the pod re-runs compose generation; `CLAW_WALL_AGENT_CHANNELS_SHA` env on the claw-wall service has a different value than before the change. (codex r3.3 must-fix)
-- `TestBuiltinClawWallDescriptorRegisteredWhenInjected` — `collectServiceDescriptors` returns the built-in claw-wall descriptor when `injectConversationWall` runs; not registered when no service consumes channels. (codex r3.1 must-fix)
-- `TestInjectConversationWallAddsToolPolicyToChannelConsumers` — channel-consuming service's in-memory `x-claw.tools` contains `{service: claw-wall, allow: [search_channel_context, get_channel_messages]}` after `injectConversationWall`; non-consumer's is unchanged. (codex r3.2 must-fix)
-- `TestComposeMaterializesAutoRegisteredToolsForChannelConsumers` — end-to-end: pod with two agents (one channel-consuming, one not); the channel-consuming agent's `tools.json` contains both tools with `http.base_url=http://claw-wall:8080` and the service token in `auth.token`; the non-consumer's `tools.json` contains neither.
-- `TestToolsJSONCarriesClawWallBearerWithoutLeakingEnv` — `tools.json` for the channel-consumer has the bearer token in `auth.token`; the same consumer's container env does **NOT** contain `CLAW_WALL_TOOL_TOKEN`. Only the claw-wall service env has the token. (codex r3.5 must-fix)
+- Default-on `channel-awareness` for Discord-channel-consuming services.
+- Fixed internal awareness defaults: `24h`, `60` messages, `8192` chars.
+- No new pod YAML config surface.
+- Retrieval tools auto-wired through the existing managed-tool path.
+- Per-agent generated channel allowlists and service-token auth for tool calls.
+- Explicit context-kind headers and `channel_context_op` telemetry.
 
-### 7.4 Pod parser (`internal/pod/`)
+## Phase 2
 
-- `TestParseChannelAwarenessConfig` — accepts `since` / `limit` / `max_chars`; rejects negatives; rejects unparseable durations. No `enabled` field (default-on).
-- `TestPodDefaultsChannelAwareness` — service-level overrides pod defaults using the standard pattern.
+Phase 2 closes the true high-volume 24h guarantee by adding a rolling digest
+producer, likely `claw-channel-memory`, aligned with #164's salience-memory
+model. The digest should preserve provenance and make exact-source retrieval
+cheap when a summary references a specific message.
 
-### 7.5 Integration (no spike)
+#232 stays open until that digest-backed phase lands.
 
-Codex r1+r2: plain integration tests against a faked claw-wall are sufficient; spike-tag inflates CI cost and requires real provider credentials this scenario does not need.
+## Non-Goals
 
-- `TestChannelAwarenessEndToEndAgainstFakeClawWall` (in `cmd/claw/` or `cllama/internal/proxy/`) — a real cllama instance fronting a faked claw-wall (httptest server). Pod wires both `channel-context` and `channel-awareness` feeds. Assert the cllama-produced upstream request contains both header lines (`kind=delta_tail` from delta, `kind=raw_window` from awareness) in the late-context block in the §4.3 order.
-- `TestTivertonReproductionFixture` (in `cmd/claw/` or as a fixture-driven harness test) — the issue-body scenario, fully reproducible without external services:
-  1. Pre-seed the fake claw-wall buffer with messages spanning a 24h window, including a "Logan CMCSA read" at T-2h.
-  2. Run cllama turn #1 with a routine prompt; the `channel-context` delta advances the cursor past Logan's message.
-  3. Run cllama turn #2 with a human-mention prompt ("wanna pick up CMCSA on Logan's read?").
-  4. Assert the upstream request for turn #2 contains the Logan message in the `[channel-awareness] kind=raw_window` block, even though the `[channel-context delta] kind=delta_tail` block has only post-cursor traffic.
-  5. Assert the per-agent allowlist enforcement: the same turn issuing a `search_channel_context(channels=["<other-channel>"])` tool call is rejected by cllama before forwarding.
-
-`TestSpikeRollCall` is **not** extended; it remains the live-Docker validation for cllama proxy enforcement and stays scoped to existing concerns.
-
-## 8. Default behavior and ramp (revised r2)
-
-**Codex r1 made the v1-opt-in posture untenable:** if v1 is opt-in and explicitly partial, then operators who don't flip the knob get nothing, and #232 closes on a stopgap that pods haven't actually adopted. The new default is **on**, with smaller caps tuned to Discord channel density, and `digest=unavailable` honestly documenting the gap in v1.
-
-v1 defaults (active when the service consumes any channel surface, no explicit opt-in needed):
-
-| Knob | v1 default | r1 draft | Rationale |
-|------|-----------|----------|-----------|
-| `enabled` | `true` (implicit) | `false` (explicit opt-in) | codex r1: opt-in fails the issue's acceptance contract |
-| `since` | `24h` | `24h` | unchanged |
-| `limit` | `60` | `120` | r1 caps were generous; smaller default reflects "raw window + retrieval pressure valve" model |
-| `max_chars` | `8192` (8KB) | `12288` (12KB) | aligned with cllama's `MaxFeedResponseBytes` so we don't risk double-truncation |
-
-Per-pod overrides still available via `x-claw.context.channel-awareness`. Operators with low-density rooms can raise the caps; high-traffic rooms keep the smaller defaults and lean on retrieval until v2.
-
-**#232 stays open through v2.** Per codex r1: v1 is a meaningful improvement (raw-window + retrieval + metadata) but does not satisfy the issue body's r2 acceptance contract ("guaranteed 24h awareness regardless of session state and trigger"). The PR that lands v1 is titled `#232 phase 1: raw-window + retrieval + metadata` and closes #232 only when v2 (digest via `claw-channel-memory`) ships.
-
-The PR body explicitly says:
-> Phase 1 of #232. Lands the raw-window feed, retrieval tools, and metadata header discipline; busy rooms still rely on retrieval to close gaps. Phase 2 (rolling digest via `claw-channel-memory`) lands when #164 is far enough along to share its salience primitives. #232 stays open through both phases.
-
-## 9. Out of scope (deliberately)
-
-- **Cross-channel digest correlation.** v1 and v2 both keep channel-awareness scoped per-channel within a single feed call. Cross-channel synthesis is a future memory adapter feature.
-- **Affect/salience scoring** of channel messages. Same #164 territory.
-- **Discord history backfill** beyond claw-wall's in-process buffer. Per #201 §3 Q3, the wider-continuity feeds cover cold-start. Operators who need a true 24h window today can raise `CLAW_WALL_LIMIT`/buffer; v2's digest reduces the urgency further.
-- **Per-channel awareness/delta toggles.** v1 keeps the pod/service knob granularity from #201.
-- **Anthropic `cache_control` markers** for awareness blocks. Same deferral as #204 v2.
-
-## 10. r1 open questions — codex answers and r2 resolution
-
-(Original five questions kept for traceability; codex r1 answers and r2 outcome inline.)
-
-1. **Composite vs co-injection.** r1 leaned two-feed.
-   - **Codex r1:** two-feed OK for v1 *if* rendered/ordered as one coherent channel layer.
-   - **r2 resolution:** two feeds (`channel-awareness`, `channel-context`) with compose-emitted manifest order enforced (§4.3.1). Telemetry treats them as one logical layer via `channel_context_op`. v2 can collapse to one feed if useful but is not required.
-
-2. **Header rewrite on `channel-context`.** r1 said "change to `[channel-context delta] kind=delta`".
-   - **Codex r1 must-fix:** rewrite targeted the wrong path (`mode=delta` is no longer the default since #201). The real delta path is `mode=tail` + `after=`.
-   - **r2 resolution:** rewrite was keyed on `after=` presence.
-   - **r3 supersedes:** keying is now explicit `context_kind=` URL param stamped by cllama; `after=`-presence inference is only a back-compat fallback. See §4.4 for the five kinds (`delta_tail`, `bootstrap_tail`, `tail`, `raw_window`, `tool_call`). (codex r3 cleanup)
-
-3. **v1 retrieval tools live where?** r1 leaned claw-wall-direct.
-   - **Codex r1:** claw-wall-direct OK *only after* ACL/auto-subscribe is solved.
-   - **r2 resolution:** claw-wall-direct with §4.2.1 per-agent channel allowlist materialized at compose time + §4.2.2 auto-subscription. ACL is the gating condition; not a separate phase.
-
-4. **v1 default opt-in vs opt-out.** r1 leaned opt-in for token cost discipline.
-   - **Codex r1:** opt-in means v1 is not acceptance-complete; either split issues or make default-on with smaller caps.
-   - **r2 resolution:** default-on with smaller caps (`limit=60`, `max_chars=8192`), and #232 stays open through v2 (§8). The smaller caps keep token-cost discipline without requiring operators to flip a knob.
-
-5. **Spike test scope.** r1 leaned plain integration over spike-tagged.
-   - **Codex r1:** plain integration, fake claw-wall, no spike-tag.
-   - **r2 resolution:** confirmed — §7.5 targeted reproduction is a normal integration test.
-
-## 10b. r2 open questions — codex answers and r3 resolution
-
-1. **CLAW_WALL_AGENT_CHANNELS env shape.** r2 leaned env-var.
-   - **Codex r2:** prefer JSON config file mounted into claw-wall (less fragile, future reload/diagnostic friendly). No hot reload needed; `claw up` recreates claw-wall on config change.
-   - **r3 resolution:** switched to `claw-wall-agent-channels.json` bind-mounted at `/etc/claw-wall/agent-channels.json` (§4.2.1, §5). Also projected into cllama context as `channels-allowlist.json` for cllama-side pre-check.
-
-2. **Tool error rendering.** r2 wanted `status` separate from generic tool_call_result.
-   - **Codex r2:** there is no existing `tool_call_result` event. Don't assume. Add explicit `channel_context_op` normalization for feed/tool ops; embed retrieval status in session-history tool-trace as structured data.
-   - **r3 resolution:** §4.5 rewritten — `channel_context_op` is a new normalized event alongside `feed_fetch`/`memory_op`; tool calls also write `status` into the session-history tool-trace record so audit reconstruction is single-stream.
-
-3. **`digest=unavailable` signaling.** r2 leaned "once in awareness only".
-   - **Codex r2:** confirmed — once in `channel-awareness` header only; repeating in delta blocks would invite the bug we're killing.
-   - **r3 resolution:** header tables in §4.4 only carry `digest=unavailable` on the `raw_window` line. Delta/bootstrap/tail headers say nothing about digest.
-
-4. **`claw-channel-memory` service location.** r2 leaned `examples/`.
-   - **Codex r2:** start under `examples/channel-memory/` (or #164-aligned path); avoid published infra image and release pinning in phase 1.
-   - **r3 resolution:** §3 v2 row, §11 build sequence, and §12 non-goals all say `examples/channel-memory/`. No `release_manifest.go` entry; no ghcr.io publication in phase 1.
-
-## 10c. r3 open questions — codex answers and r4 resolution
-
-1. **`context_kind=` URL hint vs request header.** r3 leaned query param.
-   - **Codex r3:** confirmed. Query param is fine; the URL already carries `after`, `channels`, `mode`, so adding another fetch-metadata param is in keeping. Header would be cleaner abstractly but not worth the change.
-   - **r4 resolution:** stays as URL query param.
-
-2. **Defense-in-depth allowlist on feed paths.** r3 leaned "leave feeds generated-URL-only".
-   - **Codex r3:** confirmed. The threat #232 fixes is model-supplied tool args, not cllama's compiler-generated feed URL. Leave feeds as-is for v1.
-   - **r4 resolution:** §4.1 wording corrected — feed path is not bearer-authenticated and does not consult the allowlist. The "same allowlist guards both" claim is deleted. Allowlist guards tools only.
-
-3. **`claw.describe.path` label semantics.** r3 leaned inline JSON.
-   - **Codex r3:** neither works. `internal/inspect.ParseLabels` only recognizes `claw.describe` and treats the value as a build-context file path; it does not consume `.path` label variants and does not parse inline JSON. The right path is a compiler-owned built-in descriptor sibling of `builtinClawAPIDescriptor()`.
-   - **r4 resolution:** §4.2.2 rewritten to use `builtinClawWallDescriptor()`. No `claw.describe.path` label, no inline JSON, no synthetic descriptor file on disk.
-
-## 10d. Implementation-readiness checklist (post r4)
-
-This section exists so a future implementer can confirm the plan is settled before starting work.
-
-- [x] Auth model two-lock (cllama primary gate via `channels-allowlist.json`; claw-wall defense-in-depth via mounted allowlist + service token)
-- [x] Feed path stays generated-URL-only/network-scoped (no bearer, no allowlist on feed)
-- [x] Tool path strictly cllama-mediated (Bearer + `X-Claw-ID` headers; `serviceAuth`-projected token)
-- [x] Built-in descriptor approach (no label indirection)
-- [x] Synthetic tool-subscription policy (so existing `resolveToolSubscriptions` works)
-- [x] Allowlist sha env for compose recreate-on-content-change
-- [x] `context_kind=` URL param keying for header rewrite (delta_tail / bootstrap_tail / tail / raw_window)
-- [x] Manifest order discipline (awareness before delta)
-- [x] `channel_context_op` telemetry alongside `feed_fetch`/`memory_op`
-- [x] Default-on with smaller caps (60 / 8KB); #232 stays open through v2
-- [x] Plain integration test, no spike
-- [x] v2 producer (`claw-channel-memory`) emits same wire surface; channel events never transit ADR-021 `/recall`
-
-## 11. Build sequence (assuming codex r3 sign-off)
-
-1. **claw-wall** —
-   - `channel-awareness` endpoint reusing `consumeTail`.
-   - Mounted allowlist loader (`/etc/claw-wall/agent-channels.json`), fail-closed on parse error.
-   - Tool handlers `search_channel_context`, `get_channel_messages` with the §4.2.1 auth order (Bearer service token + `X-Claw-ID` + allowlist check) and §4.2.5 `not_in_buffer` semantics.
-   - Header rewrite keyed on `context_kind=` URL param (with `after=` fallback) per §4.4.
-   - Tests in §7.1.
-2. **compose_up wiring** —
-   - `appendConversationWallAwarenessFeed` emits awareness URL **before** the existing delta feed (manifest order).
-   - Pod parser for `x-claw.context.channel-awareness`.
-   - Per-agent allowlist materialization → `.claw-runtime/claw-wall-agent-channels.json`, bind-mounted into claw-wall + projected into cllama context as `channels-allowlist.json`.
-   - `CLAW_WALL_AGENT_CHANNELS_SHA=<sha256(allowlist json)>` env on the claw-wall service so Docker Compose recreates the container when allowlist content changes.
-   - Generated per-pod tool token on claw-wall service env (`CLAW_WALL_TOOL_TOKEN`); the same value flows through `prepareConversationWallToolRuntime` → `serviceAuth[agent]` → consumer `tools.json` auth descriptor. Consumer container env does **not** carry the token.
-   - **`builtinClawWallDescriptor()`** registered in `collectServiceDescriptors` whenever the auto-injected claw-wall service is present. No `claw.describe.path` label, no synthetic descriptor file on disk.
-   - `injectConversationWall` appends synthetic `tools: [{service: claw-wall, allow: [...]}]` to each channel-consuming service's `x-claw` before `resolveToolSubscriptions`.
-   - Tests in §7.3, §7.4.
-3. **cllama side** —
-   - `prepareChannelContextFeed` stamps `context_kind=` into the URL based on `channelContextPrepareDecision`.
-   - cllama tool-mediation enforces per-agent channel allowlist before forwarding (loads `channels-allowlist.json` from context).
-   - cllama tool mediator forwards `Authorization: Bearer <CLAW_WALL_TOOL_TOKEN>` + `X-Claw-ID` to claw-wall.
-   - Late-context injection unchanged (manifest order does the work).
-   - Tests in §7.2.
-4. **Telemetry normalization** — `channel_context_op` event kind, schema per §4.5, `claw audit` rendering; session-history tool-trace records `status`.
-5. **Docs sweep** — `docs/CLLAMA_SPEC.md`, new ADR-025 once codex agrees, `skills/clawdapus/SKILL.md` mirror.
-6. **Integration test** — Tiverton-reproduction fixture (§7.5), plain integration, no spike-tag.
-7. **PR body** explicitly labels phase 1 vs phase 2 per §6; does **not** close #232.
-
-## 12. Non-goals for this PR (clean cut-line)
-
-- No #164 implementation. This PR depends on #164 *contract* only at the descriptor level; v1 wire surface has no digest section.
-- **No channel events flow through ADR-021's `/recall` in any phase.** v1 produces only through the `channel-awareness` feed and the retrieval tools. v2 produces only through the same `channel-awareness` feed and the same retrieval tools, via `claw-channel-memory` as the new producer; the v2 producer may use #164's salience-memory primitives **as a library**, but channel events do not transit per-agent `/recall`/`/retain`.
-- No release artifact changes (no `release_manifest.go` bumps, no changelog `Latest` badge, no nav dropdown). Per repo CLAUDE.md release discipline.
+- No channel-awareness pod YAML knob in phase 1.
+- No digest producer or channel-memory daemon in phase 1.
+- No UI.
+- No release artifacts.
+- No changes to release pins or public version dropdowns.
+- No LLM salience scoring of channel messages in phase 1.
+- No Discord history backfill beyond claw-wall's retained buffer.

--- a/docs/plans/2026-05-12-issue-232-channel-24h-awareness.md
+++ b/docs/plans/2026-05-12-issue-232-channel-24h-awareness.md
@@ -1,0 +1,234 @@
+# Issue 232 — Bounded 24h channel awareness independent of cursors and restarts
+
+**Author (draft):** claude (`claude:dbaba2df`) on branch `issue-232-channel-24h-awareness` — for adversarial review by codex before any implementation.
+
+**Issue:** https://github.com/mostlydev/clawdapus/issues/232
+
+**Predecessors:**
+- #201 (channel-context tail mode, v0.13.7) — flipped delta→tail as default, dual cap.
+- #204 (cursored append-only context deltas) — late-context placement, no first-system mutation.
+- #220 (channel-cursor session epoch, v0.14.7) — restart bootstrap via `X-Claw-Consumer-Session-Epoch`.
+
+**Sibling:** #164 (salience-memory adapter) — owns LLM-derived compaction. This plan does **not** duplicate that work; v2 of #232 consumes #164's adapter.
+
+## 1. Problem (one paragraph)
+
+#220 fixed *across-restart* cursor bootstrap. #201 fixed tail vs delta semantics. The remaining failure mode is *within an active session*: the agent's cursor legitimately advances past a same-day floor message, then a human prompt refers to that older message, and the agent answers "I don't see it in the last 24h" because its prompt only contains the post-cursor delta. The live Tiverton incident (May 11, 2026, boulton on `#trading-floor`) is the canonical case: Logan posted a CMCSA read at 07:47 ET, boulton's cursor advanced normally, and at 09:50 ET the operator asked "wanna pick up CMCSA on Logan's read?" — boulton's prompt contained only the immediate ping thread because the cursor was already past Logan's message.
+
+This is not a cursor bug. It is a missing *awareness layer*: cursorized delta is the right product for live continuity but the wrong product for "what does this agent know about the last 24h of the room?".
+
+## 2. Contract (the four parts from issue #232 comment r2)
+
+The operator's acceptance contract has four parts. They are not independently dispensable; they compose into "guaranteed bounded 24h awareness":
+
+1. **Raw recent window** — exact messages for immediate continuity, bounded.
+2. **Rolling 24h digest** — LLM-derived, source-backed compaction of older same-day material, regenerated under buffer churn and after restart.
+3. **Retrieval path** — explicit fetch of exact source messages by author/ticker/time/id, so a digest can cite without restating.
+4. **Provider-visible metadata** — every channel-context block in the prompt declares whether it is `delta` / `raw_window` / `digest`, with retained-coverage so the model never claims "I don't see the last 24h" when only a delta was injected.
+
+## 3. Phasing
+
+The plan splits along a hard dependency: part (2) needs a memory-grade producer, and the closest fit is #164's salience-memory adapter. v1 ships parts (1), (3), (4) and an explicit stopgap label on (2). v2 retires the stopgap once #164 lands.
+
+| Part | v1 producer | v2 producer | Wire surface in both phases |
+|------|-------------|-------------|------------------------------|
+| (1) Raw recent window | `claw-wall` (new `channel-awareness` endpoint, uncursored, dual-capped) | unchanged | feed: `channel-awareness` |
+| (2) Rolling 24h digest | **stopgap: omitted** with explicit metadata label `digest=unavailable`; busy rooms rely on retrieval | `claw-channel-memory` (subscribes to claw-wall events, retains via #164's adapter contract, emits `digest=ready`) | feed: `channel-awareness` (composite block) |
+| (3) Retrieval path | `claw-wall` exposes managed tools (ADR-020): `search_channel_context`, `get_channel_messages` | unchanged | `tools[]` |
+| (4) Metadata | header-line discipline on every channel-flavored feed; new `channel_context_op` telemetry event distinguishing `delta` / `raw_window` / `digest` / `tool_call` | unchanged | feed header + telemetry |
+
+The v1 channel-awareness block is **not** rebranded as "the 24h fix". The plan explicitly labels it as bounded raw-window + retrieval; full 24h coverage under busy-room load is only guaranteed once digest lands.
+
+## 4. Wire surfaces
+
+### 4.1 New feed: `channel-awareness` (v1, producer = claw-wall)
+
+```
+GET /channel-awareness?channels=<csv>&since=24h&limit=120&max_chars=12288
+```
+
+- **No cursor**. No `consumer=` param. No `mode=delta` path. This feed exists precisely to be cursor-independent.
+- Same channel-authorization model as `channel-context` (caller is upstream-restricted to surface-derived channels).
+- Reuses `consumeTail` semantics from #201 (newest-first walk, dual cap, sort ASC for output) but rebranded:
+  - Defaults: `since=24h`, `limit=120`, `max_chars=12288` (≈12KB). These are **larger** than `channel-context` tail defaults because this block carries 24h, not "recent ping context". Operator-tunable via `x-claw.context.channel-awareness` (parallel of #201's `x-claw.context.channel`).
+- Header line is explicit about layer kind, exactly so the model cannot conflate it with a delta:
+
+```
+[channel-awareness] kind=raw_window since=24h messages=87 range=2026-05-11T05:42Z..2026-05-12T05:42Z channels=14645…,14647… retained=87/since-24h digest=unavailable
+```
+
+`digest=unavailable` in v1 documents the known gap. In v2 the same feed emits `digest=ready` and a digest section is appended below the raw window.
+
+`channel-context` (the existing delta feed) keeps its `mode=tail` and `mode=delta` headers from #201 verbatim — but #232 lands a **header rewrite** on the `mode=delta` path so it stops claiming `[channel-context]` and instead reads `[channel-context delta] kind=delta`. See §4.4.
+
+### 4.2 New tools: retrieval (v1, producer = claw-wall, ADR-020 managed)
+
+`claw.describe` v2 on the `claw-wall` image declares two managed tools:
+
+```yaml
+tools:
+  - name: search_channel_context
+    description: "Search recent channel buffer (up to retained-coverage window) for messages matching a query."
+    params:
+      channels: { type: array, items: string, required: true }
+      query: { type: string, required: true }
+      since: { type: string, default: "24h" }
+      author: { type: string, required: false }
+      limit: { type: integer, default: 20 }
+    http: { path: /search_channel_context }
+  - name: get_channel_messages
+    description: "Fetch exact channel messages by ID range, or by author+time window."
+    params:
+      channels: { type: array, items: string, required: true }
+      message_ids: { type: array, items: string, required: false }
+      after: { type: string, required: false }    # snowflake id or ISO ts
+      before: { type: string, required: false }
+      limit: { type: integer, default: 20 }
+    http: { path: /get_channel_messages }
+```
+
+Both are **mediated** by cllama (ADR-020) so policy/telemetry/auth flow through the standard plane. Mediation gives us per-call audit, channel ACL enforcement, and bounded response sizing without a runner-specific tool plumbing pass.
+
+Tool responses include the same `kind=raw_window source=claw-wall channels=…` metadata header as the feed, so the model treats tool output and feed injection symmetrically.
+
+### 4.3 Late-context placement (per #204)
+
+The `channel-awareness` block is appended to the late runtime-context system message (OpenAI) or final user content block (Anthropic), alongside the existing `channel-context` delta block and the memory recall block.
+
+Order inside the late block (deterministic for cache-friendliness):
+
+1. memory recall (existing, from ADR-021)
+2. `channel-awareness` (new — broadest layer, anchors the model in the last 24h)
+3. `channel-context` delta (existing, narrowest layer, fresh post-cursor)
+4. current time line (existing)
+
+Rationale: digest/awareness first sets the model's frame of "what the room knows"; delta then signals "what's new since you last looked"; time anchors the moment. Reversing this lets a stale-but-large window dominate fresh signal.
+
+### 4.4 Header discipline (part 4 of contract)
+
+Every channel-flavored block carries an explicit `kind=` field in its header. The implicit assumption "channel-context = full room" is the bug we are killing.
+
+| Block kind | Header prefix | Notes |
+|------------|---------------|-------|
+| `delta` | `[channel-context delta] kind=delta cursor=<ch>:<id>,...` | rewrite of today's `[channel-context]` header; cursor pair already present |
+| `raw_window` | `[channel-awareness] kind=raw_window since=...` | v1 default |
+| `digest` | `[channel-awareness] kind=digest since=... source_count=...` | v2 only, appended below raw_window in composite block |
+| `tool_call` | tool response body, header `[channel-tool] kind=tool_call name=...` | retrieval tool output |
+
+A small change to the existing `[channel-context]` header is the riskiest back-compat surface. It's necessary: today's header has no `kind=` discriminator and operators have already observed the model misinterpreting delta as "the room". v2 of #204's `coverage_partial=true` annotation is preserved verbatim.
+
+### 4.5 Telemetry (part 4 of contract)
+
+New normalized event kind: `channel_context_op` with fields `{kind, channels[], retained, returned, omitted, latency_ms, source, status}`. Emitted for:
+- every channel-awareness fetch (kind=raw_window)
+- every channel-context delta fetch (kind=delta) — reuses existing claw-wall log line but normalizes it through cllama
+- every retrieval tool call (kind=tool_call)
+- v2 digest production (kind=digest_built) and consumption (kind=digest)
+
+`claw audit` surfaces this alongside `memory_op` and `feed_fetch`.
+
+## 5. Compose-up wiring
+
+Pod-level config extends #201's `x-claw.context.channel` with a sibling block:
+
+```yaml
+x-claw:
+  context:
+    channel:                    # existing delta feed (from #201)
+      since: 24h
+      limit: 40
+      max_chars: 8192
+    channel-awareness:          # NEW
+      since: 24h
+      limit: 120
+      max_chars: 12288
+      enabled: true             # explicit opt-in for v1 (default false) — see §8
+```
+
+Service-level overrides via the same pod-defaults pattern (`x-claw.context.channel-awareness` on individual services).
+
+`appendConversationWallFeed` (in `cmd/claw/compose_up.go`) gains a sibling `appendConversationWallAwarenessFeed` that emits `/channel-awareness?channels=...&since=...&limit=...&max_chars=...` when `enabled: true` and the service has any consumed channel IDs. Tool registration uses the existing claw-wall descriptor extraction path.
+
+## 6. Stopgap discipline (codex challenge #2)
+
+This plan **must not** ship as "the 24h fix" without phase 2. The framing in the PR body, the release note, and the on-call runbook reads:
+
+> v1 of #232 ships bounded raw-window awareness, retrieval tools, and metadata. **Busy rooms (>120 messages in 24h) will exceed the v1 dual cap.** When that happens, the agent will see the most recent N messages plus retrieved older ones on demand; full 24h compaction is delivered in v2 once #164's salience-memory adapter lands. The `digest=unavailable` header line documents this in-prompt so the model can decide whether to call retrieval.
+
+The acceptance criterion in the issue body — "later Boulton turn still includes Logan's CMCSA read in the 24h awareness layer without requiring the human to restate it" — is **partially satisfied** in v1: Logan's read is reachable via retrieval (and likely also visible in the raw 24h window for a not-too-busy floor), but not guaranteed-injected. v2 closes the gap.
+
+## 7. Tests
+
+### 7.1 claw-wall (`cmd/claw-wall/`)
+
+- `TestChannelAwarenessHandlerReturnsRawWindow` — `since=24h`, no cursor write, header reads `kind=raw_window`, `digest=unavailable` in v1.
+- `TestChannelAwarenessHandlerDualCap` — 200-message buffer, `limit=50&max_chars=…` → returns newest 50 sorted ASC, header shows `retained=50/...`.
+- `TestChannelAwarenessHandlerColdStart` — buffer holds 10 minutes worth → header reads `retained=N/buffer range=...` honest about coverage.
+- `TestChannelAwarenessHandlerDoesNotMutateCursor` — interleave with `channel-context` delta consumer; awareness fetch leaves delta cursor untouched.
+- `TestSearchChannelContextRespectsACL` — request includes channel not in caller's surface → 403 (reuses claw-wall's existing ACL).
+- `TestGetChannelMessagesByIDRange` — fetch by id range returns exact messages, ordered.
+
+### 7.2 cllama (`cllama/internal/proxy/`)
+
+- `TestChannelAwarenessFeedIsFetchedWithoutCursor` — register a `channel-awareness` feed entry; assert URL has no `after=` and `X-Claw-Consumer-Session-Epoch` is **not** consulted for it (orthogonal to #220's epoch).
+- `TestChannelAwarenessAndDeltaCoExist` — pod wires both feeds; both blocks appear in the late-context section, in the §4.3 order, with their respective `kind=` headers.
+- `TestChannelContextDeltaHeaderRewrite` — existing delta path now emits `[channel-context delta] kind=delta cursor=...`. Regression test reads the new prefix.
+- `TestChannelContextOpTelemetryNormalized` — fetch each kind, assert `audit.go`-style normalized records for `kind=raw_window`, `kind=delta`, `kind=tool_call`.
+
+### 7.3 compose_up (`cmd/claw/`)
+
+- `TestAppendChannelAwarenessFeedHonorsPodConfig` — pod-level `x-claw.context.channel-awareness` overrides flow into generated URL.
+- `TestChannelAwarenessFeedDisabledByDefault` — without explicit `enabled: true`, no feed entry is emitted (v1 opt-in; see §8).
+- `TestChannelAwarenessToolsRegisteredFromDescriptor` — claw-wall descriptor extraction picks up the two tool entries when service is auto-injected.
+
+### 7.4 Pod parser (`internal/pod/`)
+
+- `TestParseChannelAwarenessConfig` — accepts `since` / `limit` / `max_chars` / `enabled`; rejects negatives; rejects unparseable durations.
+- `TestPodDefaultsChannelAwareness` — service-level overrides pod defaults using the standard pattern.
+
+### 7.5 Integration / spike
+
+- Extend `TestSpikeRollCall` (or a sibling spike) so that the rollcall pod's `channel-awareness` feed body contains a header-line `kind=raw_window` and matches the retained-coverage shape. The spike already exercises real LLM calls through cllama; this just asserts the new feed flows end-to-end.
+- A targeted fixture test reproduces the Tiverton case: pre-seed `claw-wall` buffer with messages spanning the cursor, run a turn that advances cursor past Logan's hypothetical CMCSA message, then run a second turn with a human-mention prompt and assert the `channel-awareness` block contains Logan's message even though the `channel-context` delta does not.
+
+## 8. Default behavior and ramp
+
+`channel-awareness` is **opt-in** in v1 (`enabled: true` required at pod level). Two reasons:
+
+1. Token cost is non-trivial: 12KB default added to every cllama turn for pods with active channels. Operators should choose the trade-off explicitly until v2 makes the cost bounded by digest length rather than raw message count.
+2. The header rewrite of `channel-context` delta is the only forced change. Awareness layering itself is opt-in until digest lands and v2 can flip the default.
+
+Once v2 ships, the default flips to `enabled: true` and pods get the full contract automatically.
+
+## 9. Out of scope (deliberately)
+
+- **Cross-channel digest correlation.** v1 and v2 both keep channel-awareness scoped per-channel within a single feed call. Cross-channel synthesis is a future memory adapter feature.
+- **Affect/salience scoring** of channel messages. Same #164 territory.
+- **Discord history backfill** beyond claw-wall's in-process buffer. Per #201 §3 Q3, the wider-continuity feeds cover cold-start. Operators who need a true 24h window today can raise `CLAW_WALL_LIMIT`/buffer; v2's digest reduces the urgency further.
+- **Per-channel awareness/delta toggles.** v1 keeps the pod/service knob granularity from #201.
+- **Anthropic `cache_control` markers** for awareness blocks. Same deferral as #204 v2.
+
+## 10. Open questions for codex r1 review
+
+1. **Composite vs co-injection.** Plan currently treats `channel-awareness` and `channel-context` as two separate feeds. Codex flagged "make the provider-visible surface a channel-awareness block, with the memory adapter as the producer/backend." Should the single block model be enforced from v1 — i.e., one `channel-awareness` feed that *contains* a delta section + a raw-window section + (v2) a digest section, and `channel-context` is retired? Two-feed wins on cache stability and incremental v1→v2 path; one-block wins on model framing and metadata clarity. Lean two-feed but flag for challenge.
+2. **Header rewrite on existing `channel-context`.** v1 changes the prefix from `[channel-context]` to `[channel-context delta] kind=delta`. This is necessary for part-4 metadata discipline but is back-compat-flavored. Acceptable, or should the existing header stay verbatim and only the new feed introduce `kind=`?
+3. **v1 retrieval tools live where?** Plan puts them on `claw-wall` via `claw.describe` v2. Alternative: a thin `claw-channel-memory` shim service that proxies to claw-wall, so when v2 lands the same service produces the digest. Lower v1 cost vs lower v2 refactor cost. Lean claw-wall-direct for v1 with a clear v2 migration note.
+4. **Should the v1 default really be opt-in?** §8 argues opt-in for token-cost discipline. Counter-argument: the issue body is a live trading-desk incident and Tiverton operators would prefer opt-out semantics. Lean opt-in but flag.
+5. **Spike test scope.** Should the targeted Tiverton-reproduction fixture (§7.5 last bullet) be a new spike (`-tags spike`) or a normal integration test against a faked claw-wall? Lean integration; spike-tag inflates CI cost and requires real provider credentials, which this scenario doesn't need.
+
+## 11. Build sequence (assuming codex sign-off)
+
+1. **claw-wall** — `channel-awareness` endpoint reusing `consumeTail`; new tool handlers; descriptor declares tools. Tests in §7.1.
+2. **cllama feed plumbing** — feed name registry already supports per-feed configuration; the new feed flows through with `kind=raw_window` metadata parsing. Tests in §7.2.
+3. **compose_up wiring** — `appendConversationWallAwarenessFeed`; pod parser for `x-claw.context.channel-awareness`. Tests in §7.3, §7.4.
+4. **Header rewrite for delta path** — minimal change in `channel_context_feed.go`; regression covers existing tests.
+5. **Telemetry normalization** — `channel_context_op` event kind, `claw audit` rendering.
+6. **Docs sweep** — `docs/CLLAMA_SPEC.md`, ADR (likely new ADR-025 once codex agrees), `skills/clawdapus/SKILL.md` mirror.
+7. **Integration test** — Tiverton-reproduction fixture (§7.5).
+8. **PR body** explicitly labels phase 1 vs phase 2 per §6.
+
+## 12. Non-goals for this PR (clean cut-line)
+
+- No #164 implementation. This PR depends on #164 *contract* only at the descriptor level; v1 wire surface has no digest section.
+- No changes to ADR-021 (memory plane). v1 of #232 produces nothing through `/recall`; v2 does, but only via the #164 adapter, not directly from claw-wall.
+- No release artifact changes (no `release_manifest.go` bumps, no changelog `Latest` badge, no nav dropdown). Per repo CLAUDE.md release discipline.

--- a/docs/plans/2026-05-12-issue-232-channel-24h-awareness.md
+++ b/docs/plans/2026-05-12-issue-232-channel-24h-awareness.md
@@ -2,6 +2,10 @@
 
 **Author (draft):** claude (`claude:dbaba2df`) on branch `issue-232-channel-24h-awareness` — for adversarial review by codex before any implementation.
 
+**Revision history:**
+- 2026-05-12 r1 — initial draft.
+- 2026-05-12 r2 — codex (`codex:27f8b72e`) r1 adversarial pass; folded in: (1) header rewrite now targets the real after-bound tail path (kind discriminator keyed on `after=` presence, not on `mode=delta` — which is no longer the default per #201); (2) explicit tool ACL/auto-subscription via compose-materialized per-agent channel allowlist; (3) v2 producer model clarified — `claw-channel-memory` emits the channel-awareness wire surface and may use #164 internals, but channel events do **not** flow through ADR-021's `/recall` in any phase; (4) v1 default flipped from opt-in to default-on with smaller per-Discord-channel caps, and #232 explicitly stays open through v2 since v1 is not acceptance-complete; (5) feed ordering enforced via compose-emitted manifest order with regression test; (6) retrieval out-of-buffer semantics spelled out (structured `not_in_buffer` response with retained-coverage range).
+
 **Issue:** https://github.com/mostlydev/clawdapus/issues/232
 
 **Predecessors:**
@@ -33,11 +37,13 @@ The plan splits along a hard dependency: part (2) needs a memory-grade producer,
 | Part | v1 producer | v2 producer | Wire surface in both phases |
 |------|-------------|-------------|------------------------------|
 | (1) Raw recent window | `claw-wall` (new `channel-awareness` endpoint, uncursored, dual-capped) | unchanged | feed: `channel-awareness` |
-| (2) Rolling 24h digest | **stopgap: omitted** with explicit metadata label `digest=unavailable`; busy rooms rely on retrieval | `claw-channel-memory` (subscribes to claw-wall events, retains via #164's adapter contract, emits `digest=ready`) | feed: `channel-awareness` (composite block) |
-| (3) Retrieval path | `claw-wall` exposes managed tools (ADR-020): `search_channel_context`, `get_channel_messages` | unchanged | `tools[]` |
-| (4) Metadata | header-line discipline on every channel-flavored feed; new `channel_context_op` telemetry event distinguishing `delta` / `raw_window` / `digest` / `tool_call` | unchanged | feed header + telemetry |
+| (2) Rolling 24h digest | **stopgap: omitted** with explicit metadata label `digest=unavailable`; busy rooms rely on retrieval | `claw-channel-memory` service (new) — subscribes to claw-wall events, builds rolling digest (may use #164 salience-memory internals as a library, but channel events do **not** transit ADR-021 `/recall`); emits the **same** `channel-awareness` wire surface with `digest=ready` and an appended digest section | feed: `channel-awareness` (composite block, same name) |
+| (3) Retrieval path | `claw-wall` exposes managed tools (ADR-020) `search_channel_context` and `get_channel_messages`, gated by per-agent channel allowlist (see §4.2) | `claw-channel-memory` may offer richer retrieval (e.g., digest-cited source pull); v1 tools remain | `tools[]` |
+| (4) Metadata | header-line discipline keyed on `after=` presence (see §4.4), new `channel_context_op` telemetry distinguishing `delta_tail` / `raw_window` / `digest` / `tool_call` | unchanged | feed header + telemetry |
 
-The v1 channel-awareness block is **not** rebranded as "the 24h fix". The plan explicitly labels it as bounded raw-window + retrieval; full 24h coverage under busy-room load is only guaranteed once digest lands.
+The v1 channel-awareness block is **not** rebranded as "the 24h fix". The plan explicitly labels it as bounded raw-window + retrieval; full 24h coverage under busy-room load is only guaranteed once digest lands. **#232 itself stays open through v2** (codex r1) — v1 ships a meaningful improvement but is not acceptance-complete against the issue body's r2 contract.
+
+**Architectural invariant (codex r1):** in no phase do channel events flow through ADR-021's per-agent `/recall`. `/recall` payload is `messages[]`/`system`/metadata — agent/session shaped, not room-shaped. Channel awareness is its own producer/consumer pair with its own wire surface. #164's salience-memory adapter may be used as an internal library by `claw-channel-memory` (sharing LLM prompts, dedupe heuristics, etc.) but the two adapters do not share the recall/retain wire endpoints.
 
 ## 4. Wire surfaces
 
@@ -48,9 +54,9 @@ GET /channel-awareness?channels=<csv>&since=24h&limit=120&max_chars=12288
 ```
 
 - **No cursor**. No `consumer=` param. No `mode=delta` path. This feed exists precisely to be cursor-independent.
-- Same channel-authorization model as `channel-context` (caller is upstream-restricted to surface-derived channels).
-- Reuses `consumeTail` semantics from #201 (newest-first walk, dual cap, sort ASC for output) but rebranded:
-  - Defaults: `since=24h`, `limit=120`, `max_chars=12288` (≈12KB). These are **larger** than `channel-context` tail defaults because this block carries 24h, not "recent ping context". Operator-tunable via `x-claw.context.channel-awareness` (parallel of #201's `x-claw.context.channel`).
+- Same channel-authorization model as `channel-context` (caller is upstream-restricted to surface-derived channels), PLUS the per-agent ACL of §4.2.1 (the same allowlist guards both feed and tool paths).
+- Reuses `consumeTail` semantics from #201 (newest-first walk, dual cap, sort ASC for output) but rebranded.
+- v1 defaults (r2): `since=24h`, `limit=60`, `max_chars=8192` (8KB, aligned with cllama's `MaxFeedResponseBytes` so we don't double-truncate). Operator-tunable via `x-claw.context.channel-awareness` (parallel of #201's `x-claw.context.channel`).
 - Header line is explicit about layer kind, exactly so the model cannot conflate it with a delta:
 
 ```
@@ -87,11 +93,54 @@ tools:
     http: { path: /get_channel_messages }
 ```
 
-Both are **mediated** by cllama (ADR-020) so policy/telemetry/auth flow through the standard plane. Mediation gives us per-call audit, channel ACL enforcement, and bounded response sizing without a runner-specific tool plumbing pass.
+Both are **mediated** by cllama (ADR-020) so policy/telemetry/auth flow through the standard plane.
 
-Tool responses include the same `kind=raw_window source=claw-wall channels=…` metadata header as the feed, so the model treats tool output and feed injection symmetrically.
+#### 4.2.1 Per-agent channel ACL (codex r1 must-fix)
 
-### 4.3 Late-context placement (per #204)
+Today's `claw-wall` (`cmd/claw-wall/store.go`, `newHandler`) accepts `channels=` from any caller — auto-generated feed URLs are safe only because compose-up writes surface-derived channel IDs into the URL. Model-supplied tool arguments are **not** safe by construction: an agent could call `search_channel_context(channels=["<other-channel-id>"])` and read a room it has no surface to.
+
+Compose-up materializes a per-agent allowlist at `claw up` time and writes it into the `claw-wall` service config alongside `CLAW_WALL_TOKENS`:
+
+```
+CLAW_WALL_AGENT_CHANNELS=<agentID>:<chA>,<chB>;<agentID2>:<chC>,...
+```
+
+`agentID` is the bearer-authenticated principal (already validated by claw-wall for the feed path; same path used for tool path). The allowlist is exactly the surface-derived channel set used to materialize that agent's `channel-context` and `channel-awareness` feed URLs — i.e., what the agent already legitimately has access to.
+
+Tool request handler:
+1. Authenticate caller → `agentID` (existing Bearer validation; tools share auth with feeds).
+2. Parse requested `channels[]`.
+3. Reject any channel not in `allowlist[agentID]` with HTTP 403 and a structured `{"error": "channel_not_allowed", "agent": "...", "channel": "..."}` body. cllama surfaces this as a tool-call error to the model with a short hint ("This agent has no surface to channel X; ask the operator to add it.").
+4. Pass through to store with the validated channel set.
+
+The same allowlist guards both new tool endpoints and is checked once per request.
+
+#### 4.2.2 Auto-subscription
+
+Both tools are auto-registered for any service whose `x-claw` consumes channel surfaces (i.e., the same condition that auto-injects `claw-wall`). No separate pod knob. Rationale: if the agent has channel surfaces declared, it already needs the tools to recover from cursor/buffer-bound gaps. Forcing operators to opt-in twice (channel surface + retrieval tool) is friction without value.
+
+#### 4.2.3 Out-of-buffer semantics (codex r1 must-fix)
+
+claw-wall can only search/return messages currently in its in-process ring buffer (size from `CLAW_WALL_LIMIT`, default 50, configurable up to operator-set ceiling). When a query falls outside that window — either by `since` reach or by `message_ids` referring to evicted ids — the response is structured:
+
+```json
+{
+  "messages": [],
+  "retained_coverage": {
+    "oldest_ts": "2026-05-12T01:14Z",
+    "newest_ts": "2026-05-12T05:42Z",
+    "buffer_size": 500
+  },
+  "status": "not_in_buffer",
+  "hint": "Requested window extends before buffer's oldest_ts. Operator can widen CLAW_WALL_LIMIT or rely on v2 digest once available."
+}
+```
+
+`status: "ok"` for normal hits, `"empty"` for in-buffer-but-no-match, `"not_in_buffer"` for the eviction case. cllama renders this as a tool response with header `[channel-tool] kind=tool_call name=... status=not_in_buffer retained_coverage=...` so the model can see explicitly that the gap is buffer-bound, not absence-of-message.
+
+Tool responses include the same `kind=tool_call source=claw-wall channels=…` metadata header as the feed, so the model treats tool output and feed injection symmetrically. Every returned message carries its Discord snowflake `id` so the model can chain `search_channel_context` → `get_channel_messages` deterministically.
+
+### 4.3 Late-context placement and feed ordering (per #204)
 
 The `channel-awareness` block is appended to the late runtime-context system message (OpenAI) or final user content block (Anthropic), alongside the existing `channel-context` delta block and the memory recall block.
 
@@ -104,25 +153,38 @@ Order inside the late block (deterministic for cache-friendliness):
 
 Rationale: digest/awareness first sets the model's frame of "what the room knows"; delta then signals "what's new since you last looked"; time anchors the moment. Reversing this lets a stale-but-large window dominate fresh signal.
 
+#### 4.3.1 Manifest-order enforcement (codex r1 must-fix)
+
+cllama's `fetchFeeds` / `FormatAllFeeds` (`cllama/internal/feeds/inject.go`) iterate the feed manifest in order. There is no sort step today. The r1 plan said "order inside the late block" without saying who enforces it; codex flagged this. v1 enforces ordering at the **compose-up emission** side:
+
+- `appendConversationWallAwarenessFeed` emits the awareness entry **before** `appendConversationWallFeed` emits the delta entry, both immediately after any memory recall slot.
+- Regression test `TestConversationWallFeedsEmittedInAwarenessBeforeDeltaOrder` asserts the manifest order matches the §4.3 list.
+- A cllama-side deterministic sort for channel-flavored feeds is **deferred** (would require feed-name introspection in `inject.go`). Manifest-order discipline is sufficient because compose-up is the single writer.
+
 ### 4.4 Header discipline (part 4 of contract)
 
 Every channel-flavored block carries an explicit `kind=` field in its header. The implicit assumption "channel-context = full room" is the bug we are killing.
 
-| Block kind | Header prefix | Notes |
-|------------|---------------|-------|
-| `delta` | `[channel-context delta] kind=delta cursor=<ch>:<id>,...` | rewrite of today's `[channel-context]` header; cursor pair already present |
-| `raw_window` | `[channel-awareness] kind=raw_window since=...` | v1 default |
-| `digest` | `[channel-awareness] kind=digest since=... source_count=...` | v2 only, appended below raw_window in composite block |
-| `tool_call` | tool response body, header `[channel-tool] kind=tool_call name=...` | retrieval tool output |
+**Important (codex r1 must-fix):** the discriminator is keyed on the **presence of an `after=` cursor in the fetch URL**, not on the legacy `mode=delta` query param. Since #201, the default `channel-context` fetch uses `mode=tail`, and cllama injects `after=` from its cursor ledger when one exists (see `cllama/internal/proxy/channel_context_feed.go::prepareChannelContextFeed`). The r1 plan's "rewrite mode=delta header" missed this — the real steady-state delta path is `mode=tail` with an `after=` injection, and that is the path the model actually sees and misreads.
 
-A small change to the existing `[channel-context]` header is the riskiest back-compat surface. It's necessary: today's header has no `kind=` discriminator and operators have already observed the model misinterpreting delta as "the room". v2 of #204's `coverage_partial=true` annotation is preserved verbatim.
+| Source URL pattern | Block kind | Header prefix | Notes |
+|--------------------|------------|---------------|-------|
+| `channel-context` with `after=` (steady-state, post-cursor) | `delta_tail` | `[channel-context delta] kind=delta_tail cursor=<ch>:<id>,...` | the headline rewrite; today emits `[channel-context]` with no kind |
+| `channel-context` without `after=` (epoch bootstrap, first turn, empty cursor map) | `tail` | `[channel-context] kind=tail` | one-shot bootstrap or legacy; the cllama-side decision struct (`channelContextPrepareDecision.AppliedAfter == false`) is the trigger |
+| `channel-awareness` (always uncursored) | `raw_window` | `[channel-awareness] kind=raw_window since=...` | v1 default |
+| `channel-awareness` v2 composite | `raw_window` + `digest` sections | `[channel-awareness] kind=raw_window+digest since=... digest_source_count=...` | v2 only; v1 emits `digest=unavailable` instead |
+| Tool response | `tool_call` | `[channel-tool] kind=tool_call name=... status=...` | retrieval tool output |
+
+The header rewrite is generated in claw-wall's response formatter (it already produces the `[channel-context] mode=tail …` line per #201 §4.3). claw-wall doesn't know whether cllama is injecting `after=` against it; but the `mode=tail`-with-`after=` URL parameter is visible to claw-wall on the request, so it can switch the header based on that signal directly. v2 of #204's `coverage_partial=true` annotation is preserved verbatim.
+
+**Back-compat note:** model prompts that contained the old `[channel-context]` header for delta will now see `[channel-context delta] kind=delta_tail` once v1 ships. This is the intended behavior — the old prefix was the bug. No tool/agent code parses this header; only the model reads it.
 
 ### 4.5 Telemetry (part 4 of contract)
 
 New normalized event kind: `channel_context_op` with fields `{kind, channels[], retained, returned, omitted, latency_ms, source, status}`. Emitted for:
 - every channel-awareness fetch (kind=raw_window)
-- every channel-context delta fetch (kind=delta) — reuses existing claw-wall log line but normalizes it through cllama
-- every retrieval tool call (kind=tool_call)
+- every channel-context fetch — kind=delta_tail if `after=` was present, kind=tail otherwise — normalizes the existing claw-wall log line through cllama
+- every retrieval tool call (kind=tool_call) with `status` from §4.2.3 (`ok` / `empty` / `not_in_buffer`)
 - v2 digest production (kind=digest_built) and consumption (kind=digest)
 
 `claw audit` surfaces this alongside `memory_op` and `feed_fetch`.
@@ -138,16 +200,15 @@ x-claw:
       since: 24h
       limit: 40
       max_chars: 8192
-    channel-awareness:          # NEW
+    channel-awareness:          # NEW — defaults applied automatically; pod block only needed for overrides
       since: 24h
-      limit: 120
-      max_chars: 12288
-      enabled: true             # explicit opt-in for v1 (default false) — see §8
+      limit: 60                 # default (r2: tightened from 120)
+      max_chars: 8192           # default (r2: tightened from 12288)
 ```
 
-Service-level overrides via the same pod-defaults pattern (`x-claw.context.channel-awareness` on individual services).
+Service-level overrides via the same pod-defaults pattern (`x-claw.context.channel-awareness` on individual services). There is **no** `enabled` knob — see §8; the feed is emitted automatically when the service consumes any channel surface, matching the auto-injection of `claw-wall` itself.
 
-`appendConversationWallFeed` (in `cmd/claw/compose_up.go`) gains a sibling `appendConversationWallAwarenessFeed` that emits `/channel-awareness?channels=...&since=...&limit=...&max_chars=...` when `enabled: true` and the service has any consumed channel IDs. Tool registration uses the existing claw-wall descriptor extraction path.
+`appendConversationWallFeed` (in `cmd/claw/compose_up.go`) gains a sibling `appendConversationWallAwarenessFeed` that emits `/channel-awareness?channels=...&since=...&limit=...&max_chars=...` whenever the service has any consumed channel IDs. Tool registration uses the existing claw-wall descriptor extraction path. A second emission writes `CLAW_WALL_AGENT_CHANNELS` into the auto-injected `claw-wall` service env, per §4.2.1.
 
 ## 6. Stopgap discipline (codex challenge #2)
 
@@ -165,25 +226,32 @@ The acceptance criterion in the issue body — "later Boulton turn still include
 - `TestChannelAwarenessHandlerDualCap` — 200-message buffer, `limit=50&max_chars=…` → returns newest 50 sorted ASC, header shows `retained=50/...`.
 - `TestChannelAwarenessHandlerColdStart` — buffer holds 10 minutes worth → header reads `retained=N/buffer range=...` honest about coverage.
 - `TestChannelAwarenessHandlerDoesNotMutateCursor` — interleave with `channel-context` delta consumer; awareness fetch leaves delta cursor untouched.
-- `TestSearchChannelContextRespectsACL` — request includes channel not in caller's surface → 403 (reuses claw-wall's existing ACL).
-- `TestGetChannelMessagesByIDRange` — fetch by id range returns exact messages, ordered.
+- `TestChannelContextHeaderRewriteByAfterPresence` — same handler, two requests: one with `after=…` query param emits `[channel-context delta] kind=delta_tail`; one without emits `[channel-context] kind=tail`. (codex r1 must-fix)
+- `TestPerAgentChannelACLAllowsListed` — `CLAW_WALL_AGENT_CHANNELS=A:ch1,ch2` + Bearer for A; tool request for `channels=[ch1]` → 200 with messages.
+- `TestPerAgentChannelACLRejectsUnlisted` — same env; tool request for `channels=[ch3]` → 403 with `{"error":"channel_not_allowed",...}`.
+- `TestRetrievalToolNotInBufferStatus` — buffer has 10min; tool query with `since=12h` returns `status=not_in_buffer` + `retained_coverage` shape per §4.2.3.
+- `TestRetrievalToolEmptyVsNotInBuffer` — distinguishes `status=empty` (in-buffer, no match) from `status=not_in_buffer` (out-of-buffer).
+- `TestGetChannelMessagesByIDRange` — fetch by id range returns exact messages, ordered, each carrying its snowflake id.
 
 ### 7.2 cllama (`cllama/internal/proxy/`)
 
 - `TestChannelAwarenessFeedIsFetchedWithoutCursor` — register a `channel-awareness` feed entry; assert URL has no `after=` and `X-Claw-Consumer-Session-Epoch` is **not** consulted for it (orthogonal to #220's epoch).
 - `TestChannelAwarenessAndDeltaCoExist` — pod wires both feeds; both blocks appear in the late-context section, in the §4.3 order, with their respective `kind=` headers.
-- `TestChannelContextDeltaHeaderRewrite` — existing delta path now emits `[channel-context delta] kind=delta cursor=...`. Regression test reads the new prefix.
-- `TestChannelContextOpTelemetryNormalized` — fetch each kind, assert `audit.go`-style normalized records for `kind=raw_window`, `kind=delta`, `kind=tool_call`.
+- `TestChannelContextHeaderRewriteFlowsThroughCllama` — claw-wall returns `[channel-context delta] kind=delta_tail` for an `after=`-bound fetch; cllama formats it into the late context without further mutation. (codex r1 must-fix)
+- `TestChannelContextOpTelemetryNormalized` — fetch each kind, assert `audit.go`-style normalized records for `kind=raw_window`, `kind=delta_tail`, `kind=tail`, `kind=tool_call`.
 
 ### 7.3 compose_up (`cmd/claw/`)
 
 - `TestAppendChannelAwarenessFeedHonorsPodConfig` — pod-level `x-claw.context.channel-awareness` overrides flow into generated URL.
-- `TestChannelAwarenessFeedDisabledByDefault` — without explicit `enabled: true`, no feed entry is emitted (v1 opt-in; see §8).
-- `TestChannelAwarenessToolsRegisteredFromDescriptor` — claw-wall descriptor extraction picks up the two tool entries when service is auto-injected.
+- `TestChannelAwarenessFeedDefaultOnWithChannelSurface` — service consumes a Discord channel surface; pod has no explicit `channel-awareness` block; feed entry IS emitted with default `since=24h&limit=60&max_chars=8192`. (codex r1, default-on)
+- `TestChannelAwarenessFeedAbsentWithoutChannelSurface` — service has no channel surface; no awareness feed entry emitted.
+- `TestConversationWallFeedsEmittedInAwarenessBeforeDeltaOrder` — manifest-order regression: when both feeds are emitted, awareness appears before delta in the materialized `feeds.json`. (codex r1 must-fix §4.3.1)
+- `TestComposeMaterializesAgentChannelAllowlist` — when claw-wall is auto-injected, the service env contains `CLAW_WALL_AGENT_CHANNELS=<agentID>:<chA>,<chB>;...` reflecting each consuming agent's surface-derived channel set. (codex r1 must-fix §4.2.1)
+- `TestChannelAwarenessToolsRegisteredFromDescriptor` — claw-wall descriptor extraction picks up the two tool entries; tools auto-subscribe to any service with a channel surface (§4.2.2).
 
 ### 7.4 Pod parser (`internal/pod/`)
 
-- `TestParseChannelAwarenessConfig` — accepts `since` / `limit` / `max_chars` / `enabled`; rejects negatives; rejects unparseable durations.
+- `TestParseChannelAwarenessConfig` — accepts `since` / `limit` / `max_chars`; rejects negatives; rejects unparseable durations. No `enabled` field (default-on).
 - `TestPodDefaultsChannelAwareness` — service-level overrides pod defaults using the standard pattern.
 
 ### 7.5 Integration / spike
@@ -191,14 +259,25 @@ The acceptance criterion in the issue body — "later Boulton turn still include
 - Extend `TestSpikeRollCall` (or a sibling spike) so that the rollcall pod's `channel-awareness` feed body contains a header-line `kind=raw_window` and matches the retained-coverage shape. The spike already exercises real LLM calls through cllama; this just asserts the new feed flows end-to-end.
 - A targeted fixture test reproduces the Tiverton case: pre-seed `claw-wall` buffer with messages spanning the cursor, run a turn that advances cursor past Logan's hypothetical CMCSA message, then run a second turn with a human-mention prompt and assert the `channel-awareness` block contains Logan's message even though the `channel-context` delta does not.
 
-## 8. Default behavior and ramp
+## 8. Default behavior and ramp (revised r2)
 
-`channel-awareness` is **opt-in** in v1 (`enabled: true` required at pod level). Two reasons:
+**Codex r1 made the v1-opt-in posture untenable:** if v1 is opt-in and explicitly partial, then operators who don't flip the knob get nothing, and #232 closes on a stopgap that pods haven't actually adopted. The new default is **on**, with smaller caps tuned to Discord channel density, and `digest=unavailable` honestly documenting the gap in v1.
 
-1. Token cost is non-trivial: 12KB default added to every cllama turn for pods with active channels. Operators should choose the trade-off explicitly until v2 makes the cost bounded by digest length rather than raw message count.
-2. The header rewrite of `channel-context` delta is the only forced change. Awareness layering itself is opt-in until digest lands and v2 can flip the default.
+v1 defaults (active when the service consumes any channel surface, no explicit opt-in needed):
 
-Once v2 ships, the default flips to `enabled: true` and pods get the full contract automatically.
+| Knob | v1 default | r1 draft | Rationale |
+|------|-----------|----------|-----------|
+| `enabled` | `true` (implicit) | `false` (explicit opt-in) | codex r1: opt-in fails the issue's acceptance contract |
+| `since` | `24h` | `24h` | unchanged |
+| `limit` | `60` | `120` | r1 caps were generous; smaller default reflects "raw window + retrieval pressure valve" model |
+| `max_chars` | `8192` (8KB) | `12288` (12KB) | aligned with cllama's `MaxFeedResponseBytes` so we don't risk double-truncation |
+
+Per-pod overrides still available via `x-claw.context.channel-awareness`. Operators with low-density rooms can raise the caps; high-traffic rooms keep the smaller defaults and lean on retrieval until v2.
+
+**#232 stays open through v2.** Per codex r1: v1 is a meaningful improvement (raw-window + retrieval + metadata) but does not satisfy the issue body's r2 acceptance contract ("guaranteed 24h awareness regardless of session state and trigger"). The PR that lands v1 is titled `#232 phase 1: raw-window + retrieval + metadata` and closes #232 only when v2 (digest via `claw-channel-memory`) ships.
+
+The PR body explicitly says:
+> Phase 1 of #232. Lands the raw-window feed, retrieval tools, and metadata header discipline; busy rooms still rely on retrieval to close gaps. Phase 2 (rolling digest via `claw-channel-memory`) lands when #164 is far enough along to share its salience primitives. #232 stays open through both phases.
 
 ## 9. Out of scope (deliberately)
 
@@ -208,27 +287,50 @@ Once v2 ships, the default flips to `enabled: true` and pods get the full contra
 - **Per-channel awareness/delta toggles.** v1 keeps the pod/service knob granularity from #201.
 - **Anthropic `cache_control` markers** for awareness blocks. Same deferral as #204 v2.
 
-## 10. Open questions for codex r1 review
+## 10. r1 open questions — codex answers and r2 resolution
 
-1. **Composite vs co-injection.** Plan currently treats `channel-awareness` and `channel-context` as two separate feeds. Codex flagged "make the provider-visible surface a channel-awareness block, with the memory adapter as the producer/backend." Should the single block model be enforced from v1 — i.e., one `channel-awareness` feed that *contains* a delta section + a raw-window section + (v2) a digest section, and `channel-context` is retired? Two-feed wins on cache stability and incremental v1→v2 path; one-block wins on model framing and metadata clarity. Lean two-feed but flag for challenge.
-2. **Header rewrite on existing `channel-context`.** v1 changes the prefix from `[channel-context]` to `[channel-context delta] kind=delta`. This is necessary for part-4 metadata discipline but is back-compat-flavored. Acceptable, or should the existing header stay verbatim and only the new feed introduce `kind=`?
-3. **v1 retrieval tools live where?** Plan puts them on `claw-wall` via `claw.describe` v2. Alternative: a thin `claw-channel-memory` shim service that proxies to claw-wall, so when v2 lands the same service produces the digest. Lower v1 cost vs lower v2 refactor cost. Lean claw-wall-direct for v1 with a clear v2 migration note.
-4. **Should the v1 default really be opt-in?** §8 argues opt-in for token-cost discipline. Counter-argument: the issue body is a live trading-desk incident and Tiverton operators would prefer opt-out semantics. Lean opt-in but flag.
-5. **Spike test scope.** Should the targeted Tiverton-reproduction fixture (§7.5 last bullet) be a new spike (`-tags spike`) or a normal integration test against a faked claw-wall? Lean integration; spike-tag inflates CI cost and requires real provider credentials, which this scenario doesn't need.
+(Original five questions kept for traceability; codex r1 answers and r2 outcome inline.)
 
-## 11. Build sequence (assuming codex sign-off)
+1. **Composite vs co-injection.** r1 leaned two-feed.
+   - **Codex r1:** two-feed OK for v1 *if* rendered/ordered as one coherent channel layer.
+   - **r2 resolution:** two feeds (`channel-awareness`, `channel-context`) with compose-emitted manifest order enforced (§4.3.1). Telemetry treats them as one logical layer via `channel_context_op`. v2 can collapse to one feed if useful but is not required.
 
-1. **claw-wall** — `channel-awareness` endpoint reusing `consumeTail`; new tool handlers; descriptor declares tools. Tests in §7.1.
-2. **cllama feed plumbing** — feed name registry already supports per-feed configuration; the new feed flows through with `kind=raw_window` metadata parsing. Tests in §7.2.
-3. **compose_up wiring** — `appendConversationWallAwarenessFeed`; pod parser for `x-claw.context.channel-awareness`. Tests in §7.3, §7.4.
-4. **Header rewrite for delta path** — minimal change in `channel_context_feed.go`; regression covers existing tests.
-5. **Telemetry normalization** — `channel_context_op` event kind, `claw audit` rendering.
+2. **Header rewrite on `channel-context`.** r1 said "change to `[channel-context delta] kind=delta`".
+   - **Codex r1 must-fix:** rewrite targeted the wrong path (`mode=delta` is no longer the default since #201). The real delta path is `mode=tail` + `after=`.
+   - **r2 resolution:** rewrite is keyed on `after=` presence. See §4.4 for the four kinds (`delta_tail`, `tail`, `raw_window`, `tool_call`).
+
+3. **v1 retrieval tools live where?** r1 leaned claw-wall-direct.
+   - **Codex r1:** claw-wall-direct OK *only after* ACL/auto-subscribe is solved.
+   - **r2 resolution:** claw-wall-direct with §4.2.1 per-agent channel allowlist materialized at compose time + §4.2.2 auto-subscription. ACL is the gating condition; not a separate phase.
+
+4. **v1 default opt-in vs opt-out.** r1 leaned opt-in for token cost discipline.
+   - **Codex r1:** opt-in means v1 is not acceptance-complete; either split issues or make default-on with smaller caps.
+   - **r2 resolution:** default-on with smaller caps (`limit=60`, `max_chars=8192`), and #232 stays open through v2 (§8). The smaller caps keep token-cost discipline without requiring operators to flip a knob.
+
+5. **Spike test scope.** r1 leaned plain integration over spike-tagged.
+   - **Codex r1:** plain integration, fake claw-wall, no spike-tag.
+   - **r2 resolution:** confirmed — §7.5 targeted reproduction is a normal integration test.
+
+## 10b. Open questions for codex r2 review
+
+1. **Compose CLAW_WALL_AGENT_CHANNELS env shape.** §4.2.1 specifies `<agentID>:<chA>,<chB>;<agentID2>:...` as a single env var. Alternative: a separate small JSON file mounted into claw-wall (e.g., `claw-wall-agent-channels.json`) like the cllama memory.json pattern. Env-var keeps wiring simple but is shell-fragile for large pods; JSON is more idiomatic but adds a mount. Lean env-var for v1 because the value is small and pure ASCII.
+2. **Tool error rendering.** §4.2.3 specifies `status=not_in_buffer` with a `hint` field. Should cllama's tool-call telemetry record `status` separately from `error_class`, or fold it into the existing `tool_call_result` event? Lean separate so audits can filter "the model retrieved nothing" cases without parsing free-text hints.
+3. **digest=unavailable signaling.** v1 header always carries `digest=unavailable`. Should the model see this once at the top of `channel-awareness` or repeated in `channel-context delta` blocks too? Lean once (in awareness only) — repeating it in delta would invite the model to assume delta is the entire room when digest is unavailable, which is the original bug.
+4. **`claw-channel-memory` service naming and image location.** v2 introduces a new service. Live under `examples/channel-memory/` like `examples/reference-memory/`, or directly as `cmd/claw-channel-memory/` + published image? Lean `examples/` for v2 initial wave (operator-visible but not yet a published infra image), promote later. Matches #164's `examples/salience-memory/` pattern.
+
+## 11. Build sequence (assuming codex r2 sign-off)
+
+1. **claw-wall** — `channel-awareness` endpoint reusing `consumeTail`; per-agent channel ACL (§4.2.1) parsing `CLAW_WALL_AGENT_CHANNELS`; new tool handlers (`search_channel_context`, `get_channel_messages`) with `not_in_buffer` semantics (§4.2.3); descriptor declares tools. Tests in §7.1.
+2. **compose_up wiring** — `appendConversationWallAwarenessFeed`; pod parser for `x-claw.context.channel-awareness`; ACL allowlist materialization writes `CLAW_WALL_AGENT_CHANNELS` into the `claw-wall` service env; manifest-order discipline emits awareness before delta. Tests in §7.3, §7.4.
+3. **Header rewrite (claw-wall side)** — `channel-context` response formatter switches on `after=` presence to emit `[channel-context delta] kind=delta_tail` vs `[channel-context] kind=tail`. Tests in §7.1.
+4. **cllama feed plumbing** — feed name registry already supports per-feed configuration; the new feed flows through with `kind=raw_window` metadata parsing. Tests in §7.2.
+5. **Telemetry normalization** — `channel_context_op` event kind, `claw audit` rendering; `tool_call_result` status fold-in (or new field per §10b.2).
 6. **Docs sweep** — `docs/CLLAMA_SPEC.md`, ADR (likely new ADR-025 once codex agrees), `skills/clawdapus/SKILL.md` mirror.
 7. **Integration test** — Tiverton-reproduction fixture (§7.5).
-8. **PR body** explicitly labels phase 1 vs phase 2 per §6.
+8. **PR body** explicitly labels phase 1 vs phase 2 per §6; does **not** close #232.
 
 ## 12. Non-goals for this PR (clean cut-line)
 
 - No #164 implementation. This PR depends on #164 *contract* only at the descriptor level; v1 wire surface has no digest section.
-- No changes to ADR-021 (memory plane). v1 of #232 produces nothing through `/recall`; v2 does, but only via the #164 adapter, not directly from claw-wall.
+- **No channel events flow through ADR-021's `/recall` in any phase.** v1 produces only through the `channel-awareness` feed and the retrieval tools. v2 produces only through the same `channel-awareness` feed and the same retrieval tools, via `claw-channel-memory` as the new producer; the v2 producer may use #164's salience-memory primitives **as a library**, but channel events do not transit per-agent `/recall`/`/retain`.
 - No release artifact changes (no `release_manifest.go` bumps, no changelog `Latest` badge, no nav dropdown). Per repo CLAUDE.md release discipline.

--- a/docs/plans/2026-05-12-issue-232-channel-24h-awareness.md
+++ b/docs/plans/2026-05-12-issue-232-channel-24h-awareness.md
@@ -6,6 +6,7 @@
 - 2026-05-12 r1 — initial draft.
 - 2026-05-12 r2 — codex (`codex:27f8b72e`) r1 adversarial pass; folded in: (1) header rewrite now targets the real after-bound tail path (kind discriminator keyed on `after=` presence, not on `mode=delta` — which is no longer the default per #201); (2) explicit tool ACL/auto-subscription via compose-materialized per-agent channel allowlist; (3) v2 producer model clarified — `claw-channel-memory` emits the channel-awareness wire surface and may use #164 internals, but channel events do **not** flow through ADR-021's `/recall` in any phase; (4) v1 default flipped from opt-in to default-on with smaller per-Discord-channel caps, and #232 explicitly stays open through v2 since v1 is not acceptance-complete; (5) feed ordering enforced via compose-emitted manifest order with regression test; (6) retrieval out-of-buffer semantics spelled out (structured `not_in_buffer` response with retained-coverage range).
 - 2026-05-12 r3 — codex r2 adversarial pass; folded in: (a) auth model rewritten — claw-wall does **not** validate bearer auth on `/channel-context`; feeds remain generated-URL-only on the compose network; tools are strictly cllama-mediated with cllama validating agent identity + per-agent channel allowlist before forwarding to claw-wall (claw-wall enforces defense-in-depth via a service token + `X-Claw-ID` header); (b) tool auto-registration spelled out — compose-up emits a synthetic `claw.describe` v2 descriptor on the auto-injected claw-wall service that routes through the existing extraction path; (c) #220 epoch-bootstrap path gets its own `kind=bootstrap_tail` via a cllama-passed `context_kind=` URL hint; (d) ACL allowlist switched from env-var to a mounted JSON config file (`claw-wall-agent-channels.json`); claw-wall recreates on config change, no hot reload in v1; (e) `channel_context_op` telemetry spec'd explicitly for both feed and tool paths; (f) stale text scrubbed (§4.1 caps, §6 ">120 messages" wording, §7.5 spike vs integration, §4.1 "mode=delta header rewrite" residue).
+- 2026-05-12 r4 — codex r3 adversarial pass; folded in: (i) descriptor mechanism switched to **built-in compiler-owned descriptor** (`builtinClawWallDescriptor()`, sibling of `builtinClawAPIDescriptor()`) because `internal/inspect.ParseLabels` only knows `claw.describe` and treats the value as a build-context file path — neither inline JSON nor runtime bind-mount works at compile time; (ii) tool auto-subscription mechanism corrected — `injectConversationWall` appends a synthetic `tools: [{service: claw-wall, allow: [search_channel_context, get_channel_messages]}]` policy to each channel-consuming service **before** `resolveToolSubscriptions`, since that resolver only scans consumer `svc.Claw.Tools` and does not walk provider descriptors; (iii) allowlist file-content change triggers compose recreate via a sha256-hash env (`CLAW_WALL_AGENT_CHANNELS_SHA=<hash>`) on the claw-wall service — Docker Compose hashes service config, not bind-mounted file contents, so the file alone would not recreate the container; (iv) tool bearer-token projection corrected — token flows through `serviceAuth` map (`map[agentID]ServiceAuthEntry{Service:"claw-wall", AuthType:"bearer", Token:...}`) that `resolveManifestAuth` already consumes, NOT through `CLAW_WALL_TOOL_TOKEN` env on the agent container; (v) §4.1 "same allowlist guards both feed and tool paths" claim deleted — feeds stay generated-URL-only/network-scoped; (vi) §10 traceability note that r3 supersedes r2's after=-presence keying with explicit `context_kind=` stamping.
 
 **Issue:** https://github.com/mostlydev/clawdapus/issues/232
 
@@ -55,7 +56,7 @@ GET /channel-awareness?channels=<csv>&since=24h&limit=60&max_chars=8192&context_
 ```
 
 - **No cursor**. No `consumer=` param. No `mode=delta` path. This feed exists precisely to be cursor-independent.
-- Same channel-authorization model as `channel-context` (caller is upstream-restricted to surface-derived channels), PLUS the per-agent ACL of §4.2.1 (the same allowlist guards both feed and tool paths).
+- Same channel-authorization model as `channel-context`: caller is upstream-restricted to surface-derived channels, baked into the generated URL by compose-up. The feed path is **not** bearer-authenticated and does **not** consult the per-agent allowlist file — single-writer compose URLs on the compose network are the trust boundary (codex r3.4). The per-agent allowlist of §4.2.1 guards the **tool path only**, where channels are model-supplied.
 - Reuses `consumeTail` semantics from #201 (newest-first walk, dual cap, sort ASC for output) but rebranded.
 - v1 defaults (r2): `since=24h`, `limit=60`, `max_chars=8192` (8KB, aligned with cllama's `MaxFeedResponseBytes` so we don't double-truncate). Operator-tunable via `x-claw.context.channel-awareness` (parallel of #201's `x-claw.context.channel`).
 - Generated URL example: `/channel-awareness?channels=14645…,14647…&since=24h&limit=60&max_chars=8192&context_kind=raw_window`.
@@ -115,7 +116,7 @@ The model never speaks to claw-wall directly. Tool calls go: model → cllama va
 **Where the allowlist lives:** compose-up materializes a single JSON config at `claw up` time (codex r2: prefer file over env var) and mounts it read-only into `claw-wall`:
 
 ```json
-// claw-wall-agent-channels.json (mounted at /etc/claw-wall/agent-channels.json)
+// .claw-runtime/claw-wall-agent-channels.json (bind-mounted at /etc/claw-wall/agent-channels.json)
 {
   "version": 1,
   "agents": {
@@ -125,11 +126,30 @@ The model never speaks to claw-wall directly. Tool calls go: model → cllama va
 }
 ```
 
-The same allowlist is also projected into each agent's cllama context dir (`channels-allowlist.json`) so cllama can pre-check before forwarding. Two-lock model: cllama is the primary gate (correctness), claw-wall is the defense-in-depth (containment if cllama is bypassed or misconfigured).
+The same allowlist is also projected into each agent's cllama context dir (`channels-allowlist.json`) so cllama can pre-check before forwarding. Two-lock model: cllama is the primary gate (correctness, applied before any forwarding), claw-wall is the defense-in-depth (containment if cllama is bypassed or misconfigured).
 
-**No hot reload in v1** (codex r2): claw-wall reads the file at startup. `claw up` recreates the claw-wall container when the generated config changes (compose detects the file-mount diff). Operators who add a channel surface mid-life must `claw up` to re-materialize.
+**Compose recreates claw-wall when the allowlist content changes (codex r3.3).** Docker Compose's service-config hash sees the bind-mount path, not the file contents — so a file-only edit would not recreate the container. To force a recreate when the allowlist changes:
 
-**claw-wall service token:** compose-up generates a per-pod service token at `claw up` time (same pattern as the `claw-api` token from #44/`x-claw.master`). The token is mounted into cllama's per-agent context as part of the tool's auth descriptor (existing ADR-020 path) and into claw-wall's env as `CLAW_WALL_TOOL_TOKEN`. claw-wall validates incoming tool requests have `Authorization: Bearer <CLAW_WALL_TOOL_TOKEN>`; without it, 401.
+- compose-up computes `sha256` of the marshalled JSON and sets `CLAW_WALL_AGENT_CHANNELS_SHA=<hash>` on the auto-injected claw-wall service.
+- The env value is part of the service config, so Docker Compose detects the diff and recreates the container on `claw up`.
+- claw-wall reads the file at startup; no hot reload. The sha env is purely for compose-diff detection, not consulted by claw-wall itself.
+
+Test (§7.3): `TestComposeBumpsAllowlistShaOnAllowlistChange` — change a channel surface, re-run compose generation, assert the env hash changes.
+
+**claw-wall service token (codex r3.5):** compose-up generates a per-pod service token at `claw up` time (same pattern as the `claw-api` token from #44/`x-claw.master`). The token is set on the claw-wall service as `CLAW_WALL_TOOL_TOKEN` (server side only) and is projected per-consumer-agent through the existing `serviceAuth` map that `resolveManifestAuth` already consumes:
+
+```go
+// prepareConversationWallToolRuntime (new) returns one of these per channel-consuming agent
+ServiceAuthEntry{
+    Service:  "claw-wall",
+    AuthType: "bearer",
+    Token:    <generated-per-pod-token>,
+}
+```
+
+These entries are merged with the existing claw-api/history auth entries **before** `buildToolManifestEntries`, so `tools.json` gets the bearer token without adding `CLAW_WALL_TOOL_TOKEN` as an env on the consumer's container. Test (§7.3): `TestToolsJSONCarriesClawWallBearerWithoutLeakingEnv` — consumer's `tools.json` has the token, consumer container env does **not** contain `CLAW_WALL_TOOL_TOKEN`.
+
+claw-wall validates incoming tool requests have `Authorization: Bearer <CLAW_WALL_TOOL_TOKEN>`; without it, 401.
 
 **Tool request handler order:**
 1. Validate `Authorization` header against `CLAW_WALL_TOOL_TOKEN`. Miss → 401 `{"error":"unauthenticated"}`.
@@ -141,25 +161,60 @@ The same allowlist is also projected into each agent's cllama context dir (`chan
 
 cllama surfaces the 403 case to the model with a short hint ("This agent has no surface to channel X; ask the operator to add it.").
 
-#### 4.2.2 Tool auto-registration (codex r2 must-fix)
+#### 4.2.2 Tool auto-registration via built-in descriptor (codex r2+r3 must-fix)
 
-Auto-injected `claw-wall` is not a user-declared `x-claw` provider, so the existing descriptor extraction path needs an explicit hook. The mechanism:
+Auto-injected `claw-wall` is not a user-declared `x-claw` provider, and (per r3.1) `internal/inspect.ParseLabels` only recognizes `claw.describe` whose value is a build-context file path — it does not consume `claw.describe.path` and does not consume inline JSON. Bind-mounted runtime files are also not visible to the compile-time descriptor extractor. The clean fix is a **compiler-owned built-in descriptor**, sibling of the existing `builtinClawAPIDescriptor()` used for the auto-injected `claw-api` service:
 
-1. compose-up generates the `claw-wall` service as today (including image, env, healthcheck).
-2. compose-up additionally writes a **synthetic `claw.describe` v2 descriptor** to the runtime artifact dir (`.claw-runtime/describe/claw-wall.json`) declaring the two tool entries with their HTTP paths and `auth: {type: bearer, env: CLAW_WALL_TOOL_TOKEN}`.
-3. compose-up adds a label to the claw-wall service: `claw.describe.path=/etc/claw-wall/describe.json`, and bind-mounts the synthetic descriptor file at that path. This routes auto-injected claw-wall through the existing `internal/describe/` extraction code path without a new code branch — the descriptor extractor reads from image labels OR from the filesystem-fallback path that already exists for build-context descriptors.
-4. The normal compile pipeline (`internal/describe/registry.go`) projects the two tool entries into the `tools.json` of each agent whose `x-claw` consumes a channel surface (the same auto-subscription trigger that injects `claw-wall` itself).
-5. Per-agent `tools.json` gets the standard ADR-020 mediated tool entry shape, with `http.base_url=http://claw-wall:8080`, `http.path=/search_channel_context` (or `/get_channel_messages`), and `auth.token=<service-token-value>`.
+```go
+// internal/describe/builtins.go (new sibling)
+func builtinClawWallDescriptor() ServiceDescriptor {
+    return ServiceDescriptor{
+        Version: 2,
+        Service: "claw-wall",
+        Tools: []ToolSpec{
+            {
+                Name: "search_channel_context",
+                HTTP: &ToolHTTPSpec{BaseURL: "http://claw-wall:8080", Path: "/search_channel_context"},
+                Auth: &ToolAuthSpec{Type: "bearer", Service: "claw-wall"},
+                Params: /* per §4.2 spec */,
+            },
+            {
+                Name: "get_channel_messages",
+                HTTP: &ToolHTTPSpec{BaseURL: "http://claw-wall:8080", Path: "/get_channel_messages"},
+                Auth: &ToolAuthSpec{Type: "bearer", Service: "claw-wall"},
+                Params: /* per §4.2 spec */,
+            },
+        },
+    }
+}
+```
 
-This means **no new code in the describe extractor or tool-manifest compiler** — we use the existing label + filesystem-fallback path, and the new code is confined to compose-up (synthetic descriptor emission) and claw-wall (the two new HTTP handlers + auth).
+Register it in `collectServiceDescriptors` / `resolveServiceMetadata` whenever the auto-injected claw-wall service is present (same condition that fires `injectConversationWall`).
 
-Regression test (§7.3 `TestComposeMaterializesAutoRegisteredToolsForChannelConsumers`): a pod with two agents — one consuming a Discord channel surface, one not — produces `tools.json` for the first agent containing both `search_channel_context` and `get_channel_messages` entries with the correct base URL and bearer token; the second agent's `tools.json` contains neither.
+#### 4.2.3 Synthetic tool-subscription policy (codex r3.2 must-fix)
 
-#### 4.2.3 Auto-subscription trigger
+Provider-descriptor presence alone does not subscribe consumers. `resolveToolSubscriptions` only scans consumer `svc.Claw.Tools` and matches against registered providers — it does not walk providers and attach to consumers.
+
+`injectConversationWall` therefore appends a synthetic tool-subscription policy to each channel-consuming service **before** `resolveToolSubscriptions` runs:
+
+```yaml
+# appended in-memory to each channel-consuming service's x-claw.tools
+tools:
+  - service: claw-wall
+    allow: [search_channel_context, get_channel_messages]
+```
+
+This keeps the existing registry-validation and `buildToolManifestEntries` code paths load-bearing — no new tool-resolution code branch. The synthetic policy is conditional: only services whose surfaces consume Discord channels get it, matching the §4.2.4 auto-subscription trigger.
+
+Regression tests (§7.3):
+- `TestInjectConversationWallAddsToolPolicyToChannelConsumers` — a pod with two services (one channel-consuming, one not) results in the channel-consumer's in-memory `x-claw.tools` containing `{service: claw-wall, allow: [...]}` after `injectConversationWall`; the non-consumer's is unchanged.
+- `TestComposeMaterializesAutoRegisteredToolsForChannelConsumers` — end-to-end: the same setup produces `tools.json` for the channel-consumer with both tool entries; the non-consumer's `tools.json` has neither.
+
+#### 4.2.4 Auto-subscription trigger condition
 
 Tools are auto-registered for any service whose `x-claw` consumes channel surfaces (i.e., the same condition that auto-injects `claw-wall`). No separate pod knob. Rationale: if the agent has channel surfaces declared, it already needs the tools to recover from cursor/buffer-bound gaps. Forcing operators to opt-in twice (channel surface + retrieval tool) is friction without value.
 
-#### 4.2.4 Out-of-buffer semantics (codex r1 must-fix)
+#### 4.2.5 Out-of-buffer semantics (codex r1 must-fix)
 
 claw-wall can only search/return messages currently in its in-process ring buffer (size from `CLAW_WALL_LIMIT`, default 50, configurable up to operator-set ceiling). When a query falls outside that window — either by `since` reach or by `message_ids` referring to evicted ids — the response is structured:
 
@@ -258,7 +313,7 @@ Schema (cllama records, claw-api surfaces):
 Emission sites:
 - every `channel-awareness` fetch → `kind=raw_window`
 - every `channel-context` fetch → `kind` mirrors the cllama-side `context_kind=` decision (`delta_tail` / `bootstrap_tail` / `tail`), so the audit view shows exactly which path served each turn
-- every retrieval tool call → `kind=tool_call`, `status` reflects the §4.2.4 enum, `tool_name` is the called tool
+- every retrieval tool call → `kind=tool_call`, `status` reflects the §4.2.5 enum, `tool_name` is the called tool
 - v2: digest production → `kind=digest_built`; digest injection → `kind=digest`
 
 The retrieval `status` is also embedded in the session-history tool-trace record (per r2: agents/audits that look at session history can see "the tool was called, it returned not_in_buffer" without re-correlating two streams). The cllama tool-trace shim writes `status` into the existing trace JSON alongside the request/response pair.
@@ -284,13 +339,15 @@ x-claw:
 
 Service-level overrides via the same pod-defaults pattern (`x-claw.context.channel-awareness` on individual services). There is **no** `enabled` knob — see §8; the feed is emitted automatically when the service consumes any channel surface, matching the auto-injection of `claw-wall` itself.
 
-`appendConversationWallFeed` (in `cmd/claw/compose_up.go`) gains a sibling `appendConversationWallAwarenessFeed` that emits `/channel-awareness?channels=...&since=...&limit=...&max_chars=...&context_kind=raw_window` whenever the service has any consumed channel IDs. Three additional emissions:
+`appendConversationWallFeed` (in `cmd/claw/compose_up.go`) gains a sibling `appendConversationWallAwarenessFeed` that emits `/channel-awareness?channels=...&since=...&limit=...&max_chars=...&context_kind=raw_window` whenever the service has any consumed channel IDs. Plus the following compose-time work (codex r3 refinements):
 
-1. The synthetic `claw.describe` v2 descriptor at `.claw-runtime/describe/claw-wall.json` declaring the two retrieval tools (per §4.2.2). The claw-wall service gets a `claw.describe.path` label and a bind-mount for that file.
-2. The per-agent channel allowlist at `.claw-runtime/claw-wall-agent-channels.json` (per §4.2.1). Bind-mounted into claw-wall at `/etc/claw-wall/agent-channels.json`.
-3. The per-agent allowlist is also projected into each agent's cllama context dir as `channels-allowlist.json` so cllama can pre-check before forwarding tool calls.
+1. **Built-in descriptor registration (§4.2.2):** `collectServiceDescriptors` registers `builtinClawWallDescriptor()` when the auto-injected claw-wall service is present. No bind-mount, no `claw.describe.path` label, no synthetic descriptor file on disk — the descriptor is compiler-owned, sibling of `builtinClawAPIDescriptor()`.
+2. **Synthetic tool-subscription policy (§4.2.3):** before `resolveToolSubscriptions`, `injectConversationWall` appends `tools: [{service: claw-wall, allow: [search_channel_context, get_channel_messages]}]` in-memory to each channel-consuming service's `x-claw`. The normal resolver then materializes those into the consumer's `tools.json`.
+3. **Per-agent allowlist file (§4.2.1):** materialized at `.claw-runtime/claw-wall-agent-channels.json`, bind-mounted into claw-wall at `/etc/claw-wall/agent-channels.json`. Also projected into each consuming agent's cllama context as `channels-allowlist.json` (cllama-side primary gate).
+4. **Allowlist sha env (§4.2.1, codex r3.3):** the sha256 of the marshalled allowlist JSON is set as `CLAW_WALL_AGENT_CHANNELS_SHA=<hash>` on the claw-wall service. This is what makes Docker Compose recreate the container when allowlist contents change; without it, the bind-mount path alone would be considered stable.
+5. **Tool bearer projection via `serviceAuth` (§4.2.1, codex r3.5):** `prepareConversationWallToolRuntime` emits a `ServiceAuthEntry{Service: "claw-wall", AuthType: "bearer", Token: <generated>}` per channel-consuming agent. These flow into the existing `serviceAuth` map consumed by `resolveManifestAuth`, so per-agent `tools.json` gets the bearer token **without** the consumer container's env carrying `CLAW_WALL_TOOL_TOKEN`. Only the claw-wall service env has it.
 
-claw-wall reloads neither file at runtime in v1: a generated-config change triggers compose recreate-on-diff (Docker compose hashes mounted file content), so `claw up` after any pod edit gives claw-wall the fresh allowlist. No SIGHUP path needed.
+claw-wall reloads neither file at runtime in v1; the sha-env mechanism above ensures `claw up` after any pod edit produces a fresh claw-wall container with the fresh allowlist.
 
 ## 6. Stopgap discipline (codex challenge #2)
 
@@ -318,7 +375,7 @@ The acceptance criterion in the issue body — "later Boulton turn still include
   - `TestToolRequestRejectsDisallowedChannel` — Bearer ok, agent known, requested channel not in agent's allowlist → 403 with `{"error":"channel_not_allowed", ...}`.
   - `TestToolRequestAcceptsAllowedAgentAndChannel` — full happy path → 200.
 - `TestToolRequestLoadsAllowlistFromMountedFile` — claw-wall reads `/etc/claw-wall/agent-channels.json` at startup; a malformed file produces a startup failure (fail-closed).
-- `TestRetrievalToolNotInBufferStatus` — buffer has 10min; tool query with `since=12h` returns `status=not_in_buffer` + `retained_coverage` shape per §4.2.4.
+- `TestRetrievalToolNotInBufferStatus` — buffer has 10min; tool query with `since=12h` returns `status=not_in_buffer` + `retained_coverage` shape per §4.2.5.
 - `TestRetrievalToolEmptyVsNotInBuffer` — distinguishes `status=empty` (in-buffer, no match) from `status=not_in_buffer` (out-of-buffer).
 - `TestGetChannelMessagesByIDRange` — fetch by id range returns exact messages, ordered, each carrying its snowflake id.
 
@@ -343,9 +400,11 @@ The acceptance criterion in the issue body — "later Boulton turn still include
 - `TestConversationWallFeedsEmittedInAwarenessBeforeDeltaOrder` — manifest-order regression: when both feeds are emitted, awareness appears before delta in the materialized `feeds.json`. (codex r1 must-fix §4.3.1)
 - `TestComposeMaterializesAgentChannelAllowlistJSON` — when claw-wall is auto-injected, the runtime dir contains `claw-wall-agent-channels.json` with the per-agent allowlist, bind-mounted at `/etc/claw-wall/agent-channels.json`. (codex r2 must-fix §4.2.1)
 - `TestComposeProjectsAllowlistIntoCllamaContext` — each consuming agent's cllama context dir contains `channels-allowlist.json` mirroring the same surface-derived channels.
-- `TestComposeEmitsSyntheticClawWallDescriptor` — `.claw-runtime/describe/claw-wall.json` exists with the two tool entries; the claw-wall service has a `claw.describe.path` label pointing at the bind-mounted descriptor. (codex r2 must-fix §4.2.2)
-- `TestComposeMaterializesAutoRegisteredToolsForChannelConsumers` — pod with two agents (one channel-consuming, one not); the channel-consuming agent's `tools.json` contains both `search_channel_context` and `get_channel_messages` with `http.base_url=http://claw-wall:8080` and the service token in `auth.token`; the non-consumer's `tools.json` contains neither.
-- `TestComposeEmitsClawWallToolTokenEnv` — auto-injected claw-wall service env contains `CLAW_WALL_TOOL_TOKEN=<generated>`; the same value appears in the consuming agent's `tools.json` auth descriptor.
+- `TestComposeBumpsAllowlistShaOnAllowlistChange` — changing a channel surface in the pod re-runs compose generation; `CLAW_WALL_AGENT_CHANNELS_SHA` env on the claw-wall service has a different value than before the change. (codex r3.3 must-fix)
+- `TestBuiltinClawWallDescriptorRegisteredWhenInjected` — `collectServiceDescriptors` returns the built-in claw-wall descriptor when `injectConversationWall` runs; not registered when no service consumes channels. (codex r3.1 must-fix)
+- `TestInjectConversationWallAddsToolPolicyToChannelConsumers` — channel-consuming service's in-memory `x-claw.tools` contains `{service: claw-wall, allow: [search_channel_context, get_channel_messages]}` after `injectConversationWall`; non-consumer's is unchanged. (codex r3.2 must-fix)
+- `TestComposeMaterializesAutoRegisteredToolsForChannelConsumers` — end-to-end: pod with two agents (one channel-consuming, one not); the channel-consuming agent's `tools.json` contains both tools with `http.base_url=http://claw-wall:8080` and the service token in `auth.token`; the non-consumer's `tools.json` contains neither.
+- `TestToolsJSONCarriesClawWallBearerWithoutLeakingEnv` — `tools.json` for the channel-consumer has the bearer token in `auth.token`; the same consumer's container env does **NOT** contain `CLAW_WALL_TOOL_TOKEN`. Only the claw-wall service env has the token. (codex r3.5 must-fix)
 
 ### 7.4 Pod parser (`internal/pod/`)
 
@@ -404,7 +463,8 @@ The PR body explicitly says:
 
 2. **Header rewrite on `channel-context`.** r1 said "change to `[channel-context delta] kind=delta`".
    - **Codex r1 must-fix:** rewrite targeted the wrong path (`mode=delta` is no longer the default since #201). The real delta path is `mode=tail` + `after=`.
-   - **r2 resolution:** rewrite is keyed on `after=` presence. See §4.4 for the four kinds (`delta_tail`, `tail`, `raw_window`, `tool_call`).
+   - **r2 resolution:** rewrite was keyed on `after=` presence.
+   - **r3 supersedes:** keying is now explicit `context_kind=` URL param stamped by cllama; `after=`-presence inference is only a back-compat fallback. See §4.4 for the five kinds (`delta_tail`, `bootstrap_tail`, `tail`, `raw_window`, `tool_call`). (codex r3 cleanup)
 
 3. **v1 retrieval tools live where?** r1 leaned claw-wall-direct.
    - **Codex r1:** claw-wall-direct OK *only after* ACL/auto-subscribe is solved.
@@ -436,26 +496,53 @@ The PR body explicitly says:
    - **Codex r2:** start under `examples/channel-memory/` (or #164-aligned path); avoid published infra image and release pinning in phase 1.
    - **r3 resolution:** §3 v2 row, §11 build sequence, and §12 non-goals all say `examples/channel-memory/`. No `release_manifest.go` entry; no ghcr.io publication in phase 1.
 
-## 10c. Open questions for codex r3 review
+## 10c. r3 open questions — codex answers and r4 resolution
 
-1. **`context_kind=` URL hint vs request header.** §4.4 uses a URL query param (`context_kind=delta_tail` etc.) because it's the lowest-friction change at compose-up/cllama and survives cache-keys naturally. Alternative: an `X-Claw-Context-Kind` request header. Header is cleaner if the value should never affect upstream caching; query param is cleaner if claw-wall ever wants to log per-kind hit ratios via existing access-log infrastructure. Lean query param.
-2. **Defense-in-depth allowlist on feed paths.** §4.2.1 says feeds remain unauthenticated-on-compose-net. claw-wall could *additionally* check that `channels=` matches the agent's allowlist if it received `X-Claw-ID` on feed requests too — but feed requests don't carry `X-Claw-ID` today. Adding it would tighten the model but require cllama to send the header (small change). Lean "leave feeds as today" because the single-writer compose-URL invariant is already enforced; revisit if/when claw-wall ever gains a non-compose ingress.
-3. **`claw.describe.path` label semantics.** §4.2.2 uses this label to point at a bind-mounted descriptor file. Is the existing descriptor extractor (`internal/describe/registry.go`) actually wired for label-based path indirection, or does it only consume `claw.describe` as the JSON inline? If the latter, the alternative is to embed the descriptor JSON directly in the label value. Lean inline JSON to avoid filesystem indirection for a small descriptor.
+1. **`context_kind=` URL hint vs request header.** r3 leaned query param.
+   - **Codex r3:** confirmed. Query param is fine; the URL already carries `after`, `channels`, `mode`, so adding another fetch-metadata param is in keeping. Header would be cleaner abstractly but not worth the change.
+   - **r4 resolution:** stays as URL query param.
+
+2. **Defense-in-depth allowlist on feed paths.** r3 leaned "leave feeds generated-URL-only".
+   - **Codex r3:** confirmed. The threat #232 fixes is model-supplied tool args, not cllama's compiler-generated feed URL. Leave feeds as-is for v1.
+   - **r4 resolution:** §4.1 wording corrected — feed path is not bearer-authenticated and does not consult the allowlist. The "same allowlist guards both" claim is deleted. Allowlist guards tools only.
+
+3. **`claw.describe.path` label semantics.** r3 leaned inline JSON.
+   - **Codex r3:** neither works. `internal/inspect.ParseLabels` only recognizes `claw.describe` and treats the value as a build-context file path; it does not consume `.path` label variants and does not parse inline JSON. The right path is a compiler-owned built-in descriptor sibling of `builtinClawAPIDescriptor()`.
+   - **r4 resolution:** §4.2.2 rewritten to use `builtinClawWallDescriptor()`. No `claw.describe.path` label, no inline JSON, no synthetic descriptor file on disk.
+
+## 10d. Implementation-readiness checklist (post r4)
+
+This section exists so a future implementer can confirm the plan is settled before starting work.
+
+- [x] Auth model two-lock (cllama primary gate via `channels-allowlist.json`; claw-wall defense-in-depth via mounted allowlist + service token)
+- [x] Feed path stays generated-URL-only/network-scoped (no bearer, no allowlist on feed)
+- [x] Tool path strictly cllama-mediated (Bearer + `X-Claw-ID` headers; `serviceAuth`-projected token)
+- [x] Built-in descriptor approach (no label indirection)
+- [x] Synthetic tool-subscription policy (so existing `resolveToolSubscriptions` works)
+- [x] Allowlist sha env for compose recreate-on-content-change
+- [x] `context_kind=` URL param keying for header rewrite (delta_tail / bootstrap_tail / tail / raw_window)
+- [x] Manifest order discipline (awareness before delta)
+- [x] `channel_context_op` telemetry alongside `feed_fetch`/`memory_op`
+- [x] Default-on with smaller caps (60 / 8KB); #232 stays open through v2
+- [x] Plain integration test, no spike
+- [x] v2 producer (`claw-channel-memory`) emits same wire surface; channel events never transit ADR-021 `/recall`
 
 ## 11. Build sequence (assuming codex r3 sign-off)
 
 1. **claw-wall** —
    - `channel-awareness` endpoint reusing `consumeTail`.
    - Mounted allowlist loader (`/etc/claw-wall/agent-channels.json`), fail-closed on parse error.
-   - Tool handlers `search_channel_context`, `get_channel_messages` with the §4.2.1 auth order (Bearer service token + `X-Claw-ID` + allowlist check) and §4.2.4 `not_in_buffer` semantics.
+   - Tool handlers `search_channel_context`, `get_channel_messages` with the §4.2.1 auth order (Bearer service token + `X-Claw-ID` + allowlist check) and §4.2.5 `not_in_buffer` semantics.
    - Header rewrite keyed on `context_kind=` URL param (with `after=` fallback) per §4.4.
    - Tests in §7.1.
 2. **compose_up wiring** —
    - `appendConversationWallAwarenessFeed` emits awareness URL **before** the existing delta feed (manifest order).
    - Pod parser for `x-claw.context.channel-awareness`.
    - Per-agent allowlist materialization → `.claw-runtime/claw-wall-agent-channels.json`, bind-mounted into claw-wall + projected into cllama context as `channels-allowlist.json`.
-   - Generated `CLAW_WALL_TOOL_TOKEN` env on claw-wall; same value flowed into per-agent `tools.json` auth descriptor.
-   - Synthetic `claw.describe` v2 descriptor for claw-wall written to `.claw-runtime/describe/claw-wall.json`, with `claw.describe.path` label or inline JSON (§10c.3 pending).
+   - `CLAW_WALL_AGENT_CHANNELS_SHA=<sha256(allowlist json)>` env on the claw-wall service so Docker Compose recreates the container when allowlist content changes.
+   - Generated per-pod tool token on claw-wall service env (`CLAW_WALL_TOOL_TOKEN`); the same value flows through `prepareConversationWallToolRuntime` → `serviceAuth[agent]` → consumer `tools.json` auth descriptor. Consumer container env does **not** carry the token.
+   - **`builtinClawWallDescriptor()`** registered in `collectServiceDescriptors` whenever the auto-injected claw-wall service is present. No `claw.describe.path` label, no synthetic descriptor file on disk.
+   - `injectConversationWall` appends synthetic `tools: [{service: claw-wall, allow: [...]}]` to each channel-consuming service's `x-claw` before `resolveToolSubscriptions`.
    - Tests in §7.3, §7.4.
 3. **cllama side** —
    - `prepareChannelContextFeed` stamps `context_kind=` into the URL based on `channelContextPrepareDecision`.

--- a/internal/audit/event.go
+++ b/internal/audit/event.go
@@ -29,6 +29,13 @@ type Event struct {
 	ToolDuplicate      bool      `json:"tool_duplicate,omitempty"`
 	ToolDuplicateRound *int      `json:"tool_duplicate_of_round,omitempty"`
 	ToolDuplicateCount *int      `json:"tool_duplicate_count,omitempty"`
+	ToolStatus         string    `json:"tool_status,omitempty"`
+	ChannelKind        string    `json:"kind,omitempty"`
+	Channels           []string  `json:"channels,omitempty"`
+	Retained           *int      `json:"retained,omitempty"`
+	Returned           *int      `json:"returned,omitempty"`
+	Omitted            *int      `json:"omitted,omitempty"`
+	Status             string    `json:"status,omitempty"`
 	// provider_pool event fields
 	Provider      string `json:"provider,omitempty"`
 	KeyID         string `json:"key_id,omitempty"`
@@ -51,6 +58,8 @@ type AgentSummary struct {
 	FeedErrors         int            `json:"feed_errors"`
 	ToolCalls          int            `json:"tool_calls,omitempty"`
 	ToolErrors         int            `json:"tool_errors,omitempty"`
+	ChannelContextOps  int            `json:"channel_context_ops,omitempty"`
+	ChannelContextErrs int            `json:"channel_context_errors,omitempty"`
 	ProviderPoolEvents int            `json:"provider_pool_events,omitempty"`
 	FirstTimestamp     time.Time      `json:"first_timestamp,omitempty"`
 	LastTimestamp      time.Time      `json:"last_timestamp,omitempty"`

--- a/internal/audit/normalize.go
+++ b/internal/audit/normalize.go
@@ -34,7 +34,14 @@ func NormalizeLine(line []byte) (*Event, error) {
 		FeedName:      strings.TrimSpace(stringField(raw, "feed_name")),
 		FeedURL:       strings.TrimSpace(stringField(raw, "feed_url")),
 		SourceService: strings.TrimSpace(stringField(raw, "source_service")),
+		ChannelKind:   strings.TrimSpace(stringField(raw, "kind")),
+		Status:        strings.TrimSpace(stringField(raw, "status")),
+		ToolName:      strings.TrimSpace(stringField(raw, "tool_name")),
 	}
+	if event.SourceService == "" {
+		event.SourceService = strings.TrimSpace(stringField(raw, "source"))
+	}
+	event.Channels = stringSliceField(raw, "channels")
 	if value, ok := nullableStringField(raw, "intervention_reason"); ok {
 		event.InterventionReason = strings.TrimSpace(value)
 	} else if value, ok := nullableStringField(raw, "intervention"); ok {
@@ -57,6 +64,15 @@ func NormalizeLine(line []byte) (*Event, error) {
 	}
 	if value, ok := intField(raw, "tokens_out"); ok {
 		event.TokensOut = &value
+	}
+	if value, ok := intField(raw, "retained"); ok {
+		event.Retained = &value
+	}
+	if value, ok := intField(raw, "returned"); ok {
+		event.Returned = &value
+	}
+	if value, ok := intField(raw, "omitted"); ok {
+		event.Omitted = &value
 	}
 	if value, ok := float64Field(raw, "cost_usd"); ok {
 		event.CostUSD = &value
@@ -129,6 +145,7 @@ func NormalizeSessionHistoryLine(line []byte) ([]Event, error) {
 				FinalStatus:    finalStatus,
 				ToolName:       strings.TrimSpace(stringField(callMap, "name")),
 				ToolService:    strings.TrimSpace(stringField(callMap, "service")),
+				ToolStatus:     strings.TrimSpace(stringField(callMap, "status")),
 			}
 			if latencyMS, ok := int64Field(callMap, "latency_ms"); ok {
 				event.LatencyMS = &latencyMS
@@ -319,6 +336,25 @@ func sliceField(raw map[string]any, key string) ([]any, bool) {
 	}
 	s, ok := value.([]any)
 	return s, ok
+}
+
+func stringSliceField(raw map[string]any, key string) []string {
+	values, ok := sliceField(raw, key)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		item, ok := value.(string)
+		if !ok {
+			continue
+		}
+		item = strings.TrimSpace(item)
+		if item != "" {
+			out = append(out, item)
+		}
+	}
+	return out
 }
 
 func extractToolResultError(call map[string]any) string {

--- a/internal/audit/normalize_test.go
+++ b/internal/audit/normalize_test.go
@@ -80,6 +80,40 @@ func TestNormalizeLineParseFeedFetchEvent(t *testing.T) {
 	}
 }
 
+func TestNormalizeLineParseChannelContextOpEvent(t *testing.T) {
+	line := `{"ts":"2026-05-12T10:00:00Z","claw_id":"weston","type":"channel_context_op","kind":"raw_window","channels":["chan-1","chan-2"],"retained":60,"returned":40,"omitted":20,"source":"claw-wall","status":"ok","tool_name":"search_channel_context","status_code":200}`
+	event, err := NormalizeLine([]byte(line))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event.Type != "channel_context_op" || event.ChannelKind != "raw_window" || event.SourceService != "claw-wall" || event.Status != "ok" {
+		t.Fatalf("unexpected event: %+v", event)
+	}
+	if len(event.Channels) != 2 || event.Channels[0] != "chan-1" || event.Channels[1] != "chan-2" {
+		t.Fatalf("unexpected channels: %+v", event.Channels)
+	}
+	if event.Retained == nil || *event.Retained != 60 || event.Returned == nil || *event.Returned != 40 || event.Omitted == nil || *event.Omitted != 20 {
+		t.Fatalf("unexpected counts: %+v", event)
+	}
+	if event.ToolName != "search_channel_context" {
+		t.Fatalf("unexpected tool name: %+v", event)
+	}
+}
+
+func TestSummarizeCountsChannelContextOps(t *testing.T) {
+	events := []Event{
+		{ClawID: "weston", Type: "channel_context_op", Status: "ok"},
+		{ClawID: "weston", Type: "channel_context_op", Status: "not_in_buffer"},
+	}
+	summary := Summarize(events)
+	if len(summary.Agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(summary.Agents))
+	}
+	if summary.Agents[0].ChannelContextOps != 2 || summary.Agents[0].ChannelContextErrs != 1 {
+		t.Fatalf("unexpected channel context summary: %+v", summary.Agents[0])
+	}
+}
+
 func TestNormalizeLineParseToolManifestEvent(t *testing.T) {
 	line := `{"ts":"2026-04-05T19:00:00Z","claw_id":"weston","type":"tool_manifest_loaded","model":"openai/gpt-4o","manifest_present":true,"tools_count":2}`
 	event, err := NormalizeLine([]byte(line))
@@ -117,7 +151,7 @@ func TestSummarizeCountsFeedFetches(t *testing.T) {
 }
 
 func TestNormalizeSessionHistoryLineOpenAIManagedTool(t *testing.T) {
-	line := `{"version":1,"id":"hist1_abc","status":"ok","ts":"2026-04-03T12:00:00Z","claw_id":"tiverton","path":"/v1/chat/completions","requested_model":"xai/grok-4.1-fast","effective_provider":"xai","effective_model":"xai/grok-4.1-fast","status_code":200,"usage":{"prompt_tokens":120,"completion_tokens":40,"total_rounds":2},"tool_trace":[{"round":1,"tool_calls":[{"name":"trading-api.get_market_context","service":"trading-api","latency_ms":87,"status_code":200,"result":{"ok":true,"data":{"balance":5000}}}]}]}`
+	line := `{"version":1,"id":"hist1_abc","status":"ok","ts":"2026-04-03T12:00:00Z","claw_id":"tiverton","path":"/v1/chat/completions","requested_model":"xai/grok-4.1-fast","effective_provider":"xai","effective_model":"xai/grok-4.1-fast","status_code":200,"usage":{"prompt_tokens":120,"completion_tokens":40,"total_rounds":2},"tool_trace":[{"round":1,"tool_calls":[{"name":"trading-api.get_market_context","service":"trading-api","status":"ok","latency_ms":87,"status_code":200,"result":{"ok":true,"data":{"balance":5000}}}]}]}`
 	events, err := NormalizeSessionHistoryLine([]byte(line))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -137,6 +171,9 @@ func TestNormalizeSessionHistoryLineOpenAIManagedTool(t *testing.T) {
 	}
 	if event.StatusCode == nil || *event.StatusCode != 200 {
 		t.Fatalf("expected tool status_code 200, got %+v", event)
+	}
+	if event.ToolStatus != "ok" {
+		t.Fatalf("expected tool status ok, got %+v", event)
 	}
 	if event.FinalStatusCode == nil || *event.FinalStatusCode != 200 {
 		t.Fatalf("expected final status_code 200, got %+v", event)

--- a/internal/audit/query.go
+++ b/internal/audit/query.go
@@ -95,6 +95,11 @@ func Summarize(events []Event) Summary {
 				agent.ToolErrors++
 				summary.ToolErrors++
 			}
+		case "channel_context_op":
+			agent.ChannelContextOps++
+			if channelContextEventFailed(event) {
+				agent.ChannelContextErrs++
+			}
 		case "provider_pool":
 			agent.ProviderPoolEvents++
 			summary.ProviderPoolEvents++
@@ -122,6 +127,21 @@ func Summarize(events []Event) Summary {
 	})
 	summary.Agents = agents
 	return summary
+}
+
+func channelContextEventFailed(event Event) bool {
+	if event.Error != "" {
+		return true
+	}
+	if event.StatusCode != nil && *event.StatusCode >= 400 {
+		return true
+	}
+	switch event.Status {
+	case "error", "not_in_buffer":
+		return true
+	default:
+		return false
+	}
 }
 
 func toolEventFailed(event Event) bool {

--- a/internal/cllama/context.go
+++ b/internal/cllama/context.go
@@ -8,14 +8,15 @@ import (
 )
 
 type AgentContextInput struct {
-	AgentID     string
-	AgentsMD    string
-	ClawdapusMD string
-	Metadata    map[string]interface{}
-	Feeds       []FeedManifestEntry
-	Tools       []ToolManifestEntry
-	Memory      *MemoryManifestEntry
-	ServiceAuth []ServiceAuthEntry
+	AgentID          string
+	AgentsMD         string
+	ClawdapusMD      string
+	Metadata         map[string]interface{}
+	Feeds            []FeedManifestEntry
+	Tools            []ToolManifestEntry
+	Memory           *MemoryManifestEntry
+	ServiceAuth      []ServiceAuthEntry
+	ChannelAllowlist []string
 }
 
 type FeedManifestEntry struct {
@@ -68,6 +69,11 @@ type ToolPolicy struct {
 	MaxRounds        int `json:"max_rounds"`
 	TimeoutPerToolMS int `json:"timeout_per_tool_ms"`
 	TotalTimeoutMS   int `json:"total_timeout_ms"`
+}
+
+type ChannelAllowlistManifest struct {
+	Version  int      `json:"version"`
+	Channels []string `json:"channels"`
 }
 
 type MemoryManifestEntry struct {
@@ -153,6 +159,19 @@ func GenerateContextDir(runtimeDir string, agents []AgentContextInput) error {
 			}
 			if err := os.WriteFile(filepath.Join(agentDir, "memory.json"), append(memoryJSON, '\n'), 0644); err != nil {
 				return fmt.Errorf("write memory.json for %q: %w", agent.AgentID, err)
+			}
+		}
+
+		if len(agent.ChannelAllowlist) > 0 {
+			allowlistJSON, err := json.MarshalIndent(ChannelAllowlistManifest{
+				Version:  1,
+				Channels: append([]string(nil), agent.ChannelAllowlist...),
+			}, "", "  ")
+			if err != nil {
+				return fmt.Errorf("marshal channels allowlist for %q: %w", agent.AgentID, err)
+			}
+			if err := os.WriteFile(filepath.Join(agentDir, "channels-allowlist.json"), append(allowlistJSON, '\n'), 0644); err != nil {
+				return fmt.Errorf("write channels-allowlist.json for %q: %w", agent.AgentID, err)
 			}
 		}
 

--- a/internal/cllama/context_test.go
+++ b/internal/cllama/context_test.go
@@ -126,6 +126,7 @@ func TestGenerateContextDirWritesOptionalFeedsAndServiceAuth(t *testing.T) {
 			Token:     "capi_deadbeef",
 			Principal: "octopus",
 		}},
+		ChannelAllowlist: []string{"chan-1", "chan-2"},
 	}}
 
 	if err := GenerateContextDir(dir, agents); err != nil {
@@ -186,6 +187,18 @@ func TestGenerateContextDirWritesOptionalFeedsAndServiceAuth(t *testing.T) {
 	}
 	if auth["principal"] != "octopus" {
 		t.Fatalf("unexpected service-auth payload: %v", auth)
+	}
+
+	allowlistRaw, err := os.ReadFile(filepath.Join(dir, "context", "octopus", "channels-allowlist.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var allowlist ChannelAllowlistManifest
+	if err := json.Unmarshal(allowlistRaw, &allowlist); err != nil {
+		t.Fatal(err)
+	}
+	if allowlist.Version != 1 || len(allowlist.Channels) != 2 || allowlist.Channels[0] != "chan-1" || allowlist.Channels[1] != "chan-2" {
+		t.Fatalf("unexpected channel allowlist payload: %+v", allowlist)
 	}
 }
 

--- a/internal/pod/parser_context_test.go
+++ b/internal/pod/parser_context_test.go
@@ -125,3 +125,37 @@ services:
 		})
 	}
 }
+
+func TestParsePodContextChannelAwarenessIsNotPublicConfig(t *testing.T) {
+	p, err := Parse(strings.NewReader(`
+x-claw:
+  context:
+    channel-awareness:
+      since: 12h
+      limit: 60
+      max-chars: 8192
+services:
+  trader:
+    image: example/trader:latest
+    x-claw:
+      agent: ./AGENTS.md
+      context:
+        channel-awareness:
+          since: 30m
+          limit: 20
+          max_chars: 2048
+`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if p.Context != nil && p.Context.Channel != nil {
+		t.Fatalf("channel-awareness should not populate pod context config: %+v", p.Context.Channel)
+	}
+	trader := p.Services["trader"]
+	if trader == nil || trader.Claw == nil {
+		t.Fatal("expected parsed trader claw block")
+	}
+	if trader.Claw.Context != nil && trader.Claw.Context.Channel != nil {
+		t.Fatalf("channel-awareness should not populate service context config: %+v", trader.Claw.Context.Channel)
+	}
+}


### PR DESCRIPTION
Phase 1 of #232.

This PR lands the bounded raw-window + retrieval + metadata part of the channel-awareness plan. It intentionally does not close #232; the issue stays open for phase 2 rolling digest / channel-memory work.

What changed:
- Adds default-on `channel-awareness` feed from claw-wall: uncursored 24h raw window, bounded by internal defaults `limit=60` and `max_chars=8192`, with `digest=unavailable`.
- Requires zero operator config: any Discord-channel-consuming service is auto-wired; this PR adds no new pod YAML keys.
- Stamps `channel-context` fetches with explicit `context_kind` metadata for `tail`, `delta_tail`, and `bootstrap_tail`.
- Adds cllama-mediated claw-wall retrieval tools: `search_channel_context` and `get_channel_messages`.
- Adds generated per-agent channel allowlists, claw-wall service-token auth, `X-Claw-ID` forwarding, and defense-in-depth claw-wall checks.
- Registers a compiler-owned built-in claw-wall descriptor and auto-subscribes channel-consuming agents to the retrieval tools.
- Adds `channel_context_op` telemetry and session-history tool status.

Bloat boundary:
- No new public config surface for channel-awareness in phase 1.
- Existing `x-claw.context.channel` behavior from #201 remains for the cursorized delta/tail feed and wall buffer sizing.
- This intentionally avoids a digest producer, channel-memory daemon, UI, config profiles, release docs, and wider refactors.
- Phase 1 is only the raw bounded window, retrieval tools, internal auth/allowlist plumbing, and metadata needed to make the later memory layer safe to add.

Release boundary:
- The `cllama` submodule pointer moves to `mostlydev/cllama@433cdb2` on branch `issue-232-channel-24h-awareness`, which is past the latest local cllama tag observed during this work (`v0.6.4`).
- Do not treat this as release-ready until the maintainer either cuts the matching cllama release/image and advances the pointer to that released commit, or explicitly accepts a different integration path.

Phase 2 remaining:
- Rolling 24h digest via `claw-channel-memory` / #164-aligned salience work.
- Full acceptance guarantee for high-volume rooms beyond the phase-1 raw window cap.

Tests:
- `go test ./cmd/claw ./internal/pod`
- `go test ./...`
- `(cd cllama && go test ./...)`
- `git diff --check`
