### PR TITLE
claw: show callable managed tool aliases

### DIFF
--- a/cmd/claw/compose_up.go
+++ b/cmd/claw/compose_up.go
@@ -1698,7 +1698,11 @@ func augmentClawdapusMD(base string, tools []cllama.ToolManifestEntry, memory *c
 		b.WriteString("## Tools\n\n")
 		b.WriteString("Managed service tools are compiled into your proxy context.\n\n")
 		for _, tool := range tools {
-			line := fmt.Sprintf("- `%s`", tool.Name)
+			presentedName := cllama.PresentedToolName(tool.Name)
+			line := fmt.Sprintf("- `%s`", presentedName)
+			if presentedName != tool.Name {
+				line += fmt.Sprintf(" (canonical: `%s`)", tool.Name)
+			}
 			if tool.Description != "" {
 				line += fmt.Sprintf(" — %s", tool.Description)
 			}

--- a/cmd/claw/compose_up_test.go
+++ b/cmd/claw/compose_up_test.go
@@ -3651,6 +3651,22 @@ func TestBuildToolManifestEntriesProjectsMCPTools(t *testing.T) {
 	}
 }
 
+func TestAugmentClawdapusMDShowsProviderSafeManagedToolName(t *testing.T) {
+	presented := cllama.PresentedToolName("claw-wall.search_channel_context")
+	if presented != "claw-wall_search_channel_context_2919442f" {
+		t.Fatalf("unexpected presented tool name: %s", presented)
+	}
+
+	out := augmentClawdapusMD("", []cllama.ToolManifestEntry{{
+		Name:        "claw-wall.search_channel_context",
+		Description: "Search channel context.",
+	}}, nil)
+	want := "- `claw-wall_search_channel_context_2919442f` (canonical: `claw-wall.search_channel_context`) — Search channel context."
+	if !strings.Contains(out, want) {
+		t.Fatalf("expected provider-safe tool name in CLAWDAPUS.md, got:\n%s", out)
+	}
+}
+
 func TestBuildMemoryManifestEntryUsesProjectedServiceAuth(t *testing.T) {
 	p := &pod.Pod{
 		Services: map[string]*pod.Service{

--- a/internal/cllama/toolnames.go
+++ b/internal/cllama/toolnames.go
@@ -1,0 +1,77 @@
+package cllama
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"strings"
+)
+
+const (
+	maxManagedToolPresentedNameLen = 128
+	managedToolAliasHashBytes      = 4
+)
+
+// PresentedToolName must match cllama/internal/proxy/toolnames.go so generated
+// CLAWDAPUS.md shows the same managed tool name the provider schema exposes.
+func PresentedToolName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "managed_tool"
+	}
+	if isProviderSafeToolName(name) {
+		return name
+	}
+
+	safe := sanitizeManagedToolName(name)
+	if safe == "" {
+		safe = "managed_tool"
+	}
+
+	sum := sha1.Sum([]byte(name))
+	suffix := "_" + hex.EncodeToString(sum[:managedToolAliasHashBytes])
+	maxBaseLen := maxManagedToolPresentedNameLen - len(suffix)
+	if maxBaseLen < 1 {
+		maxBaseLen = 1
+	}
+	if len(safe) > maxBaseLen {
+		safe = safe[:maxBaseLen]
+	}
+	return safe + suffix
+}
+
+func isProviderSafeToolName(name string) bool {
+	if len(name) < 1 || len(name) > maxManagedToolPresentedNameLen {
+		return false
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '_' || r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func sanitizeManagedToolName(name string) string {
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '_' || r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return strings.Trim(b.String(), "_")
+}

--- a/site/changelog.md
+++ b/site/changelog.md
@@ -29,7 +29,7 @@ outline: deep
 
 ## Unreleased
 
-<!-- Nothing yet -->
+- **Managed tool guidance now matches callable schema names** — generated `CLAWDAPUS.md` lists the provider-safe managed tool name first, with the canonical dotted name retained as metadata, so agents are not told to call dotted names that the provider schema does not expose. Refs [#240](https://github.com/mostlydev/clawdapus/issues/240).
 
 ## v0.17.0 <Badge type="tip" text="Latest" /> {#v0-17-0}
 


### PR DESCRIPTION
## Summary
- generate `CLAWDAPUS.md` tool guidance with the provider-safe callable managed tool name first
- keep the canonical dotted name as metadata instead of making it look like the callable schema name
- add a shared compiler-side alias helper and coverage for the claw-wall tool name that failed on Tiverton

## Context
This addresses the prompt/schema mismatch behind #240. Tiverton had the claw-wall tools compiled into Boulton's context, and cllama exposed hashed provider-safe names such as `claw-wall_search_channel_context_2919442f`, but generated `CLAWDAPUS.md` showed only the canonical dotted name. Boulton then emitted hashless sanitized aliases, which Hermes rejected after cllama failed to classify them as managed tools.

The runtime tolerance piece is in mostlydev/cllama#15. This PR intentionally does not update the cllama submodule pointer or release pins; those should move only after a cllama release.

Refs #240.

## Tests
- `go test ./...`
- `go vet ./...`
- `git diff --check`