### PR TITLE
Update Hermes base to v2026.5.16

### DIFF
--- a/cmd/claw/hermes_base_image_test.go
+++ b/cmd/claw/hermes_base_image_test.go
@@ -58,7 +58,7 @@ func TestHermesBaseImageSourceContract(t *testing.T) {
 		`_claw_filter_tools`,
 		`_HERMES_CORE_TOOLS = _claw_filter_tools(_HERMES_CORE_TOOLS)`,
 		`HERMES_ALLOW_SILENT_FINAL`,
-		`Silent final enabled; treating empty-after-think response as completed no-op`,
+		`Silent final enabled; treating empty visible response as completed no-op`,
 		`intents.voice_states = False`,
 		`CLLAMA_CONSUMER_SESSION_EPOCH`,
 		`X-Claw-Consumer-Session-Epoch`,

--- a/cmd/claw/hermes_base_spike_test.go
+++ b/cmd/claw/hermes_base_spike_test.go
@@ -38,8 +38,13 @@ import os
 os.environ["HERMES_DEFAULT_AGENT_IDENTITY"] = "Clawdapus identity probe"
 os.environ["CLAWDAPUS_DISABLED_TOOLS"] = "text_to_speech"
 os.environ["CLLAMA_CONSUMER_SESSION_EPOCH"] = "epoch-contract"
+os.environ["HERMES_GATEWAY_LOCK_DIR"] = "/tmp/hermes-gateway-locks"
+os.environ["XDG_STATE_HOME"] = "/tmp/xdg-state"
 assert importlib.util.find_spec("minisweagent_path") is not None
 import tools.terminal_tool
+
+from gateway.status import _get_lock_dir
+assert str(_get_lock_dir()) == "/tmp/hermes-gateway-locks"
 
 from toolsets import _HERMES_CORE_TOOLS, TOOLSETS
 assert "text_to_speech" not in _HERMES_CORE_TOOLS

--- a/cmd/claw/hermes_base_spike_test.go
+++ b/cmd/claw/hermes_base_spike_test.go
@@ -79,8 +79,9 @@ source = inspect.getsource(run_agent.AIAgent)
 assert "_already_used_tools_this_turn" in source
 assert "api_messages[_last_user_index + 1 :]" in source
 assert "HERMES_ALLOW_SILENT_FINAL" in source
-assert "Silent final enabled; treating empty-after-think response as completed no-op" in source
+assert "Silent final enabled; treating empty visible response as completed no-op" in source
 assert '"completed": True' in source
+assert source.index('os.getenv("HERMES_ALLOW_SILENT_FINAL") == "1"') < source.index("Model returned empty after tool calls")
 assert "X-Claw-Consumer-Session-Epoch" in source
 assert "CLLAMA_CONSUMER_SESSION_EPOCH" in source
 

--- a/dockerfiles/hermes-base/Dockerfile
+++ b/dockerfiles/hermes-base/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
 ARG GIT_REVISION=unknown
 ARG CLAW_SOURCE=local-checkout
 ARG CLAW_DIRTY=true
-ARG HERMES_UPSTREAM_TAG=v2026.4.23
+ARG HERMES_UPSTREAM_TAG=v2026.5.16
 
 LABEL claw.component="hermes-base" \
       org.opencontainers.image.revision="${GIT_REVISION}" \

--- a/dockerfiles/hermes-base/patch-hermes-runtime.py
+++ b/dockerfiles/hermes-base/patch-hermes-runtime.py
@@ -261,15 +261,16 @@ text = replace_once(
     "run_agent tool_choice=required per turn in tool-only mode",
 )
 
-# Silent-final opt-in: when HERMES_ALLOW_SILENT_FINAL=1, treat empty-after-think
-# final responses as a successful no-op turn instead of retrying. Reasoning
-# models in mention_only channels can legitimately decide to stay silent.
+# Silent-final opt-in: when HERMES_ALLOW_SILENT_FINAL=1, treat empty visible
+# final responses as a successful no-op turn instead of retrying/nudging.
+# Managed messaging agents often deliver the visible reply through send_message
+# and then intentionally have nothing else to say.
 text = replace_once(
     text,
     '                    if not self._has_content_after_think_block(final_response):\n',
     '                    if not self._has_content_after_think_block(final_response):\n'
     '                        if os.getenv("HERMES_ALLOW_SILENT_FINAL") == "1":\n'
-    '                            logger.debug("Silent final enabled; treating empty-after-think response as completed no-op")\n'
+    '                            logger.debug("Silent final enabled; treating empty visible response as completed no-op")\n'
     '                            self._empty_content_retries = 0\n'
     '                            self._cleanup_task_resources(effective_task_id)\n'
     '                            self._persist_session(messages, conversation_history)\n'

--- a/dockerfiles/hermes-base/patch-hermes-runtime.py
+++ b/dockerfiles/hermes-base/patch-hermes-runtime.py
@@ -122,8 +122,8 @@ _HERMES_CORE_TOOLS = [""",
 )
 text = replace_once(
     text,
-    "    \"ha_list_entities\", \"ha_get_state\", \"ha_list_services\", \"ha_call_service\",\n]\n",
-    "    \"ha_list_entities\", \"ha_get_state\", \"ha_list_services\", \"ha_call_service\",\n]\n_HERMES_CORE_TOOLS = _claw_filter_tools(_HERMES_CORE_TOOLS)\n",
+    "    \"computer_use\",\n]\n",
+    "    \"computer_use\",\n]\n_HERMES_CORE_TOOLS = _claw_filter_tools(_HERMES_CORE_TOOLS)\n",
     "_HERMES_CORE_TOOLS env-driven disable filter application",
 )
 text = replace_once(
@@ -179,32 +179,62 @@ text = replace_once(
 )
 
 # Tool-only mode: force tool_choice=required per user turn.
-# Upstream now builds api_kwargs through a transport (`_ct.build_kwargs(...)`)
-# inside `_build_api_kwargs`. We capture the returned kwargs and inject
-# `tool_choice="required"` at the start of each user turn so the model must
-# call a tool (preferably send_message) before falling back to plain text.
+# Upstream now has a provider-profile path and a legacy fallback inside
+# `_build_api_kwargs`. Capture the chat-completions kwargs in both paths and
+# inject `tool_choice="required"` at the start of each user turn so the model
+# must call a tool (preferably send_message) before falling back to plain text.
+text = replace_once(
+    text,
+    "            return _ct.build_kwargs(\n"
+    "                model=self.model,\n"
+    "                messages=api_messages,\n"
+    "                tools=tools_for_api,\n"
+    "                base_url=self.base_url,\n",
+    "            _claw_kwargs = _ct.build_kwargs(\n"
+    "                model=self.model,\n"
+    "                messages=api_messages,\n"
+    "                tools=tools_for_api,\n"
+    "                base_url=self.base_url,\n",
+    "run_agent provider-profile _build_api_kwargs capture for tool-only mode",
+)
+text = replace_once(
+    text,
+    "                qwen_session_metadata=_qwen_meta,\n"
+    "            )\n"
+    "\n"
+    "        # ── Legacy flag path",
+    "                qwen_session_metadata=_qwen_meta,\n"
+    "            )\n"
+    "            return self._claw_apply_tool_only_choice(_claw_kwargs, api_messages)\n"
+    "\n"
+    "        # ── Legacy flag path",
+    "run_agent provider-profile tool-only mode return",
+)
 text = replace_once(
     text,
     "        return _ct.build_kwargs(\n"
     "            model=self.model,\n"
-    "            messages=api_messages,\n"
-    "            tools=self.tools,\n"
-    "            timeout=self._resolved_api_call_timeout(),\n",
+    "            messages=_msgs_for_chat,\n"
+    "            tools=tools_for_api,\n"
+    "            base_url=self.base_url,\n",
     "        _claw_kwargs = _ct.build_kwargs(\n"
     "            model=self.model,\n"
-    "            messages=api_messages,\n"
-    "            tools=self.tools,\n"
-    "            timeout=self._resolved_api_call_timeout(),\n",
-    "run_agent _build_api_kwargs capture for tool-only mode",
+    "            messages=_msgs_for_chat,\n"
+    "            tools=tools_for_api,\n"
+    "            base_url=self.base_url,\n",
+    "run_agent legacy _build_api_kwargs capture for tool-only mode",
 )
 text = replace_once(
     text,
-    "            anthropic_max_output=_ant_max,\n"
+    "            provider_name=self.provider,\n"
     "        )\n"
     "\n"
     "    def _supports_reasoning_extra_body(self) -> bool:\n",
-    "            anthropic_max_output=_ant_max,\n"
+    "            provider_name=self.provider,\n"
     "        )\n"
+    "        return self._claw_apply_tool_only_choice(_claw_kwargs, _msgs_for_chat)\n"
+    "\n"
+    "    def _claw_apply_tool_only_choice(self, _claw_kwargs: dict, api_messages: list) -> dict:\n"
     "        # In tool-only mode, force tool_choice=required on the first LLM\n"
     "        # call of each user turn. Inspect only messages after the latest\n"
     "        # user message so prior turns' tool_calls do not satisfy this turn.\n"

--- a/internal/driver/hermes/baseimage.go
+++ b/internal/driver/hermes/baseimage.go
@@ -1,7 +1,7 @@
 package hermes
 
-const UpstreamTag = "v2026.4.23"
+const UpstreamTag = "v2026.5.16"
 
-const BaseImageVersion = UpstreamTag + "-claw.2"
+const BaseImageVersion = UpstreamTag + "-claw.1"
 
 var BaseImageTag = "ghcr.io/mostlydev/hermes-base:" + BaseImageVersion

--- a/internal/driver/hermes/config.go
+++ b/internal/driver/hermes/config.go
@@ -19,11 +19,14 @@ const (
 	hermesWorkspaceDir            = "/workspace"
 	hermesPersonaDir              = "/persona"
 	hermesDefaultAgentIdentityEnv = "HERMES_DEFAULT_AGENT_IDENTITY"
+	hermesGatewayLockDirEnv       = "HERMES_GATEWAY_LOCK_DIR"
 	hermesAllowSilentFinalEnv     = "HERMES_ALLOW_SILENT_FINAL"
 	hermesToolProgressModeEnv     = "HERMES_TOOL_PROGRESS_MODE"
 	hermesDiscordReplyMentionEnv  = "DISCORD_ALLOW_MENTION_REPLIED_USER"
 	clawdapusDisabledToolsEnv     = "CLAWDAPUS_DISABLED_TOOLS"
 	hermesTextToSpeechTool        = "text_to_speech"
+	hermesDefaultGatewayLockDir   = "/tmp/hermes-gateway-locks"
+	hermesDefaultXDGStateHome     = "/tmp/xdg-state"
 	managedDefaultAgentIdentity   = "You are a Clawdapus-managed agent. Your identity, authority, communication policy, memory policy, and tool-use rules are defined by the Clawdapus project context loaded below: AGENTS.md, CLAWDAPUS.md, SOUL.md, mounted skills, feeds, and managed-tool policy. Do not identify as Hermes or as a generic assistant. Follow the Clawdapus contract when it is more specific than runner defaults; otherwise retain the Hermes runtime guidance below, including persistent memory behavior."
 )
 
@@ -73,8 +76,10 @@ func GenerateEnvFile(rc *driver.ResolvedClaw, modelCfg *modelConfig) ([]byte, er
 		env[key] = value
 	}
 	env["HERMES_HOME"] = hermesHomeDir
+	env[hermesGatewayLockDirEnv] = hermesDefaultGatewayLockDir
 	env["MESSAGING_CWD"] = hermesWorkspaceDir
 	env["TERMINAL_CWD"] = hermesWorkspaceDir
+	env["XDG_STATE_HOME"] = hermesDefaultXDGStateHome
 	env[hermesDefaultAgentIdentityEnv] = managedDefaultAgentIdentity
 	if hasDiscordHandle(rc) || hasSlackHandle(rc) {
 		env[hermesToolProgressModeEnv] = "off"
@@ -314,6 +319,7 @@ func allowedEnvPassthroughKeys() []string {
 		"DISCORD_REQUIRE_MENTION",
 		"GATEWAY_ALLOWED_USERS",
 		"GATEWAY_ALLOW_ALL_USERS",
+		hermesGatewayLockDirEnv,
 		hermesAllowSilentFinalEnv,
 		hermesToolProgressModeEnv,
 		"OPENAI_API_KEY",
@@ -332,6 +338,7 @@ func allowedEnvPassthroughKeys() []string {
 		"TELEGRAM_BOT_TOKEN",
 		"TELEGRAM_HOME_CHANNEL",
 		"TELEGRAM_HOME_CHANNEL_NAME",
+		"XDG_STATE_HOME",
 	}
 }
 

--- a/internal/driver/hermes/config.go
+++ b/internal/driver/hermes/config.go
@@ -82,6 +82,7 @@ func GenerateEnvFile(rc *driver.ResolvedClaw, modelCfg *modelConfig) ([]byte, er
 	env["XDG_STATE_HOME"] = hermesDefaultXDGStateHome
 	env[hermesDefaultAgentIdentityEnv] = managedDefaultAgentIdentity
 	if hasDiscordHandle(rc) || hasSlackHandle(rc) {
+		env[hermesAllowSilentFinalEnv] = "1"
 		env[hermesToolProgressModeEnv] = "off"
 	}
 	if hasDiscordHandle(rc) {

--- a/internal/driver/hermes/config_test.go
+++ b/internal/driver/hermes/config_test.go
@@ -303,6 +303,9 @@ func TestGenerateEnvFileDefaultsToolProgressOffForDiscord(t *testing.T) {
 	if !strings.Contains(string(data), hermesToolProgressModeEnv+"=off\n") {
 		t.Fatalf("expected %s=off in .env, got:\n%s", hermesToolProgressModeEnv, data)
 	}
+	if !strings.Contains(string(data), hermesAllowSilentFinalEnv+"=1\n") {
+		t.Fatalf("expected %s=1 in .env, got:\n%s", hermesAllowSilentFinalEnv, data)
+	}
 }
 
 func TestGenerateEnvFileDefaultsToolProgressOffForSlack(t *testing.T) {
@@ -316,6 +319,30 @@ func TestGenerateEnvFileDefaultsToolProgressOffForSlack(t *testing.T) {
 
 	if !strings.Contains(string(data), hermesToolProgressModeEnv+"=off\n") {
 		t.Fatalf("expected %s=off in .env, got:\n%s", hermesToolProgressModeEnv, data)
+	}
+	if !strings.Contains(string(data), hermesAllowSilentFinalEnv+"=1\n") {
+		t.Fatalf("expected %s=1 in .env, got:\n%s", hermesAllowSilentFinalEnv, data)
+	}
+}
+
+func TestGenerateEnvFileAllowsSilentFinalDefaultOverride(t *testing.T) {
+	rc := &driver.ResolvedClaw{
+		Handles: map[string]*driver.HandleInfo{"discord": {}},
+		Environment: map[string]string{
+			hermesAllowSilentFinalEnv: "0",
+		},
+	}
+	data, err := GenerateEnvFile(rc, &modelConfig{Env: map[string]string{}})
+	if err != nil {
+		t.Fatalf("GenerateEnvFile returned error: %v", err)
+	}
+
+	env := string(data)
+	if !strings.Contains(env, hermesAllowSilentFinalEnv+"=0\n") {
+		t.Fatalf("expected %s override in .env, got:\n%s", hermesAllowSilentFinalEnv, env)
+	}
+	if strings.Contains(env, hermesAllowSilentFinalEnv+"=1\n") {
+		t.Fatalf("expected no default %s=1 when override is set, got:\n%s", hermesAllowSilentFinalEnv, env)
 	}
 }
 

--- a/internal/driver/hermes/config_test.go
+++ b/internal/driver/hermes/config_test.go
@@ -247,6 +247,50 @@ func TestGenerateEnvFileSetsManagedDefaultIdentity(t *testing.T) {
 	}
 }
 
+func TestGenerateEnvFileDefaultsWritableGatewayState(t *testing.T) {
+	rc := &driver.ResolvedClaw{}
+	data, err := GenerateEnvFile(rc, &modelConfig{Env: map[string]string{}})
+	if err != nil {
+		t.Fatalf("GenerateEnvFile returned error: %v", err)
+	}
+
+	env := string(data)
+	for _, expected := range []string{
+		hermesGatewayLockDirEnv + "=" + hermesDefaultGatewayLockDir + "\n",
+		"XDG_STATE_HOME=" + hermesDefaultXDGStateHome + "\n",
+	} {
+		if !strings.Contains(env, expected) {
+			t.Fatalf("expected %q in .env, got:\n%s", expected, env)
+		}
+	}
+	if strings.Contains(env, "/root/.local") {
+		t.Fatalf("Hermes gateway state must not default under read-only /root/.local, got:\n%s", env)
+	}
+}
+
+func TestGenerateEnvFileAllowsGatewayStateOverride(t *testing.T) {
+	rc := &driver.ResolvedClaw{
+		Environment: map[string]string{
+			hermesGatewayLockDirEnv: "/custom/locks",
+			"XDG_STATE_HOME":        "/custom/state",
+		},
+	}
+	data, err := GenerateEnvFile(rc, &modelConfig{Env: map[string]string{}})
+	if err != nil {
+		t.Fatalf("GenerateEnvFile returned error: %v", err)
+	}
+
+	env := string(data)
+	for _, expected := range []string{
+		hermesGatewayLockDirEnv + "=/custom/locks\n",
+		"XDG_STATE_HOME=/custom/state\n",
+	} {
+		if !strings.Contains(env, expected) {
+			t.Fatalf("expected %q in .env, got:\n%s", expected, env)
+		}
+	}
+}
+
 func TestGenerateEnvFileDefaultsToolProgressOffForDiscord(t *testing.T) {
 	rc := &driver.ResolvedClaw{
 		Handles: map[string]*driver.HandleInfo{"discord": {}},

--- a/internal/driver/hermes/driver.go
+++ b/internal/driver/hermes/driver.go
@@ -196,6 +196,7 @@ func (d *Driver) Materialize(rc *driver.ResolvedClaw, opts driver.MaterializeOpt
 	// runner-native tool progress silent by default so only real replies post.
 	if hasDiscordHandle(rc) || hasSlackHandle(rc) {
 		env["HERMES_TOOL_ONLY_MODE"] = "1"
+		env[hermesAllowSilentFinalEnv] = "1"
 		env[hermesToolProgressModeEnv] = "off"
 		if disabled := resolveDisabledHermesTools(rc); len(disabled) > 0 {
 			env[clawdapusDisabledToolsEnv] = strings.Join(disabled, ",")
@@ -207,6 +208,13 @@ func (d *Driver) Materialize(rc *driver.ResolvedClaw, opts driver.MaterializeOpt
 		if value != "" {
 			env[hermesToolProgressModeEnv] = value
 		}
+	}
+	value, err := resolvedEnvValue(rc, hermesAllowSilentFinalEnv)
+	if err != nil {
+		return nil, fmt.Errorf("hermes driver: %w", err)
+	}
+	if value != "" {
+		env[hermesAllowSilentFinalEnv] = value
 	}
 	if hasSlackHandle(rc) {
 		value, err := resolvedEnvOrDefault(rc, "SLACK_REQUIRE_MENTION", "true")

--- a/internal/driver/hermes/driver.go
+++ b/internal/driver/hermes/driver.go
@@ -173,11 +173,23 @@ func (d *Driver) Materialize(rc *driver.ResolvedClaw, opts driver.MaterializeOpt
 		shared.PortableMemoryEnv:      shared.PortableMemoryDir,
 		"HOME":                        "/root",
 		"HERMES_HOME":                 hermesHomeDir,
+		hermesGatewayLockDirEnv:       hermesDefaultGatewayLockDir,
 		hermesDefaultAgentIdentityEnv: managedDefaultAgentIdentity,
 		"MESSAGING_CWD":               hermesWorkspaceDir,
 		"TERMINAL_CWD":                hermesWorkspaceDir,
+		"XDG_STATE_HOME":              hermesDefaultXDGStateHome,
 		"DISCORD_REQUIRE_MENTION":     "true",
 		"DISCORD_AUTO_THREAD":         "false",
+	}
+
+	for _, key := range []string{hermesGatewayLockDirEnv, "XDG_STATE_HOME"} {
+		value, err := resolvedEnvValue(rc, key)
+		if err != nil {
+			return nil, fmt.Errorf("hermes driver: %w", err)
+		}
+		if value != "" {
+			env[key] = value
+		}
 	}
 
 	// Chat handles need deliberate communication behavior, and Clawdapus keeps

--- a/internal/driver/hermes/driver_test.go
+++ b/internal/driver/hermes/driver_test.go
@@ -209,6 +209,9 @@ func TestMaterializeWritesRuntimeLayout(t *testing.T) {
 	if got := result.Environment["HERMES_TOOL_ONLY_MODE"]; got != "1" {
 		t.Fatalf("expected HERMES_TOOL_ONLY_MODE=1, got %q", got)
 	}
+	if got := result.Environment[hermesAllowSilentFinalEnv]; got != "1" {
+		t.Fatalf("expected %s=1, got %q", hermesAllowSilentFinalEnv, got)
+	}
 	if got := result.Environment[hermesToolProgressModeEnv]; got != "off" {
 		t.Fatalf("expected %s=off, got %q", hermesToolProgressModeEnv, got)
 	}
@@ -493,6 +496,9 @@ func TestMaterializeSlackAppliesTextChannelDefaults(t *testing.T) {
 	if got := result.Environment[hermesToolProgressModeEnv]; got != "off" {
 		t.Fatalf("expected %s=off, got %q", hermesToolProgressModeEnv, got)
 	}
+	if got := result.Environment[hermesAllowSilentFinalEnv]; got != "1" {
+		t.Fatalf("expected %s=1, got %q", hermesAllowSilentFinalEnv, got)
+	}
 	if got := result.Environment[clawdapusDisabledToolsEnv]; got != hermesTextToSpeechTool {
 		t.Fatalf("expected %s=%s, got %q", clawdapusDisabledToolsEnv, hermesTextToSpeechTool, got)
 	}
@@ -558,6 +564,36 @@ func TestMaterializeAllowsToolProgressOverride(t *testing.T) {
 	}
 	if !strings.Contains(string(envData), hermesToolProgressModeEnv+"=verbose\n") {
 		t.Fatalf("expected %s override in .env, got:\n%s", hermesToolProgressModeEnv, envData)
+	}
+}
+
+func TestMaterializeAllowsSilentFinalDefaultOverride(t *testing.T) {
+	rc, tmp := newTestRC(t)
+	rc.Environment[hermesAllowSilentFinalEnv] = "0"
+	runtimeDir := filepath.Join(tmp, "runtime")
+	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := (&Driver{}).Materialize(rc, driver.MaterializeOpts{RuntimeDir: runtimeDir, PodName: "test"})
+	if err != nil {
+		t.Fatalf("Materialize returned error: %v", err)
+	}
+
+	if got := result.Environment[hermesAllowSilentFinalEnv]; got != "0" {
+		t.Fatalf("expected %s override, got %q", hermesAllowSilentFinalEnv, got)
+	}
+
+	envData, err := os.ReadFile(filepath.Join(runtimeDir, "hermes-home", ".env"))
+	if err != nil {
+		t.Fatalf("read .env: %v", err)
+	}
+	env := string(envData)
+	if !strings.Contains(env, hermesAllowSilentFinalEnv+"=0\n") {
+		t.Fatalf("expected %s override in .env, got:\n%s", hermesAllowSilentFinalEnv, env)
+	}
+	if strings.Contains(env, hermesAllowSilentFinalEnv+"=1\n") {
+		t.Fatalf("expected no default %s=1 when override is set, got:\n%s", hermesAllowSilentFinalEnv, env)
 	}
 }
 

--- a/internal/driver/hermes/driver_test.go
+++ b/internal/driver/hermes/driver_test.go
@@ -197,6 +197,12 @@ func TestMaterializeWritesRuntimeLayout(t *testing.T) {
 	if result.Environment["HERMES_HOME"] != hermesHomeDir {
 		t.Fatalf("unexpected HERMES_HOME: %q", result.Environment["HERMES_HOME"])
 	}
+	if got := result.Environment[hermesGatewayLockDirEnv]; got != hermesDefaultGatewayLockDir {
+		t.Fatalf("expected %s=%s, got %q", hermesGatewayLockDirEnv, hermesDefaultGatewayLockDir, got)
+	}
+	if got := result.Environment["XDG_STATE_HOME"]; got != hermesDefaultXDGStateHome {
+		t.Fatalf("expected XDG_STATE_HOME=%s, got %q", hermesDefaultXDGStateHome, got)
+	}
 	if got := result.Environment[hermesDefaultAgentIdentityEnv]; got != managedDefaultAgentIdentity {
 		t.Fatalf("unexpected %s: %q", hermesDefaultAgentIdentityEnv, got)
 	}
@@ -256,6 +262,84 @@ func TestMaterializeWritesRuntimeLayout(t *testing.T) {
 	}
 	if strings.Contains(soulStr, "Nous Research") {
 		t.Fatal("default SOUL.md should not contain Hermes runner identity")
+	}
+}
+
+func TestMaterializeGatewayLocksStayWritableWithReadOnlyRootfs(t *testing.T) {
+	rc, tmp := newTestRC(t)
+	runtimeDir := filepath.Join(tmp, "runtime")
+	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := (&Driver{}).Materialize(rc, driver.MaterializeOpts{RuntimeDir: runtimeDir, PodName: "test"})
+	if err != nil {
+		t.Fatalf("Materialize returned error: %v", err)
+	}
+
+	if result.ReadOnly != true {
+		t.Fatal("test requires Hermes to run with read-only rootfs")
+	}
+	for key, want := range map[string]string{
+		hermesGatewayLockDirEnv: hermesDefaultGatewayLockDir,
+		"XDG_STATE_HOME":        hermesDefaultXDGStateHome,
+	} {
+		if got := result.Environment[key]; got != want {
+			t.Fatalf("expected container env %s=%s, got %q", key, want, got)
+		}
+	}
+
+	envData, err := os.ReadFile(filepath.Join(runtimeDir, "hermes-home", ".env"))
+	if err != nil {
+		t.Fatalf("read .env: %v", err)
+	}
+	env := string(envData)
+	for _, expected := range []string{
+		hermesGatewayLockDirEnv + "=" + hermesDefaultGatewayLockDir + "\n",
+		"XDG_STATE_HOME=" + hermesDefaultXDGStateHome + "\n",
+	} {
+		if !strings.Contains(env, expected) {
+			t.Fatalf("expected %q in .env, got:\n%s", expected, env)
+		}
+	}
+	if strings.Contains(env, "/root/.local") {
+		t.Fatalf("Hermes gateway state must not default under read-only /root/.local, got:\n%s", env)
+	}
+}
+
+func TestMaterializeAllowsGatewayStateOverrides(t *testing.T) {
+	rc, tmp := newTestRC(t)
+	rc.Environment[hermesGatewayLockDirEnv] = "/custom/locks"
+	rc.Environment["XDG_STATE_HOME"] = "/custom/state"
+	runtimeDir := filepath.Join(tmp, "runtime")
+	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := (&Driver{}).Materialize(rc, driver.MaterializeOpts{RuntimeDir: runtimeDir, PodName: "test"})
+	if err != nil {
+		t.Fatalf("Materialize returned error: %v", err)
+	}
+
+	if got := result.Environment[hermesGatewayLockDirEnv]; got != "/custom/locks" {
+		t.Fatalf("expected %s override, got %q", hermesGatewayLockDirEnv, got)
+	}
+	if got := result.Environment["XDG_STATE_HOME"]; got != "/custom/state" {
+		t.Fatalf("expected XDG_STATE_HOME override, got %q", got)
+	}
+
+	envData, err := os.ReadFile(filepath.Join(runtimeDir, "hermes-home", ".env"))
+	if err != nil {
+		t.Fatalf("read .env: %v", err)
+	}
+	env := string(envData)
+	for _, expected := range []string{
+		hermesGatewayLockDirEnv + "=/custom/locks\n",
+		"XDG_STATE_HOME=/custom/state\n",
+	} {
+		if !strings.Contains(env, expected) {
+			t.Fatalf("expected %q in .env, got:\n%s", expected, env)
+		}
 	}
 }
 

--- a/internal/infraimages/release_manifest.go
+++ b/internal/infraimages/release_manifest.go
@@ -9,7 +9,7 @@ const (
 	DefaultClawWallTag     = DefaultClawInfraTag
 	DefaultClawMCPStdioTag = DefaultClawInfraTag
 	DefaultCllamaTag       = "v0.6.7"
-	DefaultHermesBaseTag   = "v2026.4.23-claw.2"
+	DefaultHermesBaseTag   = "v2026.5.16-claw.1"
 )
 
 func ReleaseRefs(releaseTag string) []string {

--- a/site/changelog.md
+++ b/site/changelog.md
@@ -29,7 +29,7 @@ outline: deep
 
 ## Unreleased
 
-<!-- Nothing yet -->
+- **Hermes silent-final behavior is default for managed messaging agents** — Hermes Discord and Slack agents now set `HERMES_ALLOW_SILENT_FINAL=1` by default so tool-delivered replies can intentionally end without an extra final message. This avoids noisy "empty after tool calls" nudges when `send_message` already delivered the visible response, while preserving an escape hatch via `HERMES_ALLOW_SILENT_FINAL=0`. Closes [#251](https://github.com/mostlydev/clawdapus/issues/251).
 
 ## v0.17.3 <Badge type="tip" text="Latest" /> {#v0-17-3}
 

--- a/site/guide/drivers.md
+++ b/site/guide/drivers.md
@@ -57,10 +57,12 @@ Container env vars from compose `environment:` are not available in Hermes agent
 
 For Discord handles, the Hermes driver disables the upstream `text_to_speech` tool by default so agents reply in text instead of model-selected voice attachments. A service can opt back in with `x-claw.hermes.allow-tools: [text_to_speech]`.
 
-Hermes services can also opt into silent-final handling for reasoning models
-with `x-claw.hermes.allow-silent: true`. When enabled, a response containing
-only `<think>` blocks completes as a no-op instead of surfacing a retry
-exhaustion warning to Discord.
+Hermes Discord and Slack services default to silent-final handling because the
+visible reply often goes through the `send_message` tool. Empty visible final
+responses after tool calls complete as no-op turns instead of surfacing retry
+or nudge warnings to the channel. Operators can disable this per service with
+`HERMES_ALLOW_SILENT_FINAL=0`, or enable it explicitly for other Hermes
+surfaces with `x-claw.hermes.allow-silent: true`.
 
 ### nanoclaw
 


### PR DESCRIPTION
## Summary

- Updates the pinned upstream Hermes base from `v2026.4.23-claw.2` to `v2026.5.16-claw.1`.
- Refreshes Clawdapus runtime patch anchors for upstream `toolsets.py` and `run_agent._build_api_kwargs` drift.
- Keeps the existing mount contract: `HERMES_HOME` covers `/root/.hermes/hooks`, workspace context stays under `/workspace`, memory/session history/skills remain on the existing Clawdapus-managed surfaces.
- Fixes the read-only-rootfs gateway lock regression by defaulting `HERMES_GATEWAY_LOCK_DIR=/tmp/hermes-gateway-locks` and `XDG_STATE_HOME=/tmp/xdg-state` in both container env and the sourced Hermes `.env`, with operator overrides preserved.
- Defaults Hermes Discord/Slack agents to `HERMES_ALLOW_SILENT_FINAL=1` so tool-delivered replies can intentionally end without an extra final post or noisy empty-after-tool-call nudge. Operators can disable this per service with `HERMES_ALLOW_SILENT_FINAL=0`.

## Manual publish prerequisite

This PR intentionally updates `DefaultHermesBaseTag`, so it must not merge until the corresponding image exists. Right now:

```sh
docker manifest inspect ghcr.io/mostlydev/hermes-base:v2026.5.16-claw.1
# manifest unknown
```

Before merge/release, the maintainer needs to publish the multi-arch image:

```sh
docker buildx build --platform linux/amd64,linux/arm64 \
  -t ghcr.io/mostlydev/hermes-base:v2026.5.16-claw.1 \
  --push dockerfiles/hermes-base/
```

Then re-run `docker manifest inspect ghcr.io/mostlydev/hermes-base:v2026.5.16-claw.1` or the release verifier.

## Validation

- `go test ./internal/driver/hermes -run 'Test(GenerateEnvFileDefaultsToolProgressOffForDiscord|GenerateEnvFileDefaultsToolProgressOffForSlack|GenerateEnvFileAllowsSilentFinalDefaultOverride|MaterializeWritesRuntimeLayout|MaterializeSlackAppliesTextChannelDefaults|MaterializeAllowsSilentFinalDefaultOverride|MaterializeWritesAllowSilentEnv)' -count=1`
- `go test ./cmd/claw -run TestHermesBaseImageSourceContract -count=1`
- `go test -tags spike ./cmd/claw -run TestSpikeHermesBaseImageContract -count=1`
- `go test ./...`
- `go vet ./...`

Earlier validation also covered the #249 lock-state regression and broader Hermes/compose surface:

- `go test ./internal/driver/hermes -run 'Test(MaterializeGatewayLocksStayWritableWithReadOnlyRootfs|MaterializeAllowsGatewayStateOverrides|GenerateEnvFileDefaultsWritableGatewayState|GenerateEnvFileAllowsGatewayStateOverride)' -count=1`
- `go test ./internal/driver/hermes ./cmd/claw ./internal/pod -run 'Test(Hermes|BaseImage|AppendPersistentSkill|PersistentSkill|ComposeEmitsPerServiceHostPathMounts|EmitCompose|MaterializeGatewayLocks|GenerateEnvFileDefaultsWritableGatewayState|GenerateEnvFileAllowsGatewayStateOverride)' -count=1`
- Container probe: `HOOKS_DIR=/root/.hermes/hooks`, `text_to_speech` filtered from core and Discord toolsets, session epoch/header hook present, tool-choice helper present, identity env hook present.

Closes #248
Closes #249
Closes #251
