### PR TITLE
Expose Hermes native tool presets

### DIFF
--- a/cmd/claw/spike_test.go
+++ b/cmd/claw/spike_test.go
@@ -839,6 +839,56 @@ func spikeBuildImage(t *testing.T, contextDir, tag, dockerfile string) {
 	if err != nil {
 		t.Fatalf("docker build %s: %v\n%s", tag, err, out)
 	}
+	spikeTagRunnerBaseImage(t, tag)
+}
+
+func spikeTagRunnerBaseImage(t *testing.T, tag string) {
+	t.Helper()
+	if !spikeIsRunnerBaseTag(tag) {
+		return
+	}
+
+	out, err := exec.Command("docker", "image", "inspect", "--format", "{{.Id}}", tag).Output()
+	if err != nil {
+		t.Fatalf("inspect runner base image %s: %v", tag, err)
+	}
+	imageID := strings.TrimPrefix(strings.TrimSpace(string(out)), "sha256:")
+	if len(imageID) > 12 {
+		imageID = imageID[:12]
+	}
+	if imageID == "" {
+		imageID = "unknown"
+	}
+
+	versioned := spikeImageRepo(tag) + ":built-" + time.Now().UTC().Format("20060102") + "-" + imageID
+	t.Logf("tagging runner base %s as %s", tag, versioned)
+	if out, err := exec.Command("docker", "tag", tag, versioned).CombinedOutput(); err != nil {
+		t.Fatalf("tag runner base %s as %s: %v\n%s", tag, versioned, err, out)
+	}
+}
+
+func spikeIsRunnerBaseTag(tag string) bool {
+	switch tag {
+	case "openclaw:latest",
+		"nullclaw:latest",
+		"microclaw:latest",
+		"nanoclaw-orchestrator:latest",
+		"nanobot:latest",
+		"picoclaw:latest":
+		return true
+	default:
+		return false
+	}
+}
+
+func spikeImageRepo(imageRef string) string {
+	imageRef = strings.TrimSpace(imageRef)
+	slash := strings.LastIndex(imageRef, "/")
+	colon := strings.LastIndex(imageRef, ":")
+	if colon > slash {
+		return imageRef[:colon]
+	}
+	return imageRef
 }
 
 func spikeEnsureRepoInfraImages(t *testing.T, repoRoot string, components ...string) {

--- a/internal/driver/hermes/config.go
+++ b/internal/driver/hermes/config.go
@@ -27,6 +27,7 @@ const (
 	hermesTextToSpeechTool        = "text_to_speech"
 	hermesDefaultGatewayLockDir   = "/tmp/hermes-gateway-locks"
 	hermesDefaultXDGStateHome     = "/tmp/xdg-state"
+	hermesDefaultNoProxy          = "localhost,127.0.0.1,cllama"
 	managedDefaultAgentIdentity   = "You are a Clawdapus-managed agent. Your identity, authority, communication policy, memory policy, and tool-use rules are defined by the Clawdapus project context loaded below: AGENTS.md, CLAWDAPUS.md, SOUL.md, mounted skills, feeds, and managed-tool policy. Do not identify as Hermes or as a generic assistant. Follow the Clawdapus contract when it is more specific than runner defaults; otherwise retain the Hermes runtime guidance below, including persistent memory behavior."
 )
 
@@ -104,6 +105,8 @@ func GenerateEnvFile(rc *driver.ResolvedClaw, modelCfg *modelConfig) ([]byte, er
 	env["MESSAGING_CWD"] = hermesWorkspaceDir
 	env["TERMINAL_CWD"] = hermesWorkspaceDir
 	env["XDG_STATE_HOME"] = hermesDefaultXDGStateHome
+	env["NO_PROXY"] = hermesDefaultNoProxy
+	env["no_proxy"] = hermesDefaultNoProxy
 	env[hermesDefaultAgentIdentityEnv] = managedDefaultAgentIdentity
 	if hasDiscordHandle(rc) || hasSlackHandle(rc) {
 		env[hermesAllowSilentFinalEnv] = "1"
@@ -349,6 +352,8 @@ func allowedEnvPassthroughKeys() []string {
 		hermesGatewayLockDirEnv,
 		hermesAllowSilentFinalEnv,
 		hermesToolProgressModeEnv,
+		"NO_PROXY",
+		"no_proxy",
 		"OPENAI_API_KEY",
 		"OPENROUTER_API_KEY",
 		"SLACK_ALLOWED_USERS",

--- a/internal/driver/hermes/config.go
+++ b/internal/driver/hermes/config.go
@@ -51,6 +51,9 @@ func GenerateConfig(rc *driver.ResolvedClaw, modelCfg *modelConfig) ([]byte, err
 			"timeout": 180,
 		},
 	}
+	if toolsets := platformToolsetsForHandles(rc); len(toolsets) > 0 {
+		config["platform_toolsets"] = toolsets
+	}
 
 	for _, cmd := range rc.Configures {
 		path, value, err := shared.ParseConfigSetCommand(cmd, "hermes")
@@ -67,6 +70,27 @@ func GenerateConfig(rc *driver.ResolvedClaw, modelCfg *modelConfig) ([]byte, err
 		return nil, fmt.Errorf("config generation: marshal yaml: %w", err)
 	}
 	return data, nil
+}
+
+func platformToolsetsForHandles(rc *driver.ResolvedClaw) map[string]any {
+	presets := map[string]string{
+		"discord":  "hermes-discord",
+		"slack":    "hermes-slack",
+		"telegram": "hermes-telegram",
+	}
+	toolsets := make(map[string]any)
+	if rc == nil {
+		return toolsets
+	}
+	for rawPlatform := range rc.Handles {
+		platform := strings.ToLower(strings.TrimSpace(rawPlatform))
+		preset, ok := presets[platform]
+		if !ok {
+			continue
+		}
+		toolsets[platform] = []string{preset}
+	}
+	return toolsets
 }
 
 func GenerateEnvFile(rc *driver.ResolvedClaw, modelCfg *modelConfig) ([]byte, error) {
@@ -318,6 +342,8 @@ func allowedEnvPassthroughKeys() []string {
 		"DISCORD_HOME_CHANNEL",
 		"DISCORD_HOME_CHANNEL_NAME",
 		"DISCORD_REQUIRE_MENTION",
+		"FIRECRAWL_API_KEY",
+		"FIRECRAWL_API_URL",
 		"GATEWAY_ALLOWED_USERS",
 		"GATEWAY_ALLOW_ALL_USERS",
 		hermesGatewayLockDirEnv,

--- a/internal/driver/hermes/config_test.go
+++ b/internal/driver/hermes/config_test.go
@@ -225,6 +225,88 @@ func TestGenerateConfigIncludesCllamaRouting(t *testing.T) {
 	}
 }
 
+func TestGenerateConfigIncludesPlatformToolsetsForActiveHandles(t *testing.T) {
+	rc := &driver.ResolvedClaw{
+		Models: map[string]string{"primary": "openrouter/anthropic/claude-sonnet-4"},
+		Handles: map[string]*driver.HandleInfo{
+			"discord": {},
+			"Slack":   {},
+		},
+		Environment: map[string]string{
+			"DISCORD_BOT_TOKEN":  "discord-token",
+			"SLACK_BOT_TOKEN":    "slack-bot",
+			"SLACK_APP_TOKEN":    "slack-app",
+			"OPENROUTER_API_KEY": "or-key",
+		},
+	}
+
+	mc, err := resolveModelConfig(rc)
+	if err != nil {
+		t.Fatalf("resolveModelConfig returned error: %v", err)
+	}
+	data, err := GenerateConfig(rc, mc)
+	if err != nil {
+		t.Fatalf("GenerateConfig returned error: %v", err)
+	}
+
+	var cfg struct {
+		PlatformToolsets map[string][]string `yaml:"platform_toolsets"`
+	}
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse generated yaml: %v", err)
+	}
+
+	for platform, want := range map[string]string{
+		"discord": "hermes-discord",
+		"slack":   "hermes-slack",
+	} {
+		got := cfg.PlatformToolsets[platform]
+		if len(got) != 1 || got[0] != want {
+			t.Fatalf("expected %s platform_toolsets to be [%s], got %#v", platform, want, got)
+		}
+	}
+	if _, exists := cfg.PlatformToolsets["telegram"]; exists {
+		t.Fatalf("did not expect telegram platform_toolsets entry, got %#v", cfg.PlatformToolsets["telegram"])
+	}
+}
+
+func TestGenerateConfigAllowsPlatformToolsetsOverride(t *testing.T) {
+	rc := &driver.ResolvedClaw{
+		Models: map[string]string{"primary": "openrouter/anthropic/claude-sonnet-4"},
+		Handles: map[string]*driver.HandleInfo{
+			"discord": {},
+		},
+		Configures: []string{
+			`hermes config set --json platform_toolsets.discord ["custom-discord"]`,
+		},
+		Environment: map[string]string{
+			"DISCORD_BOT_TOKEN":  "discord-token",
+			"OPENROUTER_API_KEY": "or-key",
+		},
+	}
+
+	mc, err := resolveModelConfig(rc)
+	if err != nil {
+		t.Fatalf("resolveModelConfig returned error: %v", err)
+	}
+	data, err := GenerateConfig(rc, mc)
+	if err != nil {
+		t.Fatalf("GenerateConfig returned error: %v", err)
+	}
+
+	var cfg struct {
+		PlatformToolsets map[string][]string `yaml:"platform_toolsets"`
+	}
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse generated yaml: %v", err)
+	}
+
+	got := cfg.PlatformToolsets["discord"]
+	if len(got) != 1 || got[0] != "custom-discord" {
+		t.Fatalf("expected CONFIGURE override for discord platform_toolsets, got %#v", got)
+	}
+}
+
 func TestGenerateEnvFileSetsManagedDefaultIdentity(t *testing.T) {
 	rc := &driver.ResolvedClaw{}
 	data, err := GenerateEnvFile(rc, &modelConfig{Env: map[string]string{}})
@@ -439,6 +521,29 @@ func TestGenerateEnvFilePassesThroughSlackRuntimeKnobs(t *testing.T) {
 	} {
 		if !strings.Contains(env, expected) {
 			t.Fatalf("expected %q in .env, got:\n%s", expected, env)
+		}
+	}
+}
+
+func TestGenerateEnvFileIncludesFirecrawlVars(t *testing.T) {
+	rc := &driver.ResolvedClaw{
+		Environment: map[string]string{
+			"FIRECRAWL_API_KEY": "fc-key",
+			"FIRECRAWL_API_URL": "https://firecrawl.internal",
+		},
+	}
+	data, err := GenerateEnvFile(rc, &modelConfig{Env: map[string]string{}})
+	if err != nil {
+		t.Fatalf("GenerateEnvFile returned error: %v", err)
+	}
+
+	env := string(data)
+	for _, want := range []string{
+		"FIRECRAWL_API_KEY=fc-key\n",
+		"FIRECRAWL_API_URL=https://firecrawl.internal\n",
+	} {
+		if !strings.Contains(env, want) {
+			t.Fatalf("expected env output to contain %q, got:\n%s", want, env)
 		}
 	}
 }

--- a/internal/driver/hermes/config_test.go
+++ b/internal/driver/hermes/config_test.go
@@ -339,7 +339,9 @@ func TestGenerateEnvFileDefaultsWritableGatewayState(t *testing.T) {
 	env := string(data)
 	for _, expected := range []string{
 		hermesGatewayLockDirEnv + "=" + hermesDefaultGatewayLockDir + "\n",
+		"NO_PROXY=" + hermesDefaultNoProxy + "\n",
 		"XDG_STATE_HOME=" + hermesDefaultXDGStateHome + "\n",
+		"no_proxy=" + hermesDefaultNoProxy + "\n",
 	} {
 		if !strings.Contains(env, expected) {
 			t.Fatalf("expected %q in .env, got:\n%s", expected, env)
@@ -366,6 +368,29 @@ func TestGenerateEnvFileAllowsGatewayStateOverride(t *testing.T) {
 	for _, expected := range []string{
 		hermesGatewayLockDirEnv + "=/custom/locks\n",
 		"XDG_STATE_HOME=/custom/state\n",
+	} {
+		if !strings.Contains(env, expected) {
+			t.Fatalf("expected %q in .env, got:\n%s", expected, env)
+		}
+	}
+}
+
+func TestGenerateEnvFileAllowsNoProxyOverride(t *testing.T) {
+	rc := &driver.ResolvedClaw{
+		Environment: map[string]string{
+			"NO_PROXY": "localhost,cllama,internal",
+			"no_proxy": "localhost,cllama,internal",
+		},
+	}
+	data, err := GenerateEnvFile(rc, &modelConfig{Env: map[string]string{}})
+	if err != nil {
+		t.Fatalf("GenerateEnvFile returned error: %v", err)
+	}
+
+	env := string(data)
+	for _, expected := range []string{
+		"NO_PROXY=localhost,cllama,internal\n",
+		"no_proxy=localhost,cllama,internal\n",
 	} {
 		if !strings.Contains(env, expected) {
 			t.Fatalf("expected %q in .env, got:\n%s", expected, env)

--- a/internal/driver/hermes/driver.go
+++ b/internal/driver/hermes/driver.go
@@ -176,13 +176,15 @@ func (d *Driver) Materialize(rc *driver.ResolvedClaw, opts driver.MaterializeOpt
 		hermesGatewayLockDirEnv:       hermesDefaultGatewayLockDir,
 		hermesDefaultAgentIdentityEnv: managedDefaultAgentIdentity,
 		"MESSAGING_CWD":               hermesWorkspaceDir,
+		"NO_PROXY":                    hermesDefaultNoProxy,
+		"no_proxy":                    hermesDefaultNoProxy,
 		"TERMINAL_CWD":                hermesWorkspaceDir,
 		"XDG_STATE_HOME":              hermesDefaultXDGStateHome,
 		"DISCORD_REQUIRE_MENTION":     "true",
 		"DISCORD_AUTO_THREAD":         "false",
 	}
 
-	for _, key := range []string{hermesGatewayLockDirEnv, "XDG_STATE_HOME"} {
+	for _, key := range []string{hermesGatewayLockDirEnv, "XDG_STATE_HOME", "NO_PROXY", "no_proxy"} {
 		value, err := resolvedEnvValue(rc, key)
 		if err != nil {
 			return nil, fmt.Errorf("hermes driver: %w", err)

--- a/internal/driver/hermes/driver_test.go
+++ b/internal/driver/hermes/driver_test.go
@@ -203,6 +203,12 @@ func TestMaterializeWritesRuntimeLayout(t *testing.T) {
 	if got := result.Environment["XDG_STATE_HOME"]; got != hermesDefaultXDGStateHome {
 		t.Fatalf("expected XDG_STATE_HOME=%s, got %q", hermesDefaultXDGStateHome, got)
 	}
+	if got := result.Environment["NO_PROXY"]; got != hermesDefaultNoProxy {
+		t.Fatalf("expected NO_PROXY=%s, got %q", hermesDefaultNoProxy, got)
+	}
+	if got := result.Environment["no_proxy"]; got != hermesDefaultNoProxy {
+		t.Fatalf("expected no_proxy=%s, got %q", hermesDefaultNoProxy, got)
+	}
 	if got := result.Environment[hermesDefaultAgentIdentityEnv]; got != managedDefaultAgentIdentity {
 		t.Fatalf("unexpected %s: %q", hermesDefaultAgentIdentityEnv, got)
 	}
@@ -285,7 +291,9 @@ func TestMaterializeGatewayLocksStayWritableWithReadOnlyRootfs(t *testing.T) {
 	}
 	for key, want := range map[string]string{
 		hermesGatewayLockDirEnv: hermesDefaultGatewayLockDir,
+		"NO_PROXY":              hermesDefaultNoProxy,
 		"XDG_STATE_HOME":        hermesDefaultXDGStateHome,
+		"no_proxy":              hermesDefaultNoProxy,
 	} {
 		if got := result.Environment[key]; got != want {
 			t.Fatalf("expected container env %s=%s, got %q", key, want, got)
@@ -299,7 +307,9 @@ func TestMaterializeGatewayLocksStayWritableWithReadOnlyRootfs(t *testing.T) {
 	env := string(envData)
 	for _, expected := range []string{
 		hermesGatewayLockDirEnv + "=" + hermesDefaultGatewayLockDir + "\n",
+		"NO_PROXY=" + hermesDefaultNoProxy + "\n",
 		"XDG_STATE_HOME=" + hermesDefaultXDGStateHome + "\n",
+		"no_proxy=" + hermesDefaultNoProxy + "\n",
 	} {
 		if !strings.Contains(env, expected) {
 			t.Fatalf("expected %q in .env, got:\n%s", expected, env)
@@ -314,6 +324,8 @@ func TestMaterializeAllowsGatewayStateOverrides(t *testing.T) {
 	rc, tmp := newTestRC(t)
 	rc.Environment[hermesGatewayLockDirEnv] = "/custom/locks"
 	rc.Environment["XDG_STATE_HOME"] = "/custom/state"
+	rc.Environment["NO_PROXY"] = "localhost,cllama,internal"
+	rc.Environment["no_proxy"] = "localhost,cllama,internal"
 	runtimeDir := filepath.Join(tmp, "runtime")
 	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
 		t.Fatal(err)
@@ -330,6 +342,12 @@ func TestMaterializeAllowsGatewayStateOverrides(t *testing.T) {
 	if got := result.Environment["XDG_STATE_HOME"]; got != "/custom/state" {
 		t.Fatalf("expected XDG_STATE_HOME override, got %q", got)
 	}
+	if got := result.Environment["NO_PROXY"]; got != "localhost,cllama,internal" {
+		t.Fatalf("expected NO_PROXY override, got %q", got)
+	}
+	if got := result.Environment["no_proxy"]; got != "localhost,cllama,internal" {
+		t.Fatalf("expected no_proxy override, got %q", got)
+	}
 
 	envData, err := os.ReadFile(filepath.Join(runtimeDir, "hermes-home", ".env"))
 	if err != nil {
@@ -338,7 +356,9 @@ func TestMaterializeAllowsGatewayStateOverrides(t *testing.T) {
 	env := string(envData)
 	for _, expected := range []string{
 		hermesGatewayLockDirEnv + "=/custom/locks\n",
+		"NO_PROXY=localhost,cllama,internal\n",
 		"XDG_STATE_HOME=/custom/state\n",
+		"no_proxy=localhost,cllama,internal\n",
 	} {
 		if !strings.Contains(env, expected) {
 			t.Fatalf("expected %q in .env, got:\n%s", expected, env)


### PR DESCRIPTION
## Summary
- compile explicit Hermes `platform_toolsets` for active Discord, Slack, and Telegram handles
- pass `FIRECRAWL_API_KEY` and `FIRECRAWL_API_URL` through to the generated Hermes `.env`
- default Hermes `NO_PROXY` / `no_proxy` to `localhost,127.0.0.1,cllama` so Docker-injected host proxy settings cannot break local cllama traffic
- repair spike helper runner-base tagging so freshly rebuilt local runner fixtures still satisfy current `claw build` provenance checks
- add regression coverage for generated config, operator overrides, Firecrawl env passthrough, and Hermes container env defaults

## Why
Hermes upstream ships the native web, terminal, and file tool presets for its messaging platforms, but Clawdapus left that surface partly implicit. This makes the intended runner-native tool availability depend on upstream fallback behavior and prevents configured Firecrawl credentials from reaching Hermes tool execution.

The live Discord spike also exposed a separate Hermes runtime-contract issue on this machine: Docker injected proxy/NO_PROXY environment with an unbracketed IPv6 entry, and `httpx` failed before Hermes could initialize the OpenAI client for the cllama-local request. Clawdapus now gives Hermes a sane local no-proxy default while still allowing explicit operator overrides.

## Notes
Supersedes the stale draft PR #157 with a clean branch on current `master`.

Closes #156

## Tests
- `go test ./internal/driver/hermes`
- `go test ./cmd/claw -run 'Hermes|ComposeHermes|GenerateHermes|TestSpikeHermesBaseImageContract'`
- `go test -tags spike -run '^$' ./cmd/claw`
- `go test -tags spike -count=1 -v -run '^TestSpikeRollCall$/^hermes$' -timeout 30m ./cmd/claw`
- `go test -count=1 ./...`
- `go vet ./...`
