### PR TITLE
Quiet Hermes managed gateway defaults

### DIFF
--- a/internal/driver/hermes/config.go
+++ b/internal/driver/hermes/config.go
@@ -26,6 +26,7 @@ const (
 	clawdapusDisabledToolsEnv     = "CLAWDAPUS_DISABLED_TOOLS"
 	hermesTextToSpeechTool        = "text_to_speech"
 	hermesDefaultGatewayLockDir   = "/tmp/hermes-gateway-locks"
+	hermesDefaultBusyInputMode    = "queue"
 	hermesDefaultXDGStateHome     = "/tmp/xdg-state"
 	hermesDefaultNoProxy          = "localhost,127.0.0.1,cllama"
 	managedDefaultAgentIdentity   = "You are a Clawdapus-managed agent. Your identity, authority, communication policy, memory policy, and tool-use rules are defined by the Clawdapus project context loaded below: AGENTS.md, CLAWDAPUS.md, SOUL.md, mounted skills, feeds, and managed-tool policy. Do not identify as Hermes or as a generic assistant. Follow the Clawdapus contract when it is more specific than runner defaults; otherwise retain the Hermes runtime guidance below, including persistent memory behavior."
@@ -44,8 +45,25 @@ func GenerateConfig(rc *driver.ResolvedClaw, modelCfg *modelConfig) ([]byte, err
 	if modelCfg.APIKey != "" {
 		modelBlock["api_key"] = modelCfg.APIKey
 	}
+	// The gateway bridges display config into env at boot, so keep these UX
+	// defaults in config.yaml and let operators override them with CONFIGURE.
 	config := map[string]any{
+		"approvals": map[string]any{
+			"mode":      "off",
+			"cron_mode": "approve",
+		},
+		"display": map[string]any{
+			"busy_input_mode":  hermesDefaultBusyInputMode,
+			"busy_ack_enabled": false,
+		},
 		"model": modelBlock,
+		"onboarding": map[string]any{
+			"seen": map[string]any{
+				"busy_input_prompt":        true,
+				"tool_progress_prompt":     true,
+				"openclaw_residue_cleanup": true,
+			},
+		},
 		"terminal": map[string]any{
 			"backend": "local",
 			"cwd":     hermesWorkspaceDir,

--- a/internal/driver/hermes/config_test.go
+++ b/internal/driver/hermes/config_test.go
@@ -307,6 +307,111 @@ func TestGenerateConfigAllowsPlatformToolsetsOverride(t *testing.T) {
 	}
 }
 
+func TestGenerateConfigDefaultsManagedGatewayUXQuiet(t *testing.T) {
+	rc := &driver.ResolvedClaw{
+		Models: map[string]string{"primary": "openrouter/anthropic/claude-sonnet-4"},
+		Handles: map[string]*driver.HandleInfo{
+			"discord": {},
+		},
+		Environment: map[string]string{
+			"DISCORD_BOT_TOKEN":  "discord-token",
+			"OPENROUTER_API_KEY": "or-key",
+		},
+	}
+
+	mc, err := resolveModelConfig(rc)
+	if err != nil {
+		t.Fatalf("resolveModelConfig returned error: %v", err)
+	}
+	data, err := GenerateConfig(rc, mc)
+	if err != nil {
+		t.Fatalf("GenerateConfig returned error: %v", err)
+	}
+
+	var cfg map[string]any
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse generated yaml: %v", err)
+	}
+
+	approvals, _ := cfg["approvals"].(map[string]any)
+	if got := approvals["mode"]; got != "off" {
+		t.Fatalf("expected approvals.mode=off, got %#v", got)
+	}
+	if got := approvals["cron_mode"]; got != "approve" {
+		t.Fatalf("expected approvals.cron_mode=approve, got %#v", got)
+	}
+
+	display, _ := cfg["display"].(map[string]any)
+	if got := display["busy_input_mode"]; got != hermesDefaultBusyInputMode {
+		t.Fatalf("expected display.busy_input_mode=%s, got %#v", hermesDefaultBusyInputMode, got)
+	}
+	if got := display["busy_ack_enabled"]; got != false {
+		t.Fatalf("expected display.busy_ack_enabled=false, got %#v", got)
+	}
+
+	onboarding, _ := cfg["onboarding"].(map[string]any)
+	seen, _ := onboarding["seen"].(map[string]any)
+	for _, flag := range []string{"busy_input_prompt", "tool_progress_prompt", "openclaw_residue_cleanup"} {
+		if got := seen[flag]; got != true {
+			t.Fatalf("expected onboarding.seen.%s=true, got %#v", flag, got)
+		}
+	}
+}
+
+func TestGenerateConfigAllowsManagedGatewayUXOptIn(t *testing.T) {
+	rc := &driver.ResolvedClaw{
+		Models: map[string]string{"primary": "openrouter/anthropic/claude-sonnet-4"},
+		Handles: map[string]*driver.HandleInfo{
+			"discord": {},
+		},
+		Configures: []string{
+			`hermes config set approvals.mode manual`,
+			`hermes config set approvals.cron_mode deny`,
+			`hermes config set display.busy_input_mode interrupt`,
+			`hermes config set --json display.busy_ack_enabled true`,
+			`hermes config set --json onboarding.seen.busy_input_prompt false`,
+		},
+		Environment: map[string]string{
+			"DISCORD_BOT_TOKEN":  "discord-token",
+			"OPENROUTER_API_KEY": "or-key",
+		},
+	}
+
+	mc, err := resolveModelConfig(rc)
+	if err != nil {
+		t.Fatalf("resolveModelConfig returned error: %v", err)
+	}
+	data, err := GenerateConfig(rc, mc)
+	if err != nil {
+		t.Fatalf("GenerateConfig returned error: %v", err)
+	}
+
+	var cfg map[string]any
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse generated yaml: %v", err)
+	}
+
+	approvals, _ := cfg["approvals"].(map[string]any)
+	if got := approvals["mode"]; got != "manual" {
+		t.Fatalf("expected approvals.mode override, got %#v", got)
+	}
+	if got := approvals["cron_mode"]; got != "deny" {
+		t.Fatalf("expected approvals.cron_mode override, got %#v", got)
+	}
+	display, _ := cfg["display"].(map[string]any)
+	if got := display["busy_input_mode"]; got != "interrupt" {
+		t.Fatalf("expected display.busy_input_mode override, got %#v", got)
+	}
+	if got := display["busy_ack_enabled"]; got != true {
+		t.Fatalf("expected display.busy_ack_enabled override, got %#v", got)
+	}
+	onboarding, _ := cfg["onboarding"].(map[string]any)
+	seen, _ := onboarding["seen"].(map[string]any)
+	if got := seen["busy_input_prompt"]; got != false {
+		t.Fatalf("expected onboarding.seen.busy_input_prompt override, got %#v", got)
+	}
+}
+
 func TestGenerateEnvFileSetsManagedDefaultIdentity(t *testing.T) {
 	rc := &driver.ResolvedClaw{}
 	data, err := GenerateEnvFile(rc, &modelConfig{Env: map[string]string{}})

--- a/site/changelog.md
+++ b/site/changelog.md
@@ -29,7 +29,7 @@ outline: deep
 
 ## Unreleased
 
-<!-- Nothing yet -->
+- **Hermes managed pods default to non-interactive gateway UX** — generated Hermes config now disables interactive command-approval prompts while preserving hardline command blocks, queues busy follow-up messages instead of interrupting in-flight work, suppresses busy acknowledgments, and pre-seeds first-touch onboarding flags so pod recreation does not repost setup and tip chatter. Operators can opt back into the personal-assistant UX with explicit Hermes `CONFIGURE` overrides. Closes [#276](https://github.com/mostlydev/clawdapus/issues/276).
 
 ## v0.20.0 <Badge type="tip" text="Latest" /> {#v0-20-0}
 


### PR DESCRIPTION
## Summary
- Default generated Hermes config to non-interactive managed-pod gateway UX: approvals off, cron approvals allowed, busy follow-ups queued, and busy acknowledgments suppressed.
- Pre-seed Hermes onboarding flags so pod recreation does not replay one-time setup and tip messages.
- Keep these defaults config-only because Hermes treats config as authoritative when bridging display settings into runtime env; operators can opt back in with explicit `CONFIGURE hermes config set ...` overrides.
- Document the change in the Unreleased changelog.

## Verification
- `go test ./internal/driver/hermes`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

Closes #276
