### PR TITLE
Suppress Hermes lifecycle notices in managed pods

### DIFF
--- a/internal/driver/hermes/config.go
+++ b/internal/driver/hermes/config.go
@@ -73,6 +73,9 @@ func GenerateConfig(rc *driver.ResolvedClaw, modelCfg *modelConfig) ([]byte, err
 	if toolsets := platformToolsetsForHandles(rc); len(toolsets) > 0 {
 		config["platform_toolsets"] = toolsets
 	}
+	if platforms := platformConfigsForHandles(rc); len(platforms) > 0 {
+		config["platforms"] = platforms
+	}
 
 	for _, cmd := range rc.Configures {
 		path, value, err := shared.ParseConfigSetCommand(cmd, "hermes")
@@ -110,6 +113,23 @@ func platformToolsetsForHandles(rc *driver.ResolvedClaw) map[string]any {
 		toolsets[platform] = []string{preset}
 	}
 	return toolsets
+}
+
+func platformConfigsForHandles(rc *driver.ResolvedClaw) map[string]any {
+	configs := make(map[string]any)
+	if rc == nil {
+		return configs
+	}
+	for rawPlatform := range rc.Handles {
+		platform := strings.ToLower(strings.TrimSpace(rawPlatform))
+		switch platform {
+		case "discord", "slack", "telegram":
+			configs[platform] = map[string]any{
+				"gateway_restart_notification": false,
+			}
+		}
+	}
+	return configs
 }
 
 func GenerateEnvFile(rc *driver.ResolvedClaw, modelCfg *modelConfig) ([]byte, error) {

--- a/internal/driver/hermes/config_test.go
+++ b/internal/driver/hermes/config_test.go
@@ -251,6 +251,9 @@ func TestGenerateConfigIncludesPlatformToolsetsForActiveHandles(t *testing.T) {
 
 	var cfg struct {
 		PlatformToolsets map[string][]string `yaml:"platform_toolsets"`
+		Platforms        map[string]struct {
+			GatewayRestartNotification bool `yaml:"gateway_restart_notification"`
+		} `yaml:"platforms"`
 	}
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		t.Fatalf("parse generated yaml: %v", err)
@@ -264,9 +267,19 @@ func TestGenerateConfigIncludesPlatformToolsetsForActiveHandles(t *testing.T) {
 		if len(got) != 1 || got[0] != want {
 			t.Fatalf("expected %s platform_toolsets to be [%s], got %#v", platform, want, got)
 		}
+		platformCfg, exists := cfg.Platforms[platform]
+		if !exists {
+			t.Fatalf("expected %s platforms entry", platform)
+		}
+		if got := platformCfg.GatewayRestartNotification; got != false {
+			t.Fatalf("expected %s gateway_restart_notification=false, got %#v", platform, got)
+		}
 	}
 	if _, exists := cfg.PlatformToolsets["telegram"]; exists {
 		t.Fatalf("did not expect telegram platform_toolsets entry, got %#v", cfg.PlatformToolsets["telegram"])
+	}
+	if _, exists := cfg.Platforms["telegram"]; exists {
+		t.Fatalf("did not expect telegram platforms entry, got %#v", cfg.Platforms["telegram"])
 	}
 }
 
@@ -356,6 +369,12 @@ func TestGenerateConfigDefaultsManagedGatewayUXQuiet(t *testing.T) {
 			t.Fatalf("expected onboarding.seen.%s=true, got %#v", flag, got)
 		}
 	}
+
+	platforms, _ := cfg["platforms"].(map[string]any)
+	discord, _ := platforms["discord"].(map[string]any)
+	if got := discord["gateway_restart_notification"]; got != false {
+		t.Fatalf("expected platforms.discord.gateway_restart_notification=false, got %#v", got)
+	}
 }
 
 func TestGenerateConfigAllowsManagedGatewayUXOptIn(t *testing.T) {
@@ -370,6 +389,7 @@ func TestGenerateConfigAllowsManagedGatewayUXOptIn(t *testing.T) {
 			`hermes config set display.busy_input_mode interrupt`,
 			`hermes config set --json display.busy_ack_enabled true`,
 			`hermes config set --json onboarding.seen.busy_input_prompt false`,
+			`hermes config set --json platforms.discord.gateway_restart_notification true`,
 		},
 		Environment: map[string]string{
 			"DISCORD_BOT_TOKEN":  "discord-token",
@@ -409,6 +429,11 @@ func TestGenerateConfigAllowsManagedGatewayUXOptIn(t *testing.T) {
 	seen, _ := onboarding["seen"].(map[string]any)
 	if got := seen["busy_input_prompt"]; got != false {
 		t.Fatalf("expected onboarding.seen.busy_input_prompt override, got %#v", got)
+	}
+	platforms, _ := cfg["platforms"].(map[string]any)
+	discord, _ := platforms["discord"].(map[string]any)
+	if got := discord["gateway_restart_notification"]; got != true {
+		t.Fatalf("expected platforms.discord.gateway_restart_notification override, got %#v", got)
 	}
 }
 

--- a/site/changelog.md
+++ b/site/changelog.md
@@ -29,7 +29,7 @@ outline: deep
 
 ## Unreleased
 
-<!-- Nothing yet -->
+- **Hermes managed pods suppress gateway lifecycle notices** — generated Hermes config now disables upstream gateway restart and shutdown notifications for managed messaging handles, including the active-task interruption notice sent during pod recreation. Operators can opt back into upstream lifecycle pings with explicit Hermes `CONFIGURE` overrides. Closes [#278](https://github.com/mostlydev/clawdapus/issues/278).
 
 ## v0.21.0 <Badge type="tip" text="Latest" /> {#v0-21-0}
 


### PR DESCRIPTION
## Summary
- Found the source of `Gateway shutting down — Your current task will be interrupted.` in upstream Hermes `gateway/run.py` inside `_notify_active_sessions_of_shutdown()`.
- Default generated Hermes `platforms.<platform>.gateway_restart_notification` to `false` for active managed handles, which suppresses upstream shutdown/restart notices without patching `hermes-base`.
- Preserve operator opt-in with explicit `CONFIGURE hermes config set --json platforms.<platform>.gateway_restart_notification true`.
- Document the follow-up in the Unreleased changelog.

## Verification
- `go test ./internal/driver/hermes`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

Closes #278
