### PR TITLE
Hermes: disable cron response wrapper by default

### DIFF
--- a/internal/driver/hermes/config.go
+++ b/internal/driver/hermes/config.go
@@ -52,6 +52,9 @@ func GenerateConfig(rc *driver.ResolvedClaw, modelCfg *modelConfig) ([]byte, err
 			"mode":      "off",
 			"cron_mode": "approve",
 		},
+		"cron": map[string]any{
+			"wrap_response": false,
+		},
 		"display": map[string]any{
 			"busy_input_mode":  hermesDefaultBusyInputMode,
 			"busy_ack_enabled": false,

--- a/internal/driver/hermes/config_test.go
+++ b/internal/driver/hermes/config_test.go
@@ -341,6 +341,11 @@ func TestGenerateConfigDefaultsManagedGatewayUXQuiet(t *testing.T) {
 		t.Fatalf("expected approvals.cron_mode=approve, got %#v", got)
 	}
 
+	cron, _ := cfg["cron"].(map[string]any)
+	if got := cron["wrap_response"]; got != false {
+		t.Fatalf("expected cron.wrap_response=false, got %#v", got)
+	}
+
 	display, _ := cfg["display"].(map[string]any)
 	if got := display["busy_input_mode"]; got != hermesDefaultBusyInputMode {
 		t.Fatalf("expected display.busy_input_mode=%s, got %#v", hermesDefaultBusyInputMode, got)
@@ -367,6 +372,7 @@ func TestGenerateConfigAllowsManagedGatewayUXOptIn(t *testing.T) {
 		Configures: []string{
 			`hermes config set approvals.mode manual`,
 			`hermes config set approvals.cron_mode deny`,
+			`hermes config set --json cron.wrap_response true`,
 			`hermes config set display.busy_input_mode interrupt`,
 			`hermes config set --json display.busy_ack_enabled true`,
 			`hermes config set --json onboarding.seen.busy_input_prompt false`,
@@ -397,6 +403,10 @@ func TestGenerateConfigAllowsManagedGatewayUXOptIn(t *testing.T) {
 	}
 	if got := approvals["cron_mode"]; got != "deny" {
 		t.Fatalf("expected approvals.cron_mode override, got %#v", got)
+	}
+	cron, _ := cfg["cron"].(map[string]any)
+	if got := cron["wrap_response"]; got != true {
+		t.Fatalf("expected cron.wrap_response override, got %#v", got)
 	}
 	display, _ := cfg["display"].(map[string]any)
 	if got := display["busy_input_mode"]; got != "interrupt" {


### PR DESCRIPTION
## Summary

- default generated Hermes config to `cron.wrap_response: false` so scheduled posts are not wrapped with personal-assistant header/footer text
- keep the existing CONFIGURE escape hatch; operators can re-enable wrapping with `hermes config set --json cron.wrap_response true`
- cover both the default and opt-in behavior in Hermes driver config tests

Closes #282

## Verification

- `go test ./internal/driver/hermes/...`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

## Notes

- No release pins, changelog Latest badge, nav version, or cllama submodule changes.