### PR TITLE
Contributor on-ramp, troubleshooting guide, hermes-base canary CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,53 @@
+name: Bug report
+description: Something broke — a command failed, an agent misbehaved, a pod won't come up
+labels: ["bug"]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: claw version
+      description: Output of `claw --version`
+      placeholder: v0.22.0
+    validations:
+      required: true
+  - type: dropdown
+    id: driver
+    attributes:
+      label: Driver type
+      description: Which runner driver is involved (if any)
+      options:
+        - openclaw
+        - hermes
+        - nanoclaw
+        - nanobot
+        - picoclaw
+        - nullclaw
+        - microclaw
+        - generic / none
+        - not driver-related
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you did, what you expected, what you got. Include the exact command and its output.
+    validations:
+      required: true
+  - type: textarea
+    id: pod-yaml
+    attributes:
+      label: Relevant pod YAML snippet
+      description: The smallest `claw-pod.yml` (or Clawfile) fragment that reproduces it. Redact tokens and IDs.
+      render: yaml
+  - type: textarea
+    id: doctor
+    attributes:
+      label: claw doctor output
+      render: shell
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: "`claw logs <service>`, `claw audit`, or container logs as relevant"
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Project board (priorities)
+    url: https://github.com/users/mostlydev/projects/2
+    about: The prioritized roadmap — see what's planned, ready, and in progress.
+  - name: Documentation
+    url: https://clawdapus.dev
+    about: Guides, troubleshooting, and the CLI reference.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: Feature request
+description: Propose a capability, improvement, or change in behavior
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: What problem does this solve? What does it unblock? Concrete scenarios beat abstractions.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: What should happen, and where (CLI, pod YAML, Clawfile, cllama, a driver)? Sketch the UX if user-facing.
+    validations:
+      required: true
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints and open questions
+      description: Anything a future implementer should know — compatibility concerns, design alternatives you rejected, open questions.
+  - type: checkboxes
+    id: principles
+    attributes:
+      label: Compilation principles
+      description: Clawdapus resolves all wiring at compile time (`claw up`), not runtime. See AGENTS.md "Compilation Principles".
+      options:
+        - label: This proposal keeps wiring compile-time (or explains why it can't)

--- a/.github/workflows/hermes-base-canary.yml
+++ b/.github/workflows/hermes-base-canary.yml
@@ -1,0 +1,55 @@
+name: hermes-base canary
+
+# Early warning for patch anchor breakage in dockerfiles/hermes-base/
+# patch-hermes-runtime.py. The patch script applies regex-anchored edits to
+# upstream hermes-agent source and fails the build loudly when an anchor
+# misses. Building weekly against upstream HEAD (and the latest upstream tag)
+# surfaces anchor drift when upstream refactors — instead of at the moment we
+# need an urgent pin bump. No images are published from this workflow.
+
+on:
+  schedule:
+    - cron: "17 6 * * 1" # Mondays 06:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  canary:
+    name: build vs upstream ${{ matrix.ref_kind }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ref_kind: [head, latest-tag]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve upstream ref
+        id: ref
+        run: |
+          if [ "${{ matrix.ref_kind }}" = "head" ]; then
+            echo "ref=main" >> "$GITHUB_OUTPUT"
+          else
+            tag=$(git ls-remote --tags --sort=-v:refname \
+              https://github.com/NousResearch/hermes-agent.git \
+              | grep -v '\^{}' | head -1 | sed 's|.*refs/tags/||')
+            if [ -z "$tag" ]; then
+              echo "could not resolve latest upstream tag" >&2
+              exit 1
+            fi
+            echo "ref=$tag" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build hermes-base against upstream ${{ steps.ref.outputs.ref }}
+        run: |
+          docker build \
+            --build-arg HERMES_UPSTREAM_TAG="${{ steps.ref.outputs.ref }}" \
+            dockerfiles/hermes-base/ 2>&1 | tee build.log
+
+      - name: Surface failed patch anchors
+        if: failure()
+        run: |
+          echo "::error::hermes-base patch anchors failed against upstream ${{ steps.ref.outputs.ref }} — see anchor names below"
+          grep -E "replace_once|anchor|PATCH" build.log | tail -40 || true

--- a/.github/workflows/hermes-base-canary.yml
+++ b/.github/workflows/hermes-base-canary.yml
@@ -43,7 +43,9 @@ jobs:
           fi
 
       - name: Build hermes-base against upstream ${{ steps.ref.outputs.ref }}
+        shell: bash
         run: |
+          set -o pipefail
           docker build \
             --build-arg HERMES_UPSTREAM_TAG="${{ steps.ref.outputs.ref }}" \
             dockerfiles/hermes-base/ 2>&1 | tee build.log
@@ -52,4 +54,4 @@ jobs:
         if: failure()
         run: |
           echo "::error::hermes-base patch anchors failed against upstream ${{ steps.ref.outputs.ref }} — see anchor names below"
-          grep -E "replace_once|anchor|PATCH" build.log | tail -40 || true
+          grep -iE "expected to patch|replace_once|anchor|patch" build.log | tail -40 || true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,8 @@ Releases are tag-driven and cut by the maintainer. These must **never** change i
 - **The `<Badge type="tip" text="Latest" />` badge or a new version section in `site/changelog.md`** — the site deploys on every master push, so this would publicly claim a release that doesn't exist. Add your notes under `## Unreleased` instead.
 - **The version dropdown in `site/.vitepress/config.mts`** — same reason.
 - **The `cllama` submodule pointer beyond the latest cllama tag** — if your fix needs new cllama code, a cllama release happens first; the pointer bump rides release prep.
+- **Building or pushing `hermes-base` or other infra images** — there is no auto-publish for `hermes-base`; image publication is coordinated by the maintainer.
+- **Rewriting identifying details in historical changelog entries** — old entries are part of the project's incident record. Edit only the entry you are adding.
 
 If a fix genuinely requires one of these to move, say so explicitly in the PR body so the maintainer can sequence the release — don't bake it silently into the diff.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing to Clawdapus
+
+Thanks for considering a contribution. This guide covers the dev setup, the workflow, and the few hard rules that keep releases shippable.
+
+## Dev Setup
+
+- Go (see `go.mod` for the required version)
+- Docker with Compose (for integration and spike tests)
+
+```bash
+git clone https://github.com/mostlydev/clawdapus.git
+cd clawdapus
+go build -o bin/claw ./cmd/claw
+```
+
+The `cllama/` directory is a git submodule with its own repository. A fresh clone leaves it empty; populate it with:
+
+```bash
+git submodule update --init
+```
+
+End users never need the submodule — infra images are published to ghcr.io.
+
+## Test Tiers
+
+| Tier | Command | Needs |
+|------|---------|-------|
+| Unit | `go test ./...` | nothing |
+| Vet | `go vet ./...` | nothing |
+| Integration | `go test -tags integration ./...` | Docker |
+| Spike (end-to-end) | `go test -tags spike -run TestSpikeRollCall ./cmd/claw/...` | Docker + real Discord/provider credentials |
+
+Unit and vet must pass on every PR. Run the integration tier when you touch compile/runtime wiring. Spike tests are the heavy validation path — see [TESTING.md](./TESTING.md).
+
+## Issue-First Workflow
+
+All non-trivial work starts with a GitHub issue, prioritized on the [project board](https://github.com/users/mostlydev/projects/2).
+
+1. Find or create the issue. It must carry enough context for someone to pick it up cold: motivation, constraints, key decisions.
+2. Move it to **In Progress** when you start.
+3. Work on a branch tied to the issue (`issue-123-short-name`).
+4. **Put a closing keyword in the PR body** — `Closes #123` / `Fixes #123`. Board automation only links PRs to issues through closing keywords; branch names are not enough. A PR without one strands the issue in the wrong column after merge.
+
+## PR Conventions
+
+- One logical change per PR; group related issues when they ship together (`Closes #1, #2`).
+- Update tests in the same area as behavior changes.
+- `compose.generated.yml` and `Dockerfile.generated` are build artifacts — never hand-edit them as source.
+- Match the surrounding code's style; when fixing a driver bug, check whether the same bug exists in all seven drivers under `internal/driver/`.
+
+## Hands Off: Release Artifacts
+
+Releases are tag-driven and cut by the maintainer. These must **never** change in a feature PR — each one rides a coordinated lockstep across image builds, the `cllama` submodule, GitHub releases, and the published site:
+
+- **Pins in `internal/infraimages/release_manifest.go`** (`DefaultClawInfraTag`, `DefaultCllamaTag`, `DefaultHermesBaseTag`) — these move only with a real release; otherwise the release verifier fails or, worse, ships pins pointing at images that don't match the source tree.
+- **The `<Badge type="tip" text="Latest" />` badge or a new version section in `site/changelog.md`** — the site deploys on every master push, so this would publicly claim a release that doesn't exist. Add your notes under `## Unreleased` instead.
+- **The version dropdown in `site/.vitepress/config.mts`** — same reason.
+- **The `cllama` submodule pointer beyond the latest cllama tag** — if your fix needs new cllama code, a cllama release happens first; the pointer bump rides release prep.
+
+If a fix genuinely requires one of these to move, say so explicitly in the PR body so the maintainer can sequence the release — don't bake it silently into the diff.
+
+One more rule for all public artifacts (changelogs, release notes, issue comments, PR bodies): describe downstream deployments generically ("production deployments", "Hermes runners"), never by name.
+
+## Where to Start
+
+- The [project board](https://github.com/users/mostlydev/projects/2) — column order is priority order.
+- `AGENTS.md` — the repo's working knowledge: entry points, gotchas, current behavior.
+- [clawdapus.dev](https://clawdapus.dev) — user-facing docs.

--- a/README.md
+++ b/README.md
@@ -650,4 +650,6 @@ each — see **[How It Fits Together](https://clawdapus.dev/guide/architecture)*
 
 ## Contributing
 
-Start with [`MANIFESTO.md`](./MANIFESTO.md) before contributing.
+Start with [`MANIFESTO.md`](./MANIFESTO.md) for the why, then [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the how: dev setup, test tiers, the issue-first workflow, and the release-artifact rules.
+
+Priorities live on the [project board](https://github.com/users/mostlydev/projects/2) — column order is priority order. Bug reports and feature requests have [issue templates](https://github.com/mostlydev/clawdapus/issues/new/choose).

--- a/site/.vitepress/config.mts
+++ b/site/.vitepress/config.mts
@@ -80,6 +80,7 @@ export default defineConfig({
         items: [
           { text: 'CLI Commands', link: '/guide/cli' },
           { text: 'Driver Support Matrix', link: '/guide/drivers' },
+          { text: 'Troubleshooting', link: '/guide/troubleshooting' },
         ],
       },
     ],

--- a/site/guide/troubleshooting.md
+++ b/site/guide/troubleshooting.md
@@ -1,0 +1,137 @@
+# Troubleshooting
+
+Symptom-first. Find what you're seeing, get the diagnosis and the fix. Every entry here maps to a failure mode observed in real deployments.
+
+## Agent turns fail with 502 and `context deadline exceeded` at ~120s
+
+**Cause:** the managed-tool mediation budget. The whole mediated turn — every inference round plus every tool execution — shares one `total_timeout_ms` budget (default 120s). Slow reasoning models exhaust it mid-chain.
+
+**Fix:** raise the budget in pod YAML and redeploy:
+
+```yaml
+x-claw:
+  tool-policy-defaults:
+    total-timeout-ms: 300000
+```
+
+```bash
+claw up -d
+```
+
+See [Managed Tools § Budget limits](/guide/tools#mediation-loop). Check which model is slow with `claw audit` (latency column).
+
+## A feed is missing from agent context / `feed_fetch` errors at ~3s
+
+**Cause:** the feed provider responded slower than the fetch timeout (default 3s). The block is skipped silently from the agent's perspective; only the proxy logs the failure.
+
+**Fix:** raise the fetch timeout via cllama env:
+
+```yaml
+x-claw:
+  cllama-defaults:
+    env:
+      CLLAMA_FEED_FETCH_TIMEOUT_MS: "10000"
+```
+
+Then fix the slow provider — the timeout knob buys headroom, it doesn't make a synchronous upstream computation fast. Audit trail: `claw audit` shows `feed_fetch` errors and `feed_injection` events with a `skipped (...)` notice.
+
+## Managed tool calls are rejected with `schema_validation` errors
+
+**Cause:** the model emitted arguments that violate the tool's declared `inputSchema` — most commonly a required field at the wrong nesting level. cllama rejects these before the service is called and tells the model exactly what's wrong (`missing required property "x" at top level; found at "ctx.x"`).
+
+**Fix:** this is working as intended — the model corrects itself in-round. If a *valid* call is being rejected, the descriptor's `inputSchema` doesn't match what the service actually accepts: fix the service's `claw.describe` descriptor. Emergency bypass: `CLLAMA_TOOL_SCHEMA_VALIDATION: "off"` in cllama env. Audit trail: `managed_tool_schema_rejected` interventions in `claw audit`; full arguments in the session-history `tool_trace`.
+
+## Managed tool calls repeatedly rejected by the providing service (4xx)
+
+**Cause:** the service validates more strictly than its descriptor declares, so schema validation passes but the provider refuses. The model retries by guessing and burns mediation rounds.
+
+**Fix:** make the descriptor's `inputSchema` declare everything the service enforces (`required`, nesting, enums). The schema is the model's only contract — anything enforced but undeclared turns into guess-and-retry. Read the rejection bodies in `tool_trace` in session history.
+
+## Agent has no provider access / "credential starvation" preflight failures
+
+**Cause:** provider API keys placed in the agent's `environment:` block. Agents must never hold provider keys — cllama does.
+
+**Fix:** move keys to `x-claw.cllama-env` (service level) or `x-claw.cllama-defaults.env` (pod level):
+
+```yaml
+    x-claw:
+      cllama: passthrough
+      cllama-env:
+        ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"
+```
+
+## Discord bot connected but never replies
+
+**Diagnosis first:**
+
+```bash
+claw compose exec <service> cat /root/.hermes/logs/gateway.log   # Hermes
+claw logs <service>                                              # any driver
+```
+
+Zero gateway entries after startup = connected but not receiving events.
+
+**Causes, in order of likelihood:**
+1. **MESSAGE CONTENT intent** not enabled in the Discord developer portal — the bot sees mentions but no message text.
+2. Stale gateway session — `claw compose restart <service>`.
+3. The bot requires a mention (`mention_only` is set by all drivers to prevent multi-agent loops) and the message didn't mention it.
+
+## Agents mention-looping each other in a multi-agent pod
+
+**Cause:** a driver config that dropped `require_mention`, or a runner replying with an auto-mention (Hermes's reply feature pings the original author unless patched).
+
+**Fix:** Clawdapus sets `mention_only`/`requireMention` and suppresses reply mentions in all built-in drivers — if you see loops, check for a hand-edited runner config overriding the generated one, and confirm your images are built from current runner bases (`claw pull`, then `claw build`).
+
+## `claw ps` / `claw logs` / `claw health` refuse to run
+
+**Symptom:** "pod file is newer than compose.generated.yml".
+
+**Cause:** you edited `claw-pod.yml` after the last compile. The generated compose file is the single source of truth, and stale state is fail-closed.
+
+**Fix:** `claw up -d` to recompile. (`claw down` is exempt — you can always tear down.)
+
+## cllama returns "missing API key for provider" 502s, but the key is configured
+
+**Cause:** a pre-v0.2.2 cllama image silently loading a v2-format `providers.json` with empty key pools, or a stale container running an old image.
+
+**Fix:** the four-verb refresh:
+
+```bash
+claw pull
+claw up -d        # recreates the proxy container from the pulled image
+```
+
+Verify key state live: `curl -N -H "Authorization: Bearer <ui_token>" http://<host>:8181/events` — the initial payload has `providers[name].maskedKey`; an empty string means no active key loaded.
+
+## `claw build` fails closed asking for `claw pull`
+
+**Cause:** the service image's runner base (`openclaw:latest` etc.) has no versioned sibling tag — usually because it was built with a manual `docker build` instead of `claw pull`.
+
+**Fix:** run `claw pull` (refreshes runner aliases properly), then `claw build`.
+
+## `claw audit` quick reference
+
+| Event type | Meaning |
+|------------|---------|
+| `request` / `response` | A proxied LLM call: agent, model, latency, tokens, cost |
+| `error` | Upstream/provider failure (timeouts, 4xx/5xx from the LLM provider) |
+| `intervention` | Governance event — see below |
+| `feed_fetch` / `feed_injection` | Feed provider fetch results and what was injected into context |
+| `tool_call` | Managed tool execution from session-history `tool_trace` |
+
+Intervention reasons you may see:
+
+| Intervention | Meaning |
+|--------------|---------|
+| `managed_tool_schema_rejected:<tool>` | Tool call rejected pre-dispatch for schema violations |
+| `duplicate_managed_tool_call` | Same tool, same args, same turn — skipped, structured error returned |
+| `mixed_tool_order_internal_retry` | Model mixed native-first/managed-later tool order; cllama replanned internally |
+| `managed_tool_budget_finalization` | Budget exhausted; cllama forced a final text turn instead of returning empty |
+
+`manifest_present` and `tools_count` fields on each audit line confirm whether a compiled tool manifest actually reached cllama for that agent.
+
+## Still stuck?
+
+- `claw doctor` — environment sanity checks
+- `claw inspect <service>` — what was actually compiled for a service
+- [Open an issue](https://github.com/mostlydev/clawdapus/issues/new/choose) with your `claw doctor` output, driver type, and the relevant pod YAML snippet

--- a/site/guide/troubleshooting.md
+++ b/site/guide/troubleshooting.md
@@ -18,11 +18,11 @@ x-claw:
 claw up -d
 ```
 
-See [Managed Tools § Budget limits](/guide/tools#mediation-loop). Check which model is slow with `claw audit` (latency column).
+See [Managed Tools § Budget limits](/guide/tools#mediation-loop). Check which model is slow with `claw audit --json` — `latency_ms` is on each response event.
 
 ## A feed is missing from agent context / `feed_fetch` errors at ~3s
 
-**Cause:** the feed provider responded slower than the fetch timeout (default 3s). The block is skipped silently from the agent's perspective; only the proxy logs the failure.
+**Cause:** the feed provider responded slower than the fetch timeout (default 3s). The agent sees a `[Feed unavailable]` notice (or stale cached content) where fresh data should be; the proxy logs the underlying failure.
 
 **Fix:** raise the fetch timeout via cllama env:
 
@@ -118,17 +118,23 @@ Verify key state live: `curl -N -H "Authorization: Bearer <ui_token>" http://<ho
 | `intervention` | Governance event — see below |
 | `feed_fetch` / `feed_injection` | Feed provider fetch results and what was injected into context |
 | `tool_call` | Managed tool execution from session-history `tool_trace` |
+| `tool_manifest_loaded` | Whether a compiled tool manifest reached the proxy for a request (`manifest_present`, `tools_count`) |
+| `channel_context_op` | Channel-context feed and claw-wall tool activity |
+| `memory_op` | Memory plane recall/retain operations |
+| `provider_pool` | Provider key pool state changes (cooldowns, failover) |
 
 Intervention reasons you may see:
 
 | Intervention | Meaning |
 |--------------|---------|
 | `managed_tool_schema_rejected:<tool>` | Tool call rejected pre-dispatch for schema violations |
-| `duplicate_managed_tool_call` | Same tool, same args, same turn — skipped, structured error returned |
+| `duplicate_managed_tool_call:<tool>` | Same tool, same args, same turn — skipped, structured error returned |
 | `mixed_tool_order_internal_retry` | Model mixed native-first/managed-later tool order; cllama replanned internally |
+| `managed_prefix_native_suffix_serialized` | Managed prefix executed internally before a runner-native suffix in one response |
 | `managed_tool_budget_finalization` | Budget exhausted; cllama forced a final text turn instead of returning empty |
+| `bare_model_normalized` | Runner sent a bare model name; the proxy normalized it to the agent's declared slot |
 
-`manifest_present` and `tools_count` fields on each audit line confirm whether a compiled tool manifest actually reached cllama for that agent.
+In JSON output (`claw audit --json`), `tool_manifest_loaded` events carry `manifest_present` and `tools_count` — use them to confirm a compiled tool manifest actually reached cllama for an agent.
 
 ## Still stuck?
 


### PR DESCRIPTION
Replaces #300 (auto-closed when its stacked base branch was deleted; branch since rebased onto master).

- **#293**: CONTRIBUTING.md (dev setup, test tiers, issue-first workflow, closing-keyword requirement, release-artifact hands-off rules incl. infra-image coordination and the no-historical-rewrites rule), structured issue templates, board + docs contact links, README Contributing section.
- **#294**: `site/guide/troubleshooting.md` — symptom-first entries from real production failure modes with cause and fix commands, plus a `claw audit` event/intervention quick reference verified against cllama master (ships as v0.7.0, pinned by the next release). Sidebar entry.
- **#295**: weekly hermes-base canary building against upstream HEAD and latest tag via `HERMES_UPSTREAM_TAG` (no Dockerfile change, no image publish); explicit bash+pipefail so a failed build can't be masked by `tee`; failure grep matches the patch script's `expected to patch <label>` output.

Codex review round complete — all findings addressed (see commit 90ad5eb).

Closes #293, #294, #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)