### PR TITLE
Elide low-value channel acknowledgements

### DIFF
--- a/examples/channel-memory/main.go
+++ b/examples/channel-memory/main.go
@@ -1021,6 +1021,9 @@ func upsertDeterministicBlocksTx(ctx context.Context, tx *sql.Tx, source storedS
 	if isTelemetryNoise(source.Content) {
 		return rebuildTelemetryBlockTx(ctx, tx, source, now)
 	}
+	if isLowValueAcknowledgement(source.Content) {
+		return rebuildLowValueAcknowledgementBlockTx(ctx, tx, source, now)
+	}
 	kind, eventType, score := classifySourceContent(source.Content)
 	if err := upsertSourceBlockTx(ctx, tx, source, deterministicBlock{
 		Key:       sourceBlockKey(kind, source),
@@ -1140,6 +1143,83 @@ func rebuildTelemetryBlockTx(ctx context.Context, tx *sql.Tx, source storedSourc
 		) VALUES (?, 'telemetry_count', ?, ?, ?, ?, 1, 0.25, ?, 0, 0, 'deterministic')
 		ON CONFLICT(block_key) DO UPDATE SET
 			text = excluded.text,
+			source_window_from = excluded.source_window_from,
+			source_window_to = excluded.source_window_to,
+			generated_at = excluded.generated_at,
+			stale = 0,
+			dirty = 0`,
+		blockKey, text, source.ChannelID, sources[0].CreatedAt, sources[len(sources)-1].CreatedAt, generatedAt,
+	); err != nil {
+		return err
+	}
+	var blockID int64
+	if err := tx.QueryRowContext(ctx, `SELECT id FROM derived_blocks WHERE block_key = ?`, blockKey).Scan(&blockID); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM derived_block_sources WHERE block_id = ?`, blockID); err != nil {
+		return err
+	}
+	for _, record := range sources {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT OR IGNORE INTO derived_block_sources(block_id, source_kind, channel_id, message_id, content_hash)
+			VALUES (?, ?, ?, ?, ?)`,
+			blockID, record.SourceKind, record.ChannelID, record.MessageID, record.ContentHash,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rebuildLowValueAcknowledgementBlockTx(ctx context.Context, tx *sql.Tx, source storedSourceMessage, now time.Time) error {
+	from, to := telemetryBucket(source.CreatedAt)
+	rows, err := tx.QueryContext(ctx, `
+		SELECT id, source_kind, channel_id, message_id, content_hash, author_id, author_name,
+		       created_at, edited_at, deleted, content, service, surface, guild_id, visibility_scope,
+		       observed_seq, observed_at, is_current
+		FROM source_messages
+		WHERE source_kind = ? AND channel_id = ? AND is_current = 1 AND deleted = 0 AND forgotten_at = ''
+		  AND created_at >= ? AND created_at < ?
+		ORDER BY created_at, observed_seq`,
+		source.SourceKind, source.ChannelID, from, to,
+	)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	sources := make([]storedSourceMessage, 0)
+	authors := make(map[string]struct{})
+	for rows.Next() {
+		record, err := scanStoredSource(rows)
+		if err != nil {
+			return err
+		}
+		if !isLowValueAcknowledgement(record.Content) {
+			continue
+		}
+		sources = append(sources, record)
+		authors[decisionAuthorKey(record)] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if len(sources) == 0 {
+		return nil
+	}
+
+	blockKey := strings.Join([]string{"low_value_ack", source.SourceKind, source.ChannelID, from}, ":")
+	generatedAt := now.UTC().Format(time.RFC3339)
+	text := fmt.Sprintf("[%s-%s] low-value acknowledgements elided: %d messages from %d authors.",
+		clockText(sources[0].CreatedAt), clockText(sources[len(sources)-1].CreatedAt), len(sources), len(authors))
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO derived_blocks(
+			block_key, kind, event_type, text, source_channel, source_window_from, source_window_to,
+			sparse, score, generated_at, stale, dirty, processor
+		) VALUES (?, 'low_value_ack', 'low_value_acknowledgement', ?, ?, ?, ?, 1, 0.20, ?, 0, 0, 'deterministic')
+		ON CONFLICT(block_key) DO UPDATE SET
+			text = excluded.text,
+			source_channel = excluded.source_channel,
 			source_window_from = excluded.source_window_from,
 			source_window_to = excluded.source_window_to,
 			generated_at = excluded.generated_at,
@@ -1730,6 +1810,51 @@ func isTelemetryNoise(content string) bool {
 		"upstream request failed",
 		"context deadline exceeded",
 	)
+}
+
+func isLowValueAcknowledgement(content string) bool {
+	switch normalizeLowValueText(content) {
+	case "+1",
+		"ack",
+		"acked",
+		"copy",
+		"copied",
+		"got it",
+		"k",
+		"kk",
+		"makes sense",
+		"noted",
+		"ok",
+		"okay",
+		"roger",
+		"sounds good",
+		"thank you",
+		"thanks",
+		"thx",
+		"understood":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeLowValueText(text string) string {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	var b strings.Builder
+	lastWasSpace := true
+	for _, r := range lower {
+		switch {
+		case unicode.IsLetter(r), unicode.IsDigit(r), r == '+':
+			b.WriteRune(r)
+			lastWasSpace = false
+		default:
+			if !lastWasSpace {
+				b.WriteByte(' ')
+				lastWasSpace = true
+			}
+		}
+	}
+	return strings.Join(strings.Fields(b.String()), " ")
 }
 
 func formatSourceLine(source storedSourceMessage) string {

--- a/examples/channel-memory/main_test.go
+++ b/examples/channel-memory/main_test.go
@@ -303,6 +303,94 @@ func TestChannelMemoryDeterministicRepeatedDecisionCollapse(t *testing.T) {
 	}
 }
 
+func TestChannelMemoryDeterministicLowValueAcknowledgementCollapse(t *testing.T) {
+	store := newTestStore(t)
+	defer store.Close()
+
+	mustIngest := func(id, author, createdAt, content string) {
+		t.Helper()
+		if _, err := store.Ingest(context.Background(), ingestRequest{
+			ChannelID: "chan-acks",
+			Message: ingestMessage{
+				ID:          id,
+				AuthorName:  author,
+				CreatedAt:   createdAt,
+				Content:     content,
+				ContentHash: "sha256:" + id,
+			},
+		}); err != nil {
+			t.Fatalf("ingest %s: %v", id, err)
+		}
+	}
+
+	mustIngest("801", "analyst-a", "2026-05-21T18:00:00Z", "ok")
+	mustIngest("802", "analyst-b", "2026-05-21T18:02:00Z", "Thanks!")
+	mustIngest("803", "analyst-c", "2026-05-21T18:03:00Z", "got it.")
+	mustIngest("804", "analyst-a", "2026-05-21T18:04:00Z", "ok ACME level still matters")
+	mustIngest("805", "analyst-a", "2026-05-21T18:05:00Z", "[APPROVED] signal-805 BUY ACME")
+
+	digest, err := store.Digest(context.Background(), digestRequest{ChannelIDs: []string{"chan-acks"}, Since: "24h"})
+	if err != nil {
+		t.Fatalf("digest acknowledgements: %v", err)
+	}
+
+	var ack *digestBlock
+	foundRawContext := false
+	foundHardEvent := false
+	for i := range digest.Blocks {
+		block := &digest.Blocks[i]
+		if block.Kind == "low_value_ack" {
+			if ack != nil {
+				t.Fatalf("expected one low_value_ack block, got %+v", digest.Blocks)
+			}
+			ack = block
+		}
+		if block.Kind == "raw_excerpt" && len(block.SourceMessages) == 1 && block.SourceMessages[0] == "804" {
+			foundRawContext = true
+		}
+		if block.Kind == "hard_event" && len(block.SourceMessages) == 1 && block.SourceMessages[0] == "805" {
+			foundHardEvent = true
+		}
+		if block.Kind == "raw_excerpt" {
+			for _, messageID := range block.SourceMessages {
+				if messageID == "801" || messageID == "802" || messageID == "803" {
+					t.Fatalf("low-value acknowledgement %s leaked as raw excerpt: %+v", messageID, block)
+				}
+			}
+		}
+	}
+	if ack == nil {
+		t.Fatalf("expected low_value_ack block, got %+v", digest.Blocks)
+	}
+	if !ack.Sparse || ack.EventType != "low_value_acknowledgement" || ack.Processor != "deterministic" {
+		t.Fatalf("unexpected low-value acknowledgement metadata: %+v", ack)
+	}
+	if got := ack.SourceMessages; len(got) != 3 || got[0] != "801" || got[1] != "802" || got[2] != "803" {
+		t.Fatalf("low-value acknowledgement should cover only exact short acks, got %+v", got)
+	}
+	if !strings.Contains(ack.Text, "low-value acknowledgements elided: 3 messages from 3 authors") {
+		t.Fatalf("low-value acknowledgement text should include count, got %q", ack.Text)
+	}
+	if !foundRawContext {
+		t.Fatalf("non-trivial message should remain raw, got %+v", digest.Blocks)
+	}
+	if !foundHardEvent {
+		t.Fatalf("hard event should remain explicit, got %+v", digest.Blocks)
+	}
+
+	search, err := store.Search(context.Background(), searchRequest{
+		ChannelIDs: []string{"chan-acks"},
+		Query:      "low-value acknowledgements",
+		Since:      "24h",
+	})
+	if err != nil {
+		t.Fatalf("search low-value acknowledgement: %v", err)
+	}
+	if search.Status != "ok" || len(search.DerivedBlocks) != 1 || search.DerivedBlocks[0].Kind != "low_value_ack" {
+		t.Fatalf("search should return the sparse low-value acknowledgement block, got %+v", search)
+	}
+}
+
 func TestChannelMemoryHTTPAPI(t *testing.T) {
 	store := newTestStore(t)
 	defer store.Close()

--- a/site/changelog.md
+++ b/site/changelog.md
@@ -30,6 +30,7 @@ outline: deep
 ## Unreleased
 
 - **Channel memory collapses repeated low-change decisions** -- deterministic channel-memory now emits a sparse `decision_repeat` block for same-author, same-channel, same-day repeated no-change decisions while preserving source message IDs for lookup. The digest assembler prefers that block over the covered raw excerpts, reducing repetitive context without hiding hard events. Refs [#260](https://github.com/mostlydev/clawdapus/issues/260).
+- **Channel memory elides low-value acknowledgements** -- exact short acknowledgements such as "ok", "thanks", and "got it" now collapse into sparse `low_value_ack` digest blocks by channel/hour before they can bloat raw awareness feeds. Context-bearing messages and hard events remain explicit. Refs [#260](https://github.com/mostlydev/clawdapus/issues/260).
 
 ## v0.24.0 <Badge type="tip" text="Latest" /> {#v0-24-0}
 


### PR DESCRIPTION
## Summary
- collapse exact short acknowledgements like ok/thanks/got it into sparse low_value_ack digest blocks by channel/hour
- preserve source message IDs on the sparse block for lookup/provenance
- keep context-bearing messages and hard events explicit
- document this follow-on #260 slice in the changelog

## Stack
- Stacked on #326 / issue-260-repeated-decision-collapse

## Tests
- go test ./examples/channel-memory
- go test ./...

Refs #260