### PR TITLE
Add age-tiered channel memory digests

### DIFF
--- a/cmd/claw-wall/channel_memory.go
+++ b/cmd/claw-wall/channel_memory.go
@@ -63,7 +63,8 @@ type channelMemoryDigestRequest struct {
 }
 
 type channelMemoryDigestBudget struct {
-	MaxBlocks int `json:"max_blocks,omitempty"`
+	MaxBlocks int    `json:"max_blocks,omitempty"`
+	RawRecent string `json:"raw_recent,omitempty"`
 }
 
 type channelMemoryDigestResponse struct {
@@ -80,6 +81,7 @@ type channelMemoryDigestCoverage struct {
 	SourceMessages    int                        `json:"source_messages"`
 	DigestMessages    int                        `json:"digest_messages"`
 	RawRecentMessages int                        `json:"raw_recent_messages"`
+	OlderRawMessages  int                        `json:"older_raw_messages,omitempty"`
 	Gaps              []channelMemoryCoverageGap `json:"gaps,omitempty"`
 }
 
@@ -430,6 +432,7 @@ func (c *channelMemoryClient) fetchAwarenessDigest(ctx context.Context, channelI
 		ChannelIDs: normalizeChannelIDs(channelIDs),
 		Budget: channelMemoryDigestBudget{
 			MaxBlocks: defaultDigestMaxBlocks,
+			RawRecent: defaultDigestRawRecent.String(),
 		},
 	}
 	if since > 0 {
@@ -448,6 +451,8 @@ func (c *channelMemoryClient) fetchAwarenessDigest(ctx context.Context, channelI
 	digest.SourceMessages = resp.Coverage.SourceMessages
 	digest.DigestMessages = resp.Coverage.DigestMessages
 	digest.RawRecentMessages = resp.Coverage.RawRecentMessages
+	digest.OlderRawMessages = resp.Coverage.OlderRawMessages
+	digest.RawRecent = req.Budget.RawRecent
 	digest.CoverageGaps = len(resp.Coverage.Gaps)
 	digest.DeterministicOnly = resp.Cost.DeterministicOnly
 	digest.Blocks = append([]channelMemoryDigestBlock(nil), resp.Blocks...)

--- a/cmd/claw-wall/main_test.go
+++ b/cmd/claw-wall/main_test.go
@@ -310,8 +310,9 @@ func TestChannelAwarenessHandlerServesDigestWhenAvailable(t *testing.T) {
 		Status:      "ok",
 		GeneratedAt: "2026-05-21T20:00:00Z",
 		Coverage: channelMemoryDigestCoverage{
-			SourceMessages: 12,
-			DigestMessages: 1,
+			SourceMessages:   12,
+			DigestMessages:   1,
+			OlderRawMessages: 7,
 		},
 		Blocks: []channelMemoryDigestBlock{{
 			Kind:           "telemetry_count",
@@ -360,6 +361,9 @@ func TestChannelAwarenessHandlerServesDigestWhenAvailable(t *testing.T) {
 	if !strings.Contains(text, "digest_blocks=1") || !strings.Contains(text, "digest_source_messages=12") {
 		t.Fatalf("expected digest counts, got %q", text)
 	}
+	if !strings.Contains(text, "digest_raw_recent=6h0m0s") || !strings.Contains(text, "digest_older_raw_omitted=7") {
+		t.Fatalf("expected digest raw tier counts, got %q", text)
+	}
 	if !strings.Contains(text, "[digest kind=telemetry_count source_channel=chan-1 source_messages=100,101") {
 		t.Fatalf("expected digest block provenance, got %q", text)
 	}
@@ -367,7 +371,7 @@ func TestChannelAwarenessHandlerServesDigestWhenAvailable(t *testing.T) {
 		t.Fatalf("expected digest mode to keep only recent raw messages, got %q", text)
 	}
 	gotReqs := memory.requests()
-	if len(gotReqs) != 1 || gotReqs[0].SourceKind != channelMemorySourceKind || gotReqs[0].Since != "24h0m0s" || gotReqs[0].Budget.MaxBlocks != defaultDigestMaxBlocks {
+	if len(gotReqs) != 1 || gotReqs[0].SourceKind != channelMemorySourceKind || gotReqs[0].Since != "24h0m0s" || gotReqs[0].Budget.MaxBlocks != defaultDigestMaxBlocks || gotReqs[0].Budget.RawRecent != defaultDigestRawRecent.String() {
 		t.Fatalf("unexpected digest request: %+v", gotReqs)
 	}
 

--- a/cmd/claw-wall/store.go
+++ b/cmd/claw-wall/store.go
@@ -21,6 +21,7 @@ const (
 	defaultTailMaxChars    = 32 * 1024
 	defaultDigestRawLimit  = 10
 	defaultDigestMaxBlocks = 32
+	defaultDigestRawRecent = 6 * time.Hour
 )
 
 const (
@@ -153,6 +154,8 @@ type channelAwarenessDigest struct {
 	SourceMessages    int
 	DigestMessages    int
 	RawRecentMessages int
+	OlderRawMessages  int
+	RawRecent         string
 	CoverageGaps      int
 	DeterministicOnly bool
 	Blocks            []channelMemoryDigestBlock
@@ -1357,6 +1360,12 @@ func formatChannelAwareness(result tailResult, since time.Duration, contextKind 
 			digest.CoverageGaps,
 			digest.DeterministicOnly,
 		)
+		if digest.RawRecent != "" {
+			fmt.Fprintf(&b, " digest_raw_recent=%s digest_older_raw_omitted=%d",
+				headerToken(digest.RawRecent),
+				digest.OlderRawMessages,
+			)
+		}
 		if digest.GeneratedAt != "" {
 			fmt.Fprintf(&b, " digest_generated_at=%s", digest.GeneratedAt)
 		}

--- a/examples/channel-memory/README.md
+++ b/examples/channel-memory/README.md
@@ -18,7 +18,11 @@ source provenance for digest-backed `channel-awareness` work.
   blocks within explicit channel ids, returning source handles for exact
   follow-up retrieval.
 - `POST /digest` returns deterministic digest blocks over already-retained
-  messages. It does not call an LLM.
+  messages. It does not call an LLM. Set `budget.raw_recent` to a duration or
+  RFC3339 timestamp to keep deterministic `raw_excerpt` blocks only for the
+  recent tier while preserving hard events, tombstones, sparse rollups, and LLM
+  summaries across the requested horizon. The response reports omitted older raw
+  source count as `coverage.older_raw_messages`.
 - `POST /coverage-gaps` records an explicit missing source range.
 - `POST /forget` suppresses source messages and marks derived blocks dirty.
 - `GET /health` reports process liveness.

--- a/examples/channel-memory/main.go
+++ b/examples/channel-memory/main.go
@@ -1548,14 +1548,22 @@ func (s *channelMemoryStore) queryDigestBlocks(ctx context.Context, channelID, c
 	if queryLimit < limit {
 		queryLimit = limit
 	}
+	where := `source_channel = ? AND source_window_to >= ? AND stale = 0 AND dirty = 0`
+	args := []any{channelID, cutoff}
+	if opts.RawRecentEnabled {
+		// Exclude omitted older raw blocks before LIMIT so eligible sparse and hard-event blocks keep their budget.
+		where += ` AND NOT (processor = ? AND kind = 'raw_excerpt' AND source_window_to < ?)`
+		args = append(args, "deterministic", opts.RawRecentCutoff.Format(time.RFC3339))
+	}
+	args = append(args, queryLimit)
 	rows, err := s.db.QueryContext(ctx, `
 			SELECT id, kind, event_type, text, source_channel, source_window_from, source_window_to,
 			       sparse, score, generated_at, stale, dirty, processor
 			FROM derived_blocks
-			WHERE source_channel = ? AND source_window_to >= ? AND stale = 0 AND dirty = 0
+			WHERE `+where+`
 			ORDER BY source_window_to DESC, id DESC
 			LIMIT ?`,
-		channelID, cutoff, queryLimit,
+		args...,
 	)
 	if err != nil {
 		return nil, err

--- a/examples/channel-memory/main.go
+++ b/examples/channel-memory/main.go
@@ -139,7 +139,8 @@ type digestRequest struct {
 }
 
 type digestBudget struct {
-	MaxBlocks int `json:"max_blocks,omitempty"`
+	MaxBlocks int    `json:"max_blocks,omitempty"`
+	RawRecent string `json:"raw_recent,omitempty"`
 }
 
 type digestResponse struct {
@@ -156,6 +157,7 @@ type digestCoverage struct {
 	SourceMessages    int           `json:"source_messages"`
 	DigestMessages    int           `json:"digest_messages"`
 	RawRecentMessages int           `json:"raw_recent_messages"`
+	OlderRawMessages  int           `json:"older_raw_messages,omitempty"`
 	Gaps              []coverageGap `json:"gaps,omitempty"`
 }
 
@@ -721,10 +723,17 @@ func (s *channelMemoryStore) Digest(ctx context.Context, req digestRequest) (dig
 	if maxBlocks <= 0 {
 		maxBlocks = 32
 	}
+	rawRecentCutoff, rawRecentEnabled, err := parseRawRecentCutoff(req.Budget.RawRecent, s.now())
+	if err != nil {
+		return digestResponse{}, err
+	}
 
 	blocks := make([]digestBlock, 0)
 	for _, channelID := range channels {
-		channelBlocks, err := s.queryDigestBlocks(ctx, channelID, cutoff.Format(time.RFC3339), maxBlocks-len(blocks))
+		channelBlocks, err := s.queryDigestBlocks(ctx, channelID, cutoff.Format(time.RFC3339), maxBlocks-len(blocks), digestQueryOptions{
+			RawRecentCutoff:  rawRecentCutoff,
+			RawRecentEnabled: rawRecentEnabled,
+		})
 		if err != nil {
 			return digestResponse{}, err
 		}
@@ -742,11 +751,21 @@ func (s *channelMemoryStore) Digest(ctx context.Context, req digestRequest) (dig
 	if err != nil {
 		return digestResponse{}, err
 	}
+	olderRawMessages := 0
+	if rawRecentEnabled {
+		for _, channelID := range channels {
+			count, err := s.countOlderRawDigestMessages(ctx, channelID, cutoff.Format(time.RFC3339), rawRecentCutoff.Format(time.RFC3339))
+			if err != nil {
+				return digestResponse{}, err
+			}
+			olderRawMessages += count
+		}
+	}
 
 	status := "ok"
 	if len(gaps) > 0 {
 		status = "coverage_gap"
-	} else if len(blocks) == 0 {
+	} else if len(blocks) == 0 && olderRawMessages == 0 {
 		status = "unavailable"
 	}
 
@@ -775,6 +794,7 @@ func (s *channelMemoryStore) Digest(ctx context.Context, req digestRequest) (dig
 			SourceMessages:    sourceCount,
 			DigestMessages:    len(blocks),
 			RawRecentMessages: rawRecent,
+			OlderRawMessages:  olderRawMessages,
 			Gaps:              gaps,
 		},
 		Blocks: blocks,
@@ -1515,7 +1535,12 @@ func (s *channelMemoryStore) searchDerivedBlocks(ctx context.Context, sourceKind
 	return preferSparseRollups(blocks, limit), nil
 }
 
-func (s *channelMemoryStore) queryDigestBlocks(ctx context.Context, channelID, cutoff string, limit int) ([]digestBlock, error) {
+type digestQueryOptions struct {
+	RawRecentCutoff  time.Time
+	RawRecentEnabled bool
+}
+
+func (s *channelMemoryStore) queryDigestBlocks(ctx context.Context, channelID, cutoff string, limit int, opts digestQueryOptions) ([]digestBlock, error) {
 	if limit <= 0 {
 		return nil, nil
 	}
@@ -1524,12 +1549,12 @@ func (s *channelMemoryStore) queryDigestBlocks(ctx context.Context, channelID, c
 		queryLimit = limit
 	}
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, kind, event_type, text, source_channel, source_window_from, source_window_to,
-		       sparse, score, generated_at, stale, dirty, processor
-		FROM derived_blocks
-		WHERE source_channel = ? AND source_window_to >= ? AND stale = 0 AND dirty = 0
-		ORDER BY source_window_from ASC, id ASC
-		LIMIT ?`,
+			SELECT id, kind, event_type, text, source_channel, source_window_from, source_window_to,
+			       sparse, score, generated_at, stale, dirty, processor
+			FROM derived_blocks
+			WHERE source_channel = ? AND source_window_to >= ? AND stale = 0 AND dirty = 0
+			ORDER BY source_window_to DESC, id DESC
+			LIMIT ?`,
 		channelID, cutoff, queryLimit,
 	)
 	if err != nil {
@@ -1544,13 +1569,37 @@ func (s *channelMemoryStore) queryDigestBlocks(ctx context.Context, channelID, c
 	if err := rows.Close(); err != nil {
 		return nil, err
 	}
+	sort.Slice(blocks, func(i, j int) bool {
+		if blocks[i].SourceWindow.To == blocks[j].SourceWindow.To {
+			return blocks[i].ID < blocks[j].ID
+		}
+		return blocks[i].SourceWindow.To < blocks[j].SourceWindow.To
+	})
 
 	for i := range blocks {
 		if err := s.loadBlockSources(ctx, &blocks[i]); err != nil {
 			return nil, err
 		}
 	}
-	return preferSparseRollups(blocks, limit), nil
+	return preferSparseRollups(filterOlderRawBlocks(blocks, opts), limit), nil
+}
+
+func (s *channelMemoryStore) countOlderRawDigestMessages(ctx context.Context, channelID, cutoff, rawRecentCutoff string) (int, error) {
+	var count int
+	err := s.db.QueryRowContext(ctx, `
+		SELECT COUNT(DISTINCT bs.message_id)
+		FROM derived_blocks b
+		JOIN derived_block_sources bs ON bs.block_id = b.id
+		WHERE b.source_channel = ?
+		  AND b.source_window_to >= ?
+		  AND b.source_window_to < ?
+		  AND b.stale = 0
+		  AND b.dirty = 0
+		  AND b.processor = ?
+		  AND b.kind = 'raw_excerpt'`,
+		channelID, cutoff, rawRecentCutoff, "deterministic",
+	).Scan(&count)
+	return count, err
 }
 
 func scanDigestBlockRows(rows *sql.Rows) ([]digestBlock, error) {
@@ -1610,6 +1659,34 @@ func preferSparseRollups(blocks []digestBlock, limit int) []digestBlock {
 		}
 	}
 	return filtered
+}
+
+func filterOlderRawBlocks(blocks []digestBlock, opts digestQueryOptions) []digestBlock {
+	if !opts.RawRecentEnabled {
+		return blocks
+	}
+	filtered := make([]digestBlock, 0, len(blocks))
+	for _, block := range blocks {
+		if olderRawBlock(block, opts.RawRecentCutoff) {
+			continue
+		}
+		filtered = append(filtered, block)
+	}
+	return filtered
+}
+
+func olderRawBlock(block digestBlock, cutoff time.Time) bool {
+	if block.Processor != "deterministic" || block.Kind != "raw_excerpt" {
+		return false
+	}
+	if cutoff.IsZero() || strings.TrimSpace(block.SourceWindow.To) == "" {
+		return false
+	}
+	to, err := time.Parse(time.RFC3339, block.SourceWindow.To)
+	if err != nil {
+		return false
+	}
+	return to.Before(cutoff)
 }
 
 func suppressesRawExcerpt(block digestBlock) bool {
@@ -1765,6 +1842,25 @@ func parseSince(value string, now time.Time) (time.Time, string, error) {
 		return time.Time{}, "", fmt.Errorf("since must be a duration or RFC3339 timestamp")
 	}
 	return parsed.UTC(), parsed.UTC().Format(time.RFC3339), nil
+}
+
+func parseRawRecentCutoff(value string, now time.Time) (time.Time, bool, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, false, nil
+	}
+	if duration, err := time.ParseDuration(value); err == nil {
+		if duration <= 0 {
+			return time.Time{}, false, fmt.Errorf("raw_recent must be positive")
+		}
+		cutoff := now.UTC().Add(-duration)
+		return cutoff, true, nil
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("raw_recent must be a duration or RFC3339 timestamp")
+	}
+	return parsed.UTC(), true, nil
 }
 
 func sourceHandle(channelID, messageID string) string {

--- a/examples/channel-memory/main_test.go
+++ b/examples/channel-memory/main_test.go
@@ -391,6 +391,88 @@ func TestChannelMemoryDeterministicLowValueAcknowledgementCollapse(t *testing.T)
 	}
 }
 
+func TestChannelMemoryDigestRawRecentBudgetOmitsOlderRawExcerpts(t *testing.T) {
+	store := newTestStore(t)
+	defer store.Close()
+
+	mustIngest := func(id, createdAt, content string) {
+		t.Helper()
+		if _, err := store.Ingest(context.Background(), ingestRequest{
+			ChannelID: "chan-raw-tier",
+			Message: ingestMessage{
+				ID:          id,
+				AuthorName:  "analyst-a",
+				CreatedAt:   createdAt,
+				Content:     content,
+				ContentHash: "sha256:" + id,
+			},
+		}); err != nil {
+			t.Fatalf("ingest %s: %v", id, err)
+		}
+	}
+
+	mustIngest("901", "2026-05-21T10:00:00Z", "older chatter that should stay searchable")
+	mustIngest("904", "2026-05-21T10:01:00Z", "older chatter that should not spend digest budget")
+	mustIngest("905", "2026-05-21T10:02:00Z", "older chatter that also should not spend digest budget")
+	mustIngest("902", "2026-05-21T10:05:00Z", "Stop remains 610 until invalidation changes.")
+	mustIngest("903", "2026-05-21T19:30:00Z", "recent raw context still matters")
+
+	digest, err := store.Digest(context.Background(), digestRequest{
+		ChannelIDs: []string{"chan-raw-tier"},
+		Since:      "24h",
+		Budget:     digestBudget{MaxBlocks: 2, RawRecent: "2h"},
+	})
+	if err != nil {
+		t.Fatalf("digest with raw_recent: %v", err)
+	}
+	if digest.Coverage.OlderRawMessages != 3 {
+		t.Fatalf("expected three older raw messages omitted, got %+v", digest.Coverage)
+	}
+
+	foundOldHardEvent := false
+	foundRecentRaw := false
+	for _, block := range digest.Blocks {
+		if block.Kind == "raw_excerpt" {
+			for _, messageID := range block.SourceMessages {
+				if messageID == "901" || messageID == "904" || messageID == "905" {
+					t.Fatalf("older raw message leaked into digest: %+v", block)
+				}
+				if messageID == "903" {
+					foundRecentRaw = true
+				}
+			}
+		}
+		if block.Kind == "hard_event" && len(block.SourceMessages) == 1 && block.SourceMessages[0] == "902" {
+			foundOldHardEvent = true
+		}
+	}
+	if !foundOldHardEvent {
+		t.Fatalf("old hard event should stay explicit across raw_recent budget, got %+v", digest.Blocks)
+	}
+	if !foundRecentRaw {
+		t.Fatalf("recent raw excerpt should stay explicit, got %+v", digest.Blocks)
+	}
+
+	search, err := store.Search(context.Background(), searchRequest{
+		ChannelIDs: []string{"chan-raw-tier"},
+		Query:      "older chatter",
+		Since:      "24h",
+	})
+	if err != nil {
+		t.Fatalf("search omitted raw source: %v", err)
+	}
+	foundSearchSource := false
+	for _, source := range search.SourceMessages {
+		if source.MessageID == "901" {
+			foundSearchSource = true
+			break
+		}
+	}
+	if search.Status != "ok" || !foundSearchSource {
+		t.Fatalf("omitted raw source should remain searchable, got %+v", search)
+	}
+}
+
 func TestChannelMemoryHTTPAPI(t *testing.T) {
 	store := newTestStore(t)
 	defer store.Close()

--- a/examples/channel-memory/main_test.go
+++ b/examples/channel-memory/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -470,6 +471,51 @@ func TestChannelMemoryDigestRawRecentBudgetOmitsOlderRawExcerpts(t *testing.T) {
 	}
 	if search.Status != "ok" || !foundSearchSource {
 		t.Fatalf("omitted raw source should remain searchable, got %+v", search)
+	}
+}
+
+func TestChannelMemoryDigestRawRecentBudgetDoesNotCrowdOutOlderHardEvents(t *testing.T) {
+	store := newTestStore(t)
+	defer store.Close()
+
+	mustIngest := func(id, createdAt, content string) {
+		t.Helper()
+		if _, err := store.Ingest(context.Background(), ingestRequest{
+			ChannelID: "chan-raw-crowd",
+			Message: ingestMessage{
+				ID:          id,
+				AuthorName:  "analyst-a",
+				CreatedAt:   createdAt,
+				Content:     content,
+				ContentHash: "sha256:" + id,
+			},
+		}); err != nil {
+			t.Fatalf("ingest %s: %v", id, err)
+		}
+	}
+
+	mustIngest("950", "2026-05-21T10:00:00Z", "Stop remains 610 until invalidation changes.")
+	for i := 0; i < 8; i++ {
+		mustIngest(
+			fmt.Sprintf("96%d", i),
+			fmt.Sprintf("2026-05-21T11:%02d:00Z", i),
+			fmt.Sprintf("older raw note %d that should not hide hard events", i),
+		)
+	}
+
+	digest, err := store.Digest(context.Background(), digestRequest{
+		ChannelIDs: []string{"chan-raw-crowd"},
+		Since:      "24h",
+		Budget:     digestBudget{MaxBlocks: 1, RawRecent: "2h"},
+	})
+	if err != nil {
+		t.Fatalf("digest with crowded older raw tier: %v", err)
+	}
+	if digest.Coverage.OlderRawMessages != 8 {
+		t.Fatalf("expected eight older raw messages omitted, got %+v", digest.Coverage)
+	}
+	if len(digest.Blocks) != 1 || digest.Blocks[0].Kind != "hard_event" || len(digest.Blocks[0].SourceMessages) != 1 || digest.Blocks[0].SourceMessages[0] != "950" {
+		t.Fatalf("older raw omissions should not crowd out hard event, got %+v", digest.Blocks)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `budget.raw_recent` to channel-memory `/digest` so deterministic `raw_excerpt` blocks only serve inside a recent tier
- preserve hard events, tombstones, sparse deterministic rollups, and LLM summary blocks across the requested digest horizon
- have claw-wall request a six-hour raw tier and surface `digest_raw_recent` plus `digest_older_raw_omitted` in the channel-awareness header
- query newest digest candidates first so older raw history cannot starve recent useful blocks

## Tests
- `go test ./examples/channel-memory`
- `go test ./cmd/claw-wall`
- `go test ./...`

Stacked on #328 for #260.

Closes #260