### PR TITLE
Add fleet governance demo

### DIFF
--- a/cmd/claw/spike_budget_test.go
+++ b/cmd/claw/spike_budget_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -167,6 +168,178 @@ services:
 	}); err != nil {
 		t.Fatalf("cllama traffic did not resume after budget override: %v\nlast status=%d body=%s", err, resumed.Status, resumed.Body)
 	}
+}
+
+func TestSpikeFleetGovernanceBudgetLoop(t *testing.T) {
+	if err := exec.Command("docker", "info").Run(); err != nil {
+		t.Skipf("docker not available: %v", err)
+	}
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot, err := filepath.Abs(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+
+	workDir := t.TempDir()
+	projectName := "fleet-governance-spike"
+	generatedPath := filepath.Join(workDir, "compose.generated.yml")
+	networkName := projectName + "_claw-internal"
+	spikeCleanupProject(projectName, generatedPath)
+	t.Cleanup(func() {
+		spikeCleanupProject(projectName, generatedPath)
+	})
+	t.Cleanup(func() {
+		if !t.Failed() {
+			return
+		}
+		out, _ := exec.Command("docker", "compose", "-f", generatedPath, "logs", "--tail", "200").CombinedOutput()
+		t.Logf("compose logs:\n%s", out)
+	})
+
+	pythonImage := "python:3.12-alpine"
+	agentImage := fmt.Sprintf("fleet-governance-spike-agent:%d", time.Now().UnixNano())
+	spikeEnsurePulledImage(t, pythonImage)
+	spikeBuildImage(t, filepath.Join(repoRoot, "testdata", "openclaw-stub"), agentImage, "Clawfile")
+	spikeEnsureRepoInfraImages(t, repoRoot, infraComponentClawAPI, infraComponentClawdash)
+	spikeEnsureCllamaPassthroughImage(t, repoRoot)
+	t.Cleanup(func() {
+		_, _ = exec.Command("docker", "image", "rm", "-f", agentImage).CombinedOutput()
+	})
+
+	spikeWriteFile(t, filepath.Join(workDir, "GOVERNOR.md"), "# Governor\n\nRead fleet alerts and set budgets only when current evidence crosses the reference threshold.")
+	spikeWriteFile(t, filepath.Join(workDir, "WORKER.md"), "# Worker\n\nUse the configured model.")
+	spikeWriteFile(t, filepath.Join(workDir, "fake_provider.py"), budgetSpikeFakeProviderScript())
+	spikeWriteFile(t, filepath.Join(workDir, "claw-pod.yml"), fmt.Sprintf(`name: fleet-governance-spike
+
+x-claw:
+  pod: fleet-governance-spike
+  master: governor
+  cllama-defaults:
+    proxy: [passthrough]
+    env:
+      OPENAI_API_KEY: sk-local-fake
+      OPENAI_BASE_URL: http://fake-provider:8080/v1
+  models-defaults:
+    primary: openai/gpt-4o
+
+services:
+  governor:
+    image: %s
+    x-claw:
+      agent: ./GOVERNOR.md
+      feeds: [fleet-alerts]
+      surfaces:
+        - service://claw-api
+
+  worker:
+    image: %s
+    x-claw:
+      agent: ./WORKER.md
+
+  fake-provider:
+    image: %s
+    command: ["python", "/app/fake_provider.py"]
+    volumes:
+      - ./fake_provider.py:/app/fake_provider.py:ro
+    expose:
+      - "8080"
+    networks:
+      - claw-internal
+`, agentImage, agentImage, pythonImage))
+
+	t.Setenv("CLLAMA_UI_PORT", spikeFreePort(t))
+	t.Setenv("CLAWDASH_ADDR", ":"+spikeFreePort(t))
+	t.Setenv("CLAW_ALERT_MAX_COST_USD", "0.000001")
+
+	prevDetach := composeUpDetach
+	composeUpDetach = true
+	defer func() { composeUpDetach = prevDetach }()
+
+	if err := runComposeUp(filepath.Join(workDir, "claw-pod.yml")); err != nil {
+		t.Fatalf("runComposeUp: %v", err)
+	}
+
+	for _, svc := range []string{"governor", "worker", "claw-api", "cllama", "fake-provider"} {
+		id := spikeComposeContainerID(t, generatedPath, svc)
+		spikeWaitRunning(t, id, 30*time.Second)
+	}
+	spikeWaitHealthy(t, spikeComposeContainerID(t, generatedPath, "cllama"), 45*time.Second)
+	spikeWaitHealthy(t, spikeComposeContainerID(t, generatedPath, "claw-api"), 45*time.Second)
+
+	workerToken := spikeReadAgentToken(t, filepath.Join(workDir, ".claw-runtime", "context", "worker", "metadata.json"))
+	first := budgetSpikePostCllama(t, networkName, pythonImage, workerToken)
+	if first.Status != 200 || !strings.Contains(first.Body, "chatcmpl-budget-spike") {
+		t.Fatalf("worker cllama request should succeed, got status=%d body=%s", first.Status, first.Body)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	var alerts governanceAlertsResponse
+	var alertsRaw []byte
+	if err := waitForCondition(ctx, func() bool {
+		out, err := callClawAPICompose(generatedPath, "governor", httpMethodGet, "/fleet/alerts?since=2h", nil)
+		if err != nil {
+			t.Logf("fleet alerts request not ready: %v\n%s", err, out)
+			return false
+		}
+		alertsRaw = out
+		alerts = governanceDecodeAlerts(t, out)
+		return alerts.HasCostAlertFor("worker")
+	}); err != nil {
+		t.Fatalf("fleet alerts never reported worker cost threshold: %v\nlast response:\n%s", err, alertsRaw)
+	}
+
+	overrideBody := map[string]any{
+		"claw_id":      "worker",
+		"max_requests": 20,
+		"window":       "1h",
+		"behavior":     "hard_stop",
+	}
+	out, err := callClawAPICompose(generatedPath, "governor", httpMethodPost, "/fleet/budget/set", overrideBody)
+	if err != nil {
+		t.Fatalf("governor fleet.budget.set failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), `"claw_id": "worker"`) && !strings.Contains(string(out), `"claw_id":"worker"`) {
+		t.Fatalf("unexpected budget-set response:\n%s", out)
+	}
+
+	overrideRaw := spikeReadFile(t, filepath.Join(workDir, ".claw-governance", "worker", "budget.json"))
+	if !strings.Contains(overrideRaw, `"max_requests": 20`) && !strings.Contains(overrideRaw, `"max_requests":20`) {
+		t.Fatalf("budget override file missing max_requests:\n%s", overrideRaw)
+	}
+	if !strings.Contains(overrideRaw, `"behavior": "hard_stop"`) && !strings.Contains(overrideRaw, `"behavior":"hard_stop"`) {
+		t.Fatalf("budget override file missing hard_stop behavior:\n%s", overrideRaw)
+	}
+}
+
+type governanceAlertsResponse struct {
+	Alerts []struct {
+		ClawID  string `json:"claw_id"`
+		Summary string `json:"summary"`
+	} `json:"alerts"`
+}
+
+func governanceDecodeAlerts(t *testing.T, raw []byte) governanceAlertsResponse {
+	t.Helper()
+	var decoded governanceAlertsResponse
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("decode alerts response: %v\n%s", err, raw)
+	}
+	return decoded
+}
+
+func (r governanceAlertsResponse) HasCostAlertFor(clawID string) bool {
+	for _, alert := range r.Alerts {
+		if alert.ClawID == clawID && strings.Contains(strings.ToLower(alert.Summary), "cost") {
+			return true
+		}
+	}
+	return false
 }
 
 type budgetSpikeHTTPResult struct {

--- a/examples/master-claw/README.md
+++ b/examples/master-claw/README.md
@@ -1,6 +1,8 @@
 # Master Claw Example
 
-Demonstrates fleet governance using a Master Claw (ADR-012).
+Demonstrates a closed-loop fleet governor using a Master Claw (ADR-012): read
+telemetry, check one reference policy threshold, and apply one scoped write
+through `claw-api`.
 
 ## What's in the pod
 
@@ -12,15 +14,18 @@ Demonstrates fleet governance using a Master Claw (ADR-012).
 ## How it works
 
 1. `x-claw.master: governor` tells `claw up` to auto-inject a `claw-api` service
-2. Governor receives a bearer token for `claw-api` via `CLAW_API_URL` env var
-3. `/fleet/alerts` feed is injected into governor's context on every LLM turn
+2. Governor receives `CLAW_API_URL` and a scoped `CLAW_API_TOKEN`
+3. `/fleet/alerts` is injected into the governor's context on every LLM turn
 4. Governor has an INVOKE schedule that fires every 5 minutes for periodic review
+5. When the reference cost policy is breached, governor calls
+   `POST /fleet/budget/set` for the affected worker claw
 
 ## Running
 
 ```bash
 cp .env.example .env
 # Fill in Discord bot tokens and OPENROUTER_API_KEY
+export CLAW_ALERT_MAX_COST_USD=2.00
 claw pull
 claw build
 claw up -d
@@ -28,6 +33,31 @@ claw ps
 claw logs governor
 claw audit
 ```
+
+`CLAW_ALERT_MAX_COST_USD` is a host-side setting forwarded into the
+auto-injected `claw-api` container. Keep it high enough for normal use and low
+enough for the governor to demonstrate the loop in a sandbox.
+
+## Reference policy
+
+The governor contract implements one deliberately small policy:
+
+1. Read `/fleet/alerts?since=15m`.
+2. If a worker alert says its cost crossed the configured threshold, write a
+   stricter budget for that claw:
+
+```bash
+curl -sS -X POST \
+  -H "Authorization: Bearer $CLAW_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$CLAW_API_URL/fleet/budget/set" \
+  -d '{"claw_id":"worker-a","max_requests":20,"window":"1h","behavior":"hard_stop"}'
+```
+
+That write creates `.claw-governance/<claw-id>/budget.json`, which cllama reads
+on subsequent requests. This example uses `fleet.budget.set` because the
+observable effect is a plain JSON override and does not require stopping a
+container.
 
 ## Feed authentication
 

--- a/examples/master-claw/agents/GOVERNOR.md
+++ b/examples/master-claw/agents/GOVERNOR.md
@@ -5,7 +5,8 @@ You are the fleet governor for this pod.
 ## Responsibilities
 - Monitor agent health, cost, and error rates via the alerts feed injected into your context
 - When the fleet is nominal, report briefly and stop
-- When alerts appear, investigate using claw-api tools before making claims
+- When alerts appear, investigate using claw-api before making claims
+- Apply the reference cost policy below when its threshold is crossed
 
 ## Tools Available
 Use the `claw-api` service at `$CLAW_API_URL` with bearer token `$CLAW_API_TOKEN`:
@@ -19,10 +20,28 @@ Endpoints:
 - `GET /fleet/metrics?claw_id=<id>&since=<window>` — detailed telemetry for one agent
 - `GET /fleet/logs?service=<name>&lines=<n>` — recent logs for a service
 - `GET /fleet/alerts` — current anomalies (also injected as a feed)
+- `POST /fleet/budget/set` — write a live budget override for one claw ID
+
+## Reference Cost Policy
+This example intentionally demonstrates one threshold and one write verb.
+
+1. Read `GET /fleet/alerts?since=15m`.
+2. If an alert summary says a worker claw crossed the configured cost threshold, read that claw's metrics.
+3. If the alert is still current, call `POST /fleet/budget/set` for that claw ID:
+
+```bash
+curl -sS -X POST \
+  -H "Authorization: Bearer $CLAW_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$CLAW_API_URL/fleet/budget/set" \
+  -d '{"claw_id":"worker-a","max_requests":20,"window":"1h","behavior":"hard_stop"}'
+```
+
+Use the `claw_id` from the alert. Do not change budgets for claws that are not named in current evidence.
 
 ## Periodic Review
 Every 5 minutes you receive a review prompt. Check the alerts in your context.
-If nominal, say so. If anomalies appear, investigate and report findings.
+If nominal, say so. If anomalies appear, investigate, apply the reference cost policy when it matches, and report the read evidence plus the write result.
 
 ## Style
 - Short, operator-style notes

--- a/examples/master-claw/claw-pod.yml
+++ b/examples/master-claw/claw-pod.yml
@@ -57,6 +57,6 @@ services:
       invoke:
         - schedule: "*/5 * * * *"
           name: "Fleet review"
-          message: "Run your periodic fleet review. Check the alerts in your context and report."
+          message: "Run your periodic fleet review. Read fleet alerts, apply the reference cost policy if a worker crossed the threshold, and report the evidence plus any write result."
     environment:
       DISCORD_BOT_TOKEN: "${GOVERNOR_BOT_TOKEN}"

--- a/site/.vitepress/config.mts
+++ b/site/.vitepress/config.mts
@@ -68,6 +68,7 @@ export default defineConfig({
           { text: 'Clawfile', link: '/guide/clawfile' },
           { text: 'Pod YAML', link: '/guide/pod-yaml' },
           { text: 'cllama Governance Proxy', link: '/guide/cllama' },
+          { text: 'Fleet Governance', link: '/guide/fleet-governance' },
           { text: 'Managed Tools', link: '/guide/tools' },
           { text: 'Memory Plane', link: '/guide/memory' },
           { text: 'Surfaces & Skills', link: '/guide/surfaces-and-skills' },

--- a/site/guide/fleet-governance.md
+++ b/site/guide/fleet-governance.md
@@ -1,0 +1,162 @@
+# Fleet Governance
+
+Fleet governance is the closed loop that turns Clawdapus telemetry into scoped
+runtime action:
+
+```
+cllama telemetry -> claw-api read plane -> governor decision -> claw-api write plane -> runtime effect
+```
+
+The loop is explicit. Clawdapus wires the surfaces and scopes; the policy is
+operator-authored in the Master Claw contract.
+
+## Master Claw Pattern
+
+Declare one service as the pod's master:
+
+```yaml
+x-claw:
+  pod: operations-room
+  master: governor
+
+services:
+  governor:
+    image: operations-governor:latest
+    x-claw:
+      agent: ./agents/GOVERNOR.md
+      feeds: [fleet-alerts]
+      surfaces:
+        - service://claw-api
+      invoke:
+        - schedule: "*/5 * * * *"
+          name: "Fleet review"
+          message: "Read fleet alerts, apply the reference policy if needed, and report."
+```
+
+When `x-claw.master` is set, `claw up` auto-injects `claw-api`, generates a
+master principal, and injects `CLAW_API_URL` plus `CLAW_API_TOKEN` into the
+master service. The master principal can read fleet telemetry and use the write
+verbs, subject to its scopes.
+
+Use `examples/master-claw/` as the worked example. It demonstrates one policy:
+if a worker crosses the configured cost threshold, the governor calls
+`fleet.budget.set` for that claw.
+
+## Read Plane
+
+The read plane is available through `claw-api`:
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /fleet/status` | Service health, counts, and compose service names |
+| `GET /fleet/metrics?claw_id=<id>&since=<window>` | Audit telemetry for one claw |
+| `GET /fleet/logs?service=<name>&lines=<n>` | Recent container logs for one service |
+| `GET /fleet/alerts?since=<window>` | Threshold-derived anomaly summaries |
+| `GET /agents` and `GET /agents/<id>/context` | Compiled and live context visibility |
+| `GET /schedule` | Scheduled invocation state |
+
+`/fleet/alerts` is also exposed as the built-in `fleet-alerts` feed. Subscribe
+the governor to that feed so each scheduled review starts with current anomaly
+state.
+
+## Alert Thresholds
+
+Set thresholds on the host before `claw up`; Clawdapus forwards them into the
+auto-injected `claw-api` container.
+
+```bash
+export CLAW_ALERT_ERROR_RATE_PERCENT=5.0
+export CLAW_ALERT_MAX_COST_USD=10.0
+export CLAW_ALERT_FEED_ERROR_RATE_PERCENT=20.0
+export CLAW_ALERT_INTERVENTION_COUNT=5
+claw up -d
+```
+
+Thresholds only decide when an alert is emitted. They do not apply enforcement
+by themselves. The governor closes the loop by choosing whether to call a write
+verb.
+
+## Write Plane
+
+The write plane is also served by `claw-api`:
+
+| Verb | Endpoint | Scope checked | Runtime effect |
+|---|---|---|---|
+| `fleet.restart` | `POST /fleet/restart` | `compose_services` | Restarts matching compose containers |
+| `fleet.quarantine` | `POST /fleet/quarantine` | `compose_services` | Writes a quarantine marker, then stops matching containers |
+| `fleet.budget.set` | `POST /fleet/budget/set` | `claw_ids` | Writes `.claw-governance/<claw-id>/budget.json` |
+| `fleet.model.restrict` | `POST /fleet/model/restrict` | `claw_ids` | Writes `.claw-governance/<claw-id>/model-restrict.json` |
+| `schedule.control` | `POST /schedule/<id>/<action>` | `services` | Pauses, resumes, skips, clears, or fires a schedule |
+
+The smallest useful governor uses one threshold and one write verb. For example:
+
+```bash
+curl -sS -H "Authorization: Bearer $CLAW_API_TOKEN" \
+  "$CLAW_API_URL/fleet/alerts?since=15m"
+
+curl -sS -X POST \
+  -H "Authorization: Bearer $CLAW_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$CLAW_API_URL/fleet/budget/set" \
+  -d '{"claw_id":"worker-a","max_requests":20,"window":"1h","behavior":"hard_stop"}'
+```
+
+The budget write is immediately observable on the host under
+`.claw-governance/worker-a/budget.json`, and cllama reads that override on
+subsequent requests.
+
+## Principal Scopes
+
+`claw-api` principals combine verbs with scope dimensions:
+
+| Scope | Used for |
+|---|---|
+| `pods` | Broad authority over all services and claws in a pod |
+| `services` | Service-level read access and schedule control |
+| `claw_ids` | Per-agent telemetry and claw-targeted write verbs |
+| `compose_services` | Container lifecycle writes such as restart and quarantine |
+
+A narrower master principal can override the auto-generated one by using the
+same name as `x-claw.master`. The master service still receives
+`CLAW_API_URL` and `CLAW_API_TOKEN`; omit `inject-into` because the master
+injection point is reserved.
+
+```yaml
+x-claw:
+  master: governor
+  principals:
+    - name: governor
+      verbs:
+        - fleet.status
+        - fleet.alerts
+        - fleet.query_metrics
+        - fleet.budget.set
+        - schedule.read
+        - schedule.control
+      claw_ids:
+        - worker-a
+        - worker-b
+      services:
+        - worker-a
+        - worker-b
+```
+
+The built-in master principal is broader: it gets all read and write verbs for
+the pod named by `x-claw.master`. Use explicit principals when you want a
+smaller authority surface.
+
+## Operating Contract
+
+Keep the governor contract concrete:
+
+- Name the threshold it is allowed to act on.
+- Name the exact write verb it may call.
+- Require a fresh read before any write.
+- Require the report to include the alert, the target claw or service, and the
+  write response.
+- Keep escalation paths explicit for actions that stop containers or change
+  model access.
+
+This keeps the governor auditable. The model makes a decision, but the
+authority boundary remains the scoped `claw-api` bearer token and the generated
+compose/runtime artifacts.


### PR DESCRIPTION
## Summary
- extend `examples/master-claw` into a one-threshold, one-verb closed-loop governor example using cost alerts -> `fleet.budget.set`
- add the Fleet Governance guide and site nav entry covering read plane, write verbs, scopes, and the operating contract
- add `TestSpikeFleetGovernanceBudgetLoop` to prove telemetry -> alerts -> governor write -> budget override

## Tests
- `go test ./internal/pod -run TestMasterClawExampleParsesCorrectly -count=1`
- `go test ./cmd/claw-api -run 'TestHandlerBudgetSetWritesOverrideFile|TestHandlerBudgetSetDefaultsBehavior|TestHandlerModelRestrictWritesOverrideFile' -count=1`
- `go test -tags spike -run TestSpikeFleetGovernanceBudgetLoop -count=0 ./cmd/claw/...`
- `go test -tags spike -v -run TestSpikeFleetGovernanceBudgetLoop -timeout 10m ./cmd/claw/...` -> `--- PASS: TestSpikeFleetGovernanceBudgetLoop (96.50s)`
- `go test -tags spike -v -run 'TestSpike(BudgetEnforcementAndOverride|FleetGovernanceBudgetLoop)$' -timeout 15m ./cmd/claw/...` -> `--- PASS: TestSpikeBudgetEnforcementAndOverride (32.65s)` and `--- PASS: TestSpikeFleetGovernanceBudgetLoop (31.83s)`
- `npm run build` (site)
- `go test ./...`
- `go vet ./...`

Closes #309
