### PR TITLE
Pre-create cllama context ledger directory

### DIFF
--- a/cmd/claw/compose_up.go
+++ b/cmd/claw/compose_up.go
@@ -673,11 +673,7 @@ func runComposeUp(podFile string) (err error) {
 
 		// .claw-auth and .claw-session-history are persistent siblings of
 		// .claw-runtime — claw up never wipes them.
-		authDir, err := ensurePersistentCllamaDir(podDir, ".claw-auth")
-		if err != nil {
-			return err
-		}
-		sessionHistoryDir, err := ensurePersistentCllamaDir(podDir, ".claw-session-history")
+		authDir, sessionHistoryDir, err := ensureCllamaPersistentDirs(podDir)
 		if err != nil {
 			return err
 		}
@@ -5226,7 +5222,25 @@ func ensurePersistentCllamaDir(podDir, name string) (string, error) {
 	if err := os.MkdirAll(dir, 0o777); err != nil {
 		return "", fmt.Errorf("create %s dir: %w", name, err)
 	}
+	if err := os.Chmod(dir, 0o777); err != nil {
+		return "", fmt.Errorf("chmod %s dir: %w", name, err)
+	}
 	return dir, nil
+}
+
+func ensureCllamaPersistentDirs(podDir string) (authDir string, sessionHistoryDir string, err error) {
+	authDir, err = ensurePersistentCllamaDir(podDir, ".claw-auth")
+	if err != nil {
+		return "", "", err
+	}
+	sessionHistoryDir, err = ensurePersistentCllamaDir(podDir, ".claw-session-history")
+	if err != nil {
+		return "", "", err
+	}
+	if _, err := ensurePersistentCllamaDir(sessionHistoryDir, "context-ledger"); err != nil {
+		return "", "", err
+	}
+	return authDir, sessionHistoryDir, nil
 }
 
 func appendPersistentSkillMount(result *driver.MaterializeResult, skillRoot string, rc *driver.ResolvedClaw) error {

--- a/cmd/claw/compose_up_test.go
+++ b/cmd/claw/compose_up_test.go
@@ -4995,9 +4995,40 @@ func TestEnsurePersistentCllamaDir(t *testing.T) {
 	if !fi.IsDir() {
 		t.Error("expected directory")
 	}
-	// Check permissions (mask against 0o777 to ignore umask/OS bits)
-	if fi.Mode().Perm()&0o777 == 0 {
-		t.Error("expected writable permissions")
+	if got := fi.Mode().Perm(); got != 0o777 {
+		t.Errorf("dir mode=%o want 777", got)
+	}
+}
+
+func TestEnsureCllamaPersistentDirsCreatesContextLedger(t *testing.T) {
+	podDir := t.TempDir()
+	sessionRoot := filepath.Join(podDir, ".claw-session-history")
+	contextLedgerDir := filepath.Join(sessionRoot, "context-ledger")
+	if err := os.MkdirAll(contextLedgerDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(contextLedgerDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	authDir, sessionHistoryDir, err := ensureCllamaPersistentDirs(podDir)
+	if err != nil {
+		t.Fatalf("ensureCllamaPersistentDirs: %v", err)
+	}
+	if authDir != filepath.Join(podDir, ".claw-auth") {
+		t.Fatalf("unexpected auth dir: %q", authDir)
+	}
+	if sessionHistoryDir != sessionRoot {
+		t.Fatalf("unexpected session history dir: %q", sessionHistoryDir)
+	}
+	for _, path := range []string{authDir, sessionHistoryDir, contextLedgerDir} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		if got := info.Mode().Perm(); got != 0o777 {
+			t.Fatalf("%s mode=%o want 777", path, got)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- force persistent cllama host dirs to `0o777` after `MkdirAll`, including existing tighter dirs
- add `ensureCllamaPersistentDirs` so `claw up` pre-creates `.claw-session-history/context-ledger`
- cover existing `0o700` context-ledger repair in tests

## Tests
- `go test ./cmd/claw`
- `go test ./...`
- `go vet ./...`

Closes #334
