### PR TITLE
Bump Hermes base image pin

### DIFF
--- a/internal/driver/hermes/baseimage.go
+++ b/internal/driver/hermes/baseimage.go
@@ -2,6 +2,6 @@ package hermes
 
 const UpstreamTag = "v2026.6.19"
 
-const BaseImageVersion = UpstreamTag + "-claw.2"
+const BaseImageVersion = UpstreamTag + "-claw.3"
 
 var BaseImageTag = "ghcr.io/mostlydev/hermes-base:" + BaseImageVersion

--- a/internal/infraimages/release_manifest.go
+++ b/internal/infraimages/release_manifest.go
@@ -10,7 +10,7 @@ const (
 	DefaultClawChannelMemoryTag = DefaultClawInfraTag
 	DefaultClawMCPStdioTag      = DefaultClawInfraTag
 	DefaultCllamaTag            = "v0.7.7"
-	DefaultHermesBaseTag        = "v2026.6.19-claw.2"
+	DefaultHermesBaseTag        = "v2026.6.19-claw.3"
 )
 
 func ReleaseRefs(releaseTag string) []string {


### PR DESCRIPTION
## Summary

- bump the Clawdapus Hermes base pin to the published `ghcr.io/mostlydev/hermes-base:v2026.6.19-claw.3`
- keep `internal/driver/hermes` and `internal/infraimages` in sync

This follows mostlydev/clawdapus#337. The image tag is already published and verified before this pin change.

## Published image proof

- `docker buildx imagetools inspect ghcr.io/mostlydev/hermes-base:v2026.6.19-claw.3`
  - manifest digest `sha256:6907bb2857613a159aadb2aaf345c43d8cebc2e59dd9f5c21113c10876bb11e9`
  - `linux/amd64`
  - `linux/arm64`
- direct container probe against the published tag passed and verified the memory replace matching patch

## Tests

- `go test ./cmd/claw ./internal/driver/hermes ./internal/infraimages`
- `go run ./scripts/check-release-infra-tags --release-tag v0.27.0`
- `git diff --check`
