### PR TITLE
Surface cllama failover audit events

### DIFF
--- a/cmd/claw/audit.go
+++ b/cmd/claw/audit.go
@@ -122,14 +122,15 @@ func writeAuditText(w io.Writer, podName string, skipped int, summary audit.Summ
 	}
 
 	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(tw, "CLAW\tREQ\tRESP\tERR\tINT\tTOOLS\tTOOL_ERR\tTOK_IN\tTOK_OUT\tCOST_USD\tMODELS")
+	fmt.Fprintln(tw, "CLAW\tREQ\tRESP\tERR\tINT\tFAILOVER\tTOOLS\tTOOL_ERR\tTOK_IN\tTOK_OUT\tCOST_USD\tMODELS")
 	for _, item := range summary.Agents {
-		fmt.Fprintf(tw, "%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%.4f\t%s\n",
+		fmt.Fprintf(tw, "%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%.4f\t%s\n",
 			item.ClawID,
 			item.Requests,
 			item.Responses,
 			item.Errors,
 			item.Interventions,
+			item.Failovers,
 			item.ToolCalls,
 			item.ToolErrors,
 			item.TokensIn,
@@ -142,11 +143,12 @@ func writeAuditText(w io.Writer, podName string, skipped int, summary audit.Summ
 		return err
 	}
 
-	_, err := fmt.Fprintf(w, "\nTotals: req=%d resp=%d err=%d int=%d tools=%d/%d tokens=%d/%d cost=$%.4f\n",
+	_, err := fmt.Fprintf(w, "\nTotals: req=%d resp=%d err=%d int=%d failover=%d tools=%d/%d tokens=%d/%d cost=$%.4f\n",
 		summary.Requests,
 		summary.Responses,
 		summary.Errors,
 		summary.Interventions,
+		summary.Failovers,
 		summary.ToolCalls,
 		summary.ToolErrors,
 		summary.TokensIn,
@@ -189,7 +191,7 @@ func formatModelUsage(models map[string]int) string {
 func init() {
 	auditCmd.Flags().StringVar(&auditSince, "since", "", "Only include events since this duration or RFC3339 timestamp")
 	auditCmd.Flags().StringVar(&auditClaw, "claw", "", "Only include events for one claw_id")
-	auditCmd.Flags().StringVar(&auditType, "type", "", "Only include one event type (for example request, response, error, intervention, feed_fetch, channel_context_op, provider_pool, tool_call)")
+	auditCmd.Flags().StringVar(&auditType, "type", "", "Only include one event type (for example request, response, error, intervention, failover, feed_fetch, channel_context_op, provider_pool, tool_call)")
 	auditCmd.Flags().BoolVar(&auditJSON, "json", false, "Emit machine-readable JSON")
 	rootCmd.AddCommand(auditCmd)
 }

--- a/cmd/claw/audit_test.go
+++ b/cmd/claw/audit_test.go
@@ -69,7 +69,7 @@ func TestWriteAuditTextShowsManagedToolCounts(t *testing.T) {
 		t.Fatalf("writeAuditText: %v", err)
 	}
 	rendered := out.String()
-	for _, want := range []string{"TOOLS", "TOOL_ERR", "weston", "Totals: req=1 resp=0 err=0 int=0 tools=2/1"} {
+	for _, want := range []string{"FAILOVER", "TOOLS", "TOOL_ERR", "weston", "Totals: req=1 resp=0 err=0 int=0 failover=0 tools=2/1"} {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("expected %q in output, got:\n%s", want, rendered)
 		}

--- a/internal/audit/event.go
+++ b/internal/audit/event.go
@@ -47,6 +47,12 @@ type Event struct {
 	Action        string `json:"action,omitempty"`
 	Reason        string `json:"reason,omitempty"`
 	CooldownUntil string `json:"cooldown_until,omitempty"`
+	// failover event fields
+	FromProvider string `json:"from_provider,omitempty"`
+	ToProvider   string `json:"to_provider,omitempty"`
+	FromModel    string `json:"from_model,omitempty"`
+	ToModel      string `json:"to_model,omitempty"`
+	SlotIndex    *int   `json:"slot_index,omitempty"`
 }
 
 type AgentSummary struct {
@@ -66,6 +72,7 @@ type AgentSummary struct {
 	ChannelContextOps  int            `json:"channel_context_ops,omitempty"`
 	ChannelContextErrs int            `json:"channel_context_errors,omitempty"`
 	ProviderPoolEvents int            `json:"provider_pool_events,omitempty"`
+	Failovers          int            `json:"failovers,omitempty"`
 	FirstTimestamp     time.Time      `json:"first_timestamp,omitempty"`
 	LastTimestamp      time.Time      `json:"last_timestamp,omitempty"`
 }
@@ -82,4 +89,5 @@ type Summary struct {
 	ToolCalls          int            `json:"tool_calls,omitempty"`
 	ToolErrors         int            `json:"tool_errors,omitempty"`
 	ProviderPoolEvents int            `json:"provider_pool_events,omitempty"`
+	Failovers          int            `json:"failovers,omitempty"`
 }

--- a/internal/audit/normalize.go
+++ b/internal/audit/normalize.go
@@ -98,6 +98,14 @@ func NormalizeLine(line []byte) (*Event, error) {
 	event.Action = strings.TrimSpace(stringField(raw, "action"))
 	event.Reason = strings.TrimSpace(stringField(raw, "reason"))
 	event.CooldownUntil = strings.TrimSpace(stringField(raw, "cooldown_until"))
+	// failover event fields
+	event.FromProvider = strings.TrimSpace(stringField(raw, "from_provider"))
+	event.ToProvider = strings.TrimSpace(stringField(raw, "to_provider"))
+	event.FromModel = strings.TrimSpace(stringField(raw, "from_model"))
+	event.ToModel = strings.TrimSpace(stringField(raw, "to_model"))
+	if value, ok := intField(raw, "slot_index"); ok {
+		event.SlotIndex = &value
+	}
 
 	return event, nil
 }

--- a/internal/audit/normalize_test.go
+++ b/internal/audit/normalize_test.go
@@ -30,6 +30,23 @@ func TestNormalizeLineAcceptsSpecShape(t *testing.T) {
 	}
 }
 
+func TestNormalizeLineParseFailoverEvent(t *testing.T) {
+	line := `{"ts":"2026-07-02T10:00:00Z","claw_id":"weston","type":"failover","model":"openai/gpt-4o","from_provider":"openai","from_model":"gpt-4o","to_provider":"openrouter","to_model":"anthropic/claude-haiku-4-5","reason":"http_500","slot_index":1,"latency_ms":42}`
+	event, err := NormalizeLine([]byte(line))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event.Type != "failover" || event.ClawID != "weston" || event.Model != "openai/gpt-4o" {
+		t.Fatalf("unexpected failover identity fields: %+v", event)
+	}
+	if event.FromProvider != "openai" || event.FromModel != "gpt-4o" || event.ToProvider != "openrouter" || event.ToModel != "anthropic/claude-haiku-4-5" {
+		t.Fatalf("unexpected failover route fields: %+v", event)
+	}
+	if event.Reason != "http_500" || event.SlotIndex == nil || *event.SlotIndex != 1 || event.LatencyMS == nil || *event.LatencyMS != 42 {
+		t.Fatalf("unexpected failover reason/timing fields: %+v", event)
+	}
+}
+
 func TestParseReaderSkipsMalformedLines(t *testing.T) {
 	raw := strings.NewReader("{bad json\n" +
 		"{\"ts\":\"2026-03-19T14:32:00Z\",\"claw_id\":\"octopus\",\"type\":\"request\"}\n")
@@ -50,12 +67,16 @@ func TestSummarizeAggregatesByClaw(t *testing.T) {
 		{ClawID: "octopus", Type: "request", Model: "openai/gpt-4o"},
 		{ClawID: "octopus", Type: "response", Model: "openai/gpt-4o", TokensIn: ptrInt(100), TokensOut: ptrInt(40), CostUSD: ptrFloat64(0.12)},
 		{ClawID: "octopus", Type: "error"},
+		{ClawID: "octopus", Type: "failover"},
 	}
 	summary := Summarize(events)
 	if summary.Requests != 1 || summary.Responses != 1 || summary.Errors != 1 {
 		t.Fatalf("unexpected summary: %+v", summary)
 	}
-	if len(summary.Agents) != 1 || summary.Agents[0].TokensIn != 100 {
+	if summary.Failovers != 1 {
+		t.Fatalf("expected one failover, got %+v", summary)
+	}
+	if len(summary.Agents) != 1 || summary.Agents[0].TokensIn != 100 || summary.Agents[0].Failovers != 1 {
 		t.Fatalf("unexpected agent summary: %+v", summary.Agents)
 	}
 }

--- a/internal/audit/query.go
+++ b/internal/audit/query.go
@@ -103,6 +103,9 @@ func Summarize(events []Event) Summary {
 		case "provider_pool":
 			agent.ProviderPoolEvents++
 			summary.ProviderPoolEvents++
+		case "failover":
+			agent.Failovers++
+			summary.Failovers++
 		}
 	}
 


### PR DESCRIPTION
## Summary
- bumps cllama to the merged failover telemetry commit (`mostlydev/cllama#26`)
- normalizes `type:"failover"` events through `claw audit --json`
- adds failover counts to the text audit summary and documents the `--type failover` filter

## Tests
- `go test ./...` in `cllama/`
- `go test ./internal/audit ./cmd/claw`
- `git diff --check` in parent and `cllama/`
